### PR TITLE
Prepare settings.php page, solves #2

### DIFF
--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -24,7 +24,25 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+// General.
 $string['pluginname'] = 'Boost Union';
 $string['choosereadme'] = 'Theme Boost Union is an enhanced child theme of Boost provided by Moodle an Hochschulen e.V.';
 $string['configtitle'] = 'Boost Union';
+
+// Settings: General settings tab.
+$string['presetheading'] = 'Theme presets';
+
+// Settings: Advances settings tab.
+$string['scssheading'] = 'Raw SCSS';
+
+// Settings: Branding tab.
+$string['brandingtab'] = 'Branding';
+$string['backgroundimagesheading'] = 'Background images';
+$string['brandcolorsheading'] = 'Brand colors';
+
+// Settings: Blocks tab.
+$string['blockstab'] = 'Blocks';
+$string['blocksgeneralheading'] = 'General blocks';
+
+// Privacy API.
 $string['privacy:metadata'] = 'The Boost Union theme does not store any personal data about any user.';

--- a/settings.php
+++ b/settings.php
@@ -26,21 +26,24 @@ defined('MOODLE_INTERNAL') || die();
 
 if ($ADMIN->fulltree) {
 
-    $settings = new theme_boost_admin_settingspage_tabs('themesettingboost_union', get_string('configtitle', 'theme_boost_union'));
-    $page = new admin_settingpage('theme_boost_union_general', get_string('generalsettings', 'theme_boost'));
+    // Create settings page with tabs.
+    $settings = new theme_boost_admin_settingspage_tabs('themesettingboost_union',
+            get_string('configtitle', 'theme_boost_union', null, true));
 
-    // Unaddable blocks.
-    // Blocks to be excluded when this theme is enabled in the "Add a block" list: Administration, Navigation, Courses and
-    // Section links.
-    $default = 'navigation,settings,course_list,section_links';
-    $setting = new admin_setting_configtext('theme_boost_union/unaddableblocks',
-            get_string('unaddableblocks', 'theme_boost'), get_string('unaddableblocks_desc', 'theme_boost'), $default, PARAM_TEXT);
+
+    // Create general settings tab.
+    $page = new admin_settingpage('theme_boost_union_general', get_string('generalsettings', 'theme_boost', null, true));
+
+    // Create theme presets heading.
+    $name = 'theme_boost_union/presetheading';
+    $title = get_string('presetheading', 'theme_boost_union', null, true);
+    $setting = new admin_setting_heading($name, $title, null);
     $page->add($setting);
 
-    // Preset.
+    // Replicate the preset setting from theme_boost, but use our own file area.
     $name = 'theme_boost_union/preset';
-    $title = get_string('preset', 'theme_boost');
-    $description = get_string('preset_desc', 'theme_boost');
+    $title = get_string('preset', 'theme_boost', null, true);
+    $description = get_string('preset_desc', 'theme_boost', null, true);
     $default = 'default.scss';
 
     $context = context_system::instance();
@@ -51,7 +54,6 @@ if ($ADMIN->fulltree) {
     foreach ($files as $file) {
         $choices[$file->get_filename()] = $file->get_filename();
     }
-    // These are the built in presets.
     $choices['default.scss'] = 'default.scss';
     $choices['plain.scss'] = 'plain.scss';
 
@@ -59,57 +61,109 @@ if ($ADMIN->fulltree) {
     $setting->set_updatedcallback('theme_reset_all_caches');
     $page->add($setting);
 
-    // Preset files setting.
+    // Replicate the preset files setting from theme_boost.
     $name = 'theme_boost_union/presetfiles';
-    $title = get_string('presetfiles', 'theme_boost');
-    $description = get_string('presetfiles_desc', 'theme_boost');
-
+    $title = get_string('presetfiles', 'theme_boost', null, true);
+    $description = get_string('presetfiles_desc', 'theme_boost', null, true);
     $setting = new admin_setting_configstoredfile($name, $title, $description, 'preset', 0,
             array('maxfiles' => 20, 'accepted_types' => array('.scss')));
     $page->add($setting);
 
-    // Background image setting.
+    // Add tab to settings page.
+    $settings->add($page);
+
+
+    // Create advanced settings tab.
+    $page = new admin_settingpage('theme_boost_union_advanced', get_string('advancedsettings', 'theme_boost', null, true));
+
+    // Create Raw SCSS heading.
+    $name = 'theme_boost_union/scssheading';
+    $title = get_string('scssheading', 'theme_boost_union', null, true);
+    $setting = new admin_setting_heading($name, $title, null);
+    $page->add($setting);
+
+    // Replicate the Raw initial SCSS setting from theme_boost.
+    $name = 'theme_boost_union/scsspre';
+    $title = get_string('rawscsspre', 'theme_boost', null, true);
+    $description = get_string('rawscsspre_desc', 'theme_boost', null, true);
+    $default = '';
+    $setting = new admin_setting_scsscode($name, $title, $description, $default, PARAM_RAW);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
+    // Replicate the Raw SCSS setting from theme_boost.
+    $name = 'theme_boost_union/scss';
+    $title = get_string('rawscss', 'theme_boost', null, true);
+    $description = get_string('rawscss_desc', 'theme_boost', null, true);
+    $default = '';
+    $setting = new admin_setting_scsscode($name, $title, $description, $default, PARAM_RAW);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
+    // Add tab to settings page.
+    $settings->add($page);
+
+
+    // Create branding tab.
+    $page = new admin_settingpage('theme_boost_union_branding', get_string('brandingtab', 'theme_boost_union', null, true));
+
+    // Create background images heading.
+    $name = 'theme_boost_union/backgroundimages';
+    $title = get_string('backgroundimagesheading', 'theme_boost_union', null, true);
+    $setting = new admin_setting_heading($name, $title, null);
+    $page->add($setting);
+
+    // Replicate the Background image setting from theme_boost.
     $name = 'theme_boost_union/backgroundimage';
-    $title = get_string('backgroundimage', 'theme_boost');
-    $description = get_string('backgroundimage_desc', 'theme_boost');
+    $title = get_string('backgroundimage', 'theme_boost', null, true);
+    $description = get_string('backgroundimage_desc', 'theme_boost', null, true);
     $setting = new admin_setting_configstoredfile($name, $title, $description, 'backgroundimage');
     $setting->set_updatedcallback('theme_reset_all_caches');
     $page->add($setting);
 
-    // Login Background image setting.
+    // Replicate the Login Background image setting from theme_boost.
     $name = 'theme_boost_union/loginbackgroundimage';
-    $title = get_string('loginbackgroundimage', 'theme_boost');
-    $description = get_string('loginbackgroundimage_desc', 'theme_boost');
+    $title = get_string('loginbackgroundimage', 'theme_boost', null, true);
+    $description = get_string('loginbackgroundimage_desc', 'theme_boost', null, true);
     $setting = new admin_setting_configstoredfile($name, $title, $description, 'loginbackgroundimage');
     $setting->set_updatedcallback('theme_reset_all_caches');
     $page->add($setting);
 
-    // Variable $body-color.
-    // We use an empty default value because the default colour should come from the preset.
+    // Create brand colors heading.
+    $name = 'theme_boost_union/brandcolors';
+    $title = get_string('brandcolorsheading', 'theme_boost_union', null, true);
+    $setting = new admin_setting_heading($name, $title, null);
+    $page->add($setting);
+
+    // Replicate the Variable $body-color setting from theme_boost.
     $name = 'theme_boost_union/brandcolor';
-    $title = get_string('brandcolor', 'theme_boost');
-    $description = get_string('brandcolor_desc', 'theme_boost');
+    $title = get_string('brandcolor', 'theme_boost', null, true);
+    $description = get_string('brandcolor_desc', 'theme_boost', null, true);
     $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
     $setting->set_updatedcallback('theme_reset_all_caches');
     $page->add($setting);
 
-    // Must add the page after definiting all the settings!
+    // Add tab to settings page.
     $settings->add($page);
 
-    // Advanced settings.
-    $page = new admin_settingpage('theme_boost_union_advanced', get_string('advancedsettings', 'theme_boost'));
 
-    // Raw SCSS to include before the content.
-    $setting = new admin_setting_scsscode('theme_boost_union/scsspre',
-            get_string('rawscsspre', 'theme_boost'), get_string('rawscsspre_desc', 'theme_boost'), '', PARAM_RAW);
-    $setting->set_updatedcallback('theme_reset_all_caches');
+    // Create blocks tab.
+    $page = new admin_settingpage('theme_boost_union_blocks', get_string('blockstab', 'theme_boost_union', null, true));
+
+    // Create blocks general heading.
+    $name = 'theme_boost_union/blocks';
+    $title = get_string('blocksgeneralheading', 'theme_boost_union', null, true);
+    $setting = new admin_setting_heading($name, $title, null);
     $page->add($setting);
 
-    // Raw SCSS to include after the content.
-    $setting = new admin_setting_scsscode('theme_boost_union/scss', get_string('rawscss', 'theme_boost'),
-            get_string('rawscss_desc', 'theme_boost'), '', PARAM_RAW);
-    $setting->set_updatedcallback('theme_reset_all_caches');
+    // Replicate the Unaddable blocks setting from theme_boost.
+    $name = 'theme_boost_union/unaddableblocks';
+    $title = get_string('unaddableblocks', 'theme_boost', null, true);
+    $description = get_string('unaddableblocks_desc', 'theme_boost', null, true);
+    $default = 'navigation,settings,course_list,section_links';
+    $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_TEXT);
     $page->add($setting);
 
+    // Add tab to settings page.
     $settings->add($page);
 }


### PR DESCRIPTION
This patch prepares the settings.php page for the integration of all the upcoming Boost Union settings.
To achieve this, it slightly breaks up the existing settings code from Boost Core while keeping all existing settings.
As a side effect, it adds lazy loading to the existing setting strings.