### PR TITLE
Add course related hints feature, solves #5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-06-21 - Add course related hints feature, solves #5
 * 2022-04-30 - Added footnote functionality, helps to resolve #6.
 * 2022-06-20 - Allow full Behat runs with Boost Campus suite, fixes #14.
 * 2022-06-20 - Prepare settings.php page, solves #2.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ In this tab there are the following settings:
 
 This setting is already available in the Moodle core theme Boost. For more information how to use it, please have a look at the official Moodle documentation: http://docs.moodle.org/en/Boost_theme
 
+### Tab "Courses"
+
+In this tab there are the following settings:
+
+#### Course related hints
+
+##### Position of switch role information
+
+With this setting a hint will appear in the course header if the user has switched the role in the course.
+
+##### Show hint in hidden courses
+
+With this setting a hint will appear in the course header as long as the visibility of the course is hidden.
+
+##### Show hint for guest access
+
+With this setting a hint will appear in the course header when a user is accessing it with the guest access feature.
+
+##### Show hint for self enrolment without enrolment key
+
+With this setting a hint will appear in the course header if the course is visible and an enrolment without enrolment key is currently possible.
+
 ### Tab "Footer"
 
 In this tab there are the following settings:

--- a/db/access.php
+++ b/db/access.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Theme Boost Union - Version file
+ * Theme Boost Union - Capability definitions.
  *
  * @package    theme_boost_union
  * @copyright  2022 Moodle an Hochschulen e.V. <kontakt@moodle-an-hochschulen.de>
@@ -24,10 +24,25 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'theme_boost_union';
-$plugin->version = 2022031705;
-$plugin->release = 'v4.0-r1';
-$plugin->requires = 2022041900;
-$plugin->supported = [400, 400];
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = array('theme_boost' => 2022041900);
+$capabilities = array(
+
+    // Ability to see a hint for unrestricted self enrolment in a visible course.
+        'theme/boost_union:viewhintcourseselfenrol' => array(
+                'captype' => 'read',
+                'contextlevel' => CONTEXT_COURSE,
+                'archetypes' => array(
+                        'teacher' => CAP_ALLOW,
+                        'editingteacher' => CAP_ALLOW,
+                        'manager' => CAP_ALLOW )
+        ),
+    // Ability to see a hint in a hidden course.
+        'theme/boost_union:viewhintinhiddencourse' => array(
+                'captype' => 'read',
+                'contextlevel' => CONTEXT_COURSE,
+                'archetypes' => array(
+                        'teacher' => CAP_ALLOW,
+                        'editingteacher' => CAP_ALLOW,
+                        'manager' => CAP_ALLOW
+                )
+        )
+);

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -44,11 +44,46 @@ $string['brandcolorsheading'] = 'Brand colors';
 $string['blockstab'] = 'Blocks';
 $string['blocksgeneralheading'] = 'General blocks';
 
+// Settings: Courses tab.
+$string['coursestab'] = 'Courses';
+$string['courserelatedhintsheading'] = 'Course related hints';
+// ... Setting: Position of switch role information setting.
+$string['showswitchedroleincoursesetting'] = 'Position of switch role information';
+$string['showswitchedroleincoursesetting_desc'] = 'With this setting a hint will appear in the course header if the user has switched the role in the course. By default, this information is only displayed right near the user\'s name in the user menu. By enabling this option, you can show this information - together with a link to switch back - within the course page as well.';
+$string['switchedroleto'] = 'You are viewing this course currently with the role: <strong>{$a->role}</strong>';
+// ... Setting: Show hint for hidden course.
+$string['showhintcoursehiddensetting'] = 'Show hint in hidden courses';
+$string['showhintcoursehiddensetting_desc'] = 'With this setting a hint will appear in the course header as long as the visibility of the course is hidden. This helps to identify the visibility state of a course at a glance without the need for looking at the course settings.';
+$string['showhintcoursehiddengeneral'] = 'This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.';
+$string['showhintcoursehiddensettingslink'] = 'You can change the visibility in the <a href="{$a->url}">course settings</a>.';
+// ... Setting: Show hint for guest access.
+$string['showhintcoursguestaccesssetting'] = 'Show hint for guest access';
+$string['showhintcourseguestaccesssetting_desc'] = 'With this setting a hint will appear in the course header when a user is accessing it with the guest access feature. If the course provides an active self enrolment, a link to that page is also presented to the user.';
+$string['showhintcourseguestaccessgeneral'] = 'You are currently viewing this course as <strong>{$a->role}</strong>.';
+$string['showhintcourseguestaccesslink'] = 'To have full access to the course, you can <a href="{$a->url}">self enrol into this course</a>.';
+// ... Setting: Show hint for unrestricted self enrolment.
+$string['showhintcourseselfenrolsetting'] = 'Show hint for self enrolment without enrolment key';
+$string['showhintcourseselfenrolsetting_desc'] = 'With this setting a hint will appear in the course header if the course is visible and an enrolment without enrolment key is currently possible.';
+$string['showhintcourseselfenrolstartcurrently'] = 'This course is currently visible and <strong>self enrolment without enrolment key</strong> is currently possible.';
+$string['showhintcourseselfenrolstartfuture'] = 'This course is currently visible and <strong>self enrolment without enrolment key</strong> is planned to become possible.';
+$string['showhintcourseselfenrolunlimited'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment infinitely.';
+$string['showhintcourseselfenroluntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment until {$a->until}.';
+$string['showhintcourseselfenrolfrom'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment from {$a->from} on.';
+$string['showhintcourseselfenrolsince'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment currently.';
+$string['showhintcourseselfenrolfromuntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment from {$a->from} until {$a->until}.';
+$string['showhintcourseselfenrolsinceuntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment until {$a->until}.';
+$string['showhintcourseselfenrolinstancecallforaction'] = 'If you don\'t want that any Moodle user can enrol into this course freely, please restrict the self enrolment settings.';
+
 // Settings: Footer tab.
 $string['footertab'] = 'Footer';
 $string['footnoteheading'] = 'Footnote';
+// ... Setting: Footnote:
 $string['footnotesetting'] = 'Footnote';
 $string['footnotesetting_desc'] = 'Whatever you add to this textarea will be displayed at the end of a page, in the footer (not the floating footer) on every page which uses the layouts "drawers", "columns2" or "login". Content in this area could be for example the copyright, the terms of use or the name of your organisation. <br/> If you want to remove the footnote again, just empty the text area.';
 
 // Privacy API.
 $string['privacy:metadata'] = 'The Boost Union theme does not store any personal data about any user.';
+
+// Capabilities.
+$string['boost_union:viewhintcourseselfenrol'] = 'To be able to see a hint for unrestricted self enrolment in a visible course.';
+$string['boost_union:viewhintinhiddencourse'] = 'To be able to see a hint in a hidden course.';

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -34,6 +34,9 @@ defined('MOODLE_INTERNAL') || die();
 user_preference_allow_ajax_update('drawer-open-nav', PARAM_ALPHA);
 require_once($CFG->libdir . '/behat/lib.php');
 
+// Require own locallib.php.
+require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
+
 // Add block button in editing mode.
 $addblockbutton = $OUTPUT->addblockbutton();
 
@@ -81,6 +84,12 @@ $templatecontext = [
     'overflow' => $overflow,
     'addblockbutton' => $addblockbutton,
 ];
+
+// Get and use the course related hints HTML code, if any hints are configured.
+$courserelatedhintshtml = theme_boost_union_get_course_related_hints();
+if ($courserelatedhintshtml) {
+    $templatecontext['courserelatedhints'] = $courserelatedhintshtml;
+}
 
 // Set the template content for the footnote.
 require_once(__DIR__ . '/includes/footnote.php');

--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -34,6 +34,9 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->libdir . '/behat/lib.php');
 require_once($CFG->dirroot . '/course/lib.php');
 
+// Require own locallib.php.
+require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
+
 // Add block button in editing mode.
 $addblockbutton = $OUTPUT->addblockbutton();
 
@@ -114,6 +117,12 @@ $templatecontext = [
     'headercontent' => $headercontent,
     'addblockbutton' => $addblockbutton
 ];
+
+// Get and use the course related hints HTML code, if any hints are configured.
+$courserelatedhintshtml = theme_boost_union_get_course_related_hints();
+if ($courserelatedhintshtml) {
+    $templatecontext['courserelatedhints'] = $courserelatedhintshtml;
+}
 
 // Set the template content for the footnote.
 require_once(__DIR__ . '/includes/footnote.php');

--- a/lib.php
+++ b/lib.php
@@ -22,6 +22,11 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+// Constants which are use throughout this theme.
+define('THEME_BOOST_UNION_SETTING_SELECT_YES', 'yes');
+define('THEME_BOOST_UNION_SETTING_SELECT_NO', 'no');
+
+
 /**
  * Returns the main SCSS content.
  *
@@ -58,6 +63,11 @@ function theme_boost_union_get_pre_scss($theme) {
     global $CFG;
 
     $scss = '';
+
+    // Add SCSS constants for evaluating select setting values in SCSS code.
+    $scss .= '$boostunionsettingyes: '.THEME_BOOST_UNION_SETTING_SELECT_YES. ";\n";
+    $scss .= '$boostunionsettingno: '.THEME_BOOST_UNION_SETTING_SELECT_NO. ";\n";
+
     $configurable = [
         // Config key => [variableName, ...].
             'brandcolor' => ['primary'],

--- a/locallib.php
+++ b/locallib.php
@@ -1,0 +1,276 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - Local library
+ *
+ * @package    theme_boost_union
+ * @copyright  2022 Moodle an Hochschulen e.V. <kontakt@moodle-an-hochschulen.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Build the course related hints HTML code.
+ * This function evaluates and composes all course related hints which may appear on a course page below the course header.
+ *
+ * @return string.
+ */
+function theme_boost_union_get_course_related_hints() {
+    global $CFG, $COURSE, $PAGE, $USER, $OUTPUT;
+
+    // Require user library.
+    require_once($CFG->dirroot.'/user/lib.php');
+
+    // Initialize HTML code.
+    $html = '';
+
+    // If the setting showhintcoursehidden is set and the visibility of the course is hidden and
+    // a hint for the visibility will be shown.
+    if (get_config('theme_boost_union', 'showhintcoursehidden') == THEME_BOOST_UNION_SETTING_SELECT_YES
+            && has_capability('theme/boost_union:viewhintinhiddencourse', \context_course::instance($COURSE->id))
+            && $PAGE->has_set_url()
+            && $PAGE->url->compare(new moodle_url('/course/view.php'), URL_MATCH_BASE)
+            && $COURSE->visible == false) {
+
+        // Prepare template context.
+        $templatecontext = array('courseid' => $COURSE->id);
+
+        // If the user has the capability to change the course settings, an additional link to the course settings is shown.
+        if (has_capability('moodle/course:update', context_course::instance($COURSE->id))) {
+            $templatecontext['showcoursesettingslink'] = true;
+        } else {
+            $templatecontext['showcoursesettingslink'] = false;
+        }
+
+        // Render template and add it to HTML code.
+        $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-hidden', $templatecontext);
+    }
+
+    // If the setting showhintcourseguestaccess is set and the user is accessing the course with guest access,
+    // a hint for users is shown.
+    // We also check that the user did not switch the role. This is a special case for roles that can fully access the course
+    // without being enrolled. A role switch would show the guest access hint additionally in that case and this is not
+    // intended.
+    if (get_config('theme_boost_union', 'showhintcourseguestaccess') == THEME_BOOST_UNION_SETTING_SELECT_YES
+            && is_guest(\context_course::instance($COURSE->id), $USER->id)
+            && $PAGE->has_set_url()
+            && $PAGE->url->compare(new moodle_url('/course/view.php'), URL_MATCH_BASE)
+            && !is_role_switched($COURSE->id)) {
+
+        // Require self enrolment library.
+        require_once($CFG->dirroot . '/enrol/self/lib.php');
+
+        // Prepare template context.
+        $templatecontext = array('courseid' => $COURSE->id,
+                'role' => role_get_name(get_guest_role()));
+
+        // Search for an available self enrolment link in this course.
+        $templatecontext['showselfenrollink'] = false;
+        $instances = enrol_get_instances($COURSE->id, true);
+        $plugins = enrol_get_plugins(true);
+        foreach ($instances as $instance) {
+            // If the enrolment plugin isn't enabled currently, skip it.
+            if (!isset($plugins[$instance->enrol])) {
+                continue;
+            }
+
+            // Remember the enrolment plugin.
+            $plugin = $plugins[$instance->enrol];
+
+            // If there is a self enrolment link.
+            if ($plugin->show_enrolme_link($instance)) {
+                $templatecontext['showselfenrollink'] = true;
+                break;
+            }
+        }
+
+        // Render template and add it to HTML code.
+        $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-guestaccess', $templatecontext);
+    }
+
+    // If the setting showhintcourseselfenrol is set, a hint for users is shown that the course allows unrestricted self
+    // enrolment. This hint is only shown if the course is visible, the self enrolment is visible and if the user has the
+    // capability "theme/boost_union:viewhintcourseselfenrol".
+    if (get_config('theme_boost_union', 'showhintcourseselfenrol') == THEME_BOOST_UNION_SETTING_SELECT_YES
+            && has_capability('theme/boost_union:viewhintcourseselfenrol', \context_course::instance($COURSE->id))
+            && $PAGE->has_set_url()
+            && $PAGE->url->compare(new moodle_url('/course/view.php'), URL_MATCH_BASE)
+            && $COURSE->visible == true) {
+
+        // Get the active enrol instances for this course.
+        $enrolinstances = enrol_get_instances($COURSE->id, true);
+
+        // Prepare to remember when self enrolment is / will be possible.
+        $selfenrolmentpossiblecurrently = false;
+        $selfenrolmentpossiblefuture = false;
+        foreach ($enrolinstances as $instance) {
+            // Check if unrestricted self enrolment is possible currently or in the future.
+            $now = (new \DateTime("now", \core_date::get_server_timezone_object()))->getTimestamp();
+            if ($instance->enrol == 'self' && empty($instance->password) && $instance->customint6 == 1 &&
+                    (empty($instance->enrolenddate) || $instance->enrolenddate > $now)) {
+
+                // Build enrol instance object with all necessary information for rendering the note later.
+                $instanceobject = new stdClass();
+
+                // Remember instance name.
+                if (empty($instance->name)) {
+                    $instanceobject->name = get_string('pluginname', 'enrol_self') .
+                            " (" . get_string('defaultcoursestudent', 'core') . ")";
+                } else {
+                    $instanceobject->name = $instance->name;
+                }
+
+                // Remember type of unrestrictedness.
+                if (empty($instance->enrolenddate) && empty($instance->enrolstartdate)) {
+                    $instanceobject->unrestrictedness = 'unlimited';
+                    $selfenrolmentpossiblecurrently = true;
+                } else if (empty($instance->enrolstartdate) &&
+                        !empty($instance->enrolenddate) && $instance->enrolenddate > $now) {
+                    $instanceobject->unrestrictedness = 'until';
+                    $selfenrolmentpossiblecurrently = true;
+                } else if (empty($instance->enrolenddate) &&
+                        !empty($instance->enrolstartdate) && $instance->enrolstartdate > $now) {
+                    $instanceobject->unrestrictedness = 'from';
+                    $selfenrolmentpossiblefuture = true;
+                } else if (empty($instance->enrolenddate) &&
+                        !empty($instance->enrolstartdate) && $instance->enrolstartdate <= $now) {
+                    $instanceobject->unrestrictedness = 'since';
+                    $selfenrolmentpossiblecurrently = true;
+                } else if (!empty($instance->enrolstartdate) && $instance->enrolstartdate > $now &&
+                        !empty($instance->enrolenddate) && $instance->enrolenddate > $now) {
+                    $instanceobject->unrestrictedness = 'fromuntil';
+                    $selfenrolmentpossiblefuture = true;
+                } else if (!empty($instance->enrolstartdate) && $instance->enrolstartdate <= $now &&
+                        !empty($instance->enrolenddate) && $instance->enrolenddate > $now) {
+                    $instanceobject->unrestrictedness = 'sinceuntil';
+                    $selfenrolmentpossiblecurrently = true;
+                } else {
+                    // This should not happen, thus continue to next instance.
+                    continue;
+                }
+
+                // Remember enrol start date.
+                if (!empty($instance->enrolstartdate)) {
+                    $instanceobject->startdate = $instance->enrolstartdate;
+                } else {
+                    $instanceobject->startdate = null;
+                }
+
+                // Remember enrol end date.
+                if (!empty($instance->enrolenddate)) {
+                    $instanceobject->enddate = $instance->enrolenddate;
+                } else {
+                    $instanceobject->enddate = null;
+                }
+
+                // Remember this instance.
+                $selfenrolinstances[$instance->id] = $instanceobject;
+            }
+        }
+
+        // If there is at least one unrestricted enrolment instance,
+        // show the hint with information about each unrestricted active self enrolment in the course.
+        if (!empty($selfenrolinstances) &&
+                ($selfenrolmentpossiblecurrently == true || $selfenrolmentpossiblefuture == true)) {
+
+            // Prepare template context.
+            $templatecontext = array();
+
+            // Add the start of the hint t the template context
+            // depending on the fact if enrolment is already possible currently or will be in the future.
+            if ($selfenrolmentpossiblecurrently == true) {
+                $templatecontext['selfenrolhintstart'] = get_string('showhintcourseselfenrolstartcurrently', 'theme_boost_union');
+            } else if ($selfenrolmentpossiblefuture == true) {
+                $templatecontext['selfenrolhintstart'] = get_string('showhintcourseselfenrolstartfuture', 'theme_boost_union');
+            }
+
+            // Iterate over all enrolment instances to output the details.
+            foreach ($selfenrolinstances as $selfenrolinstanceid => $selfenrolinstanceobject) {
+                // If the user has the capability to config self enrolments, enrich the instance name with the settings link.
+                if (has_capability('enrol/self:config', \context_course::instance($COURSE->id))) {
+                    $url = new moodle_url('/enrol/editinstance.php', array('courseid' => $COURSE->id,
+                            'id' => $selfenrolinstanceid, 'type' => 'self'));
+                    $selfenrolinstanceobject->name = html_writer::link($url, $selfenrolinstanceobject->name);
+                }
+
+                // Add the enrolment instance information to the template context depending on the instance configuration.
+                if ($selfenrolinstanceobject->unrestrictedness == 'unlimited') {
+                    $templatecontext['selfenrolinstances'][] = get_string('showhintcourseselfenrolunlimited', 'theme_boost_union',
+                            array('name' => $selfenrolinstanceobject->name));
+                } else if ($selfenrolinstanceobject->unrestrictedness == 'until') {
+                    $templatecontext['selfenrolinstances'][] = get_string('showhintcourseselfenroluntil', 'theme_boost_union',
+                            array('name' => $selfenrolinstanceobject->name,
+                                    'until' => userdate($selfenrolinstanceobject->enddate)));
+                } else if ($selfenrolinstanceobject->unrestrictedness == 'from') {
+                    $templatecontext['selfenrolinstances'][] = get_string('showhintcourseselfenrolfrom', 'theme_boost_union',
+                            array('name' => $selfenrolinstanceobject->name,
+                                    'from' => userdate($selfenrolinstanceobject->startdate)));
+                } else if ($selfenrolinstanceobject->unrestrictedness == 'since') {
+                    $templatecontext['selfenrolinstances'][] = get_string('showhintcourseselfenrolsince', 'theme_boost_union',
+                            array('name' => $selfenrolinstanceobject->name,
+                                    'since' => userdate($selfenrolinstanceobject->startdate)));
+                } else if ($selfenrolinstanceobject->unrestrictedness == 'fromuntil') {
+                    $templatecontext['selfenrolinstances'][] = get_string('showhintcourseselfenrolfromuntil', 'theme_boost_union',
+                            array('name' => $selfenrolinstanceobject->name,
+                                    'until' => userdate($selfenrolinstanceobject->enddate),
+                                    'from' => userdate($selfenrolinstanceobject->startdate)));
+                } else if ($selfenrolinstanceobject->unrestrictedness == 'sinceuntil') {
+                    $templatecontext['selfenrolinstances'][] = get_string('showhintcourseselfenrolsinceuntil', 'theme_boost_union',
+                            array('name' => $selfenrolinstanceobject->name,
+                                    'until' => userdate($selfenrolinstanceobject->enddate),
+                                    'since' => userdate($selfenrolinstanceobject->startdate)));
+                }
+            }
+
+            // If the user has the capability to config self enrolments, add the call for action to the template context.
+            if (has_capability('enrol/self:config', \context_course::instance($COURSE->id))) {
+                $templatecontext['calltoaction'] = true;
+            } else {
+                $templatecontext['calltoaction'] = false;
+            }
+
+            // Render template and add it to HTML code.
+            $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-selfenrol', $templatecontext);
+        }
+    }
+
+    // If the setting showswitchedroleincourse is set and the user has switched his role,
+    // a hint for the role switch will be shown.
+    if (get_config('theme_boost_union', 'showswitchedroleincourse') === THEME_BOOST_UNION_SETTING_SELECT_YES
+            && is_role_switched($COURSE->id) ) {
+
+        // Get the role name switched to.
+        $opts = \user_get_user_navigation_info($USER, $PAGE);
+        $role = $opts->metadata['rolename'];
+
+        // Get the URL to switch back (normal role).
+        $url = new moodle_url('/course/switchrole.php',
+                array('id' => $COURSE->id,
+                        'sesskey' => sesskey(),
+                        'switchrole' => 0,
+                        'returnurl' => $PAGE->url->out_as_local_url(false)));
+
+        // Prepare template context.
+        $templatecontext = array('role' => $role,
+                'url' => $url->out());
+
+        // Render template and add it to HTML code.
+        $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-switchedrole', $templatecontext);
+    }
+
+    // Return HTML code.
+    return $html;
+}

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -1,2 +1,15 @@
-/* This file is empty by purpose.
-You can add your SCSS code here if you really need to. */
+/*=======================================
+ * Settings: Course.
+ ======================================*/
+
+/*---------------------------------------
+ * Setting: Course related hints.
+ --------------------------------------*/
+
+.course-hint-hidden,
+.course-hint-guestaccess,
+.course-hint-selfenrol,
+.course-hint-switchedrole {
+    margin-left: 15px;
+    margin-right: 15px;
+}

--- a/settings.php
+++ b/settings.php
@@ -24,7 +24,15 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+// Require the necessary libraries.
+require_once($CFG->dirroot.'/theme/boost_union/lib.php');
+
 if ($ADMIN->fulltree) {
+
+    // Prepare options array for select settings.
+    // Due to MDL-58376, we will use binary select settings instead of checkbox settings throughout this theme.
+    $yesnooption = array(THEME_BOOST_UNION_SETTING_SELECT_YES => get_string('yes'),
+            THEME_BOOST_UNION_SETTING_SELECT_NO => get_string('no'));
 
     // Create settings page with tabs.
     $settings = new theme_boost_admin_settingspage_tabs('themesettingboost_union',
@@ -168,6 +176,48 @@ if ($ADMIN->fulltree) {
     $settings->add($page);
 
 
+    // Create courses tab.
+    $page = new admin_settingpage('theme_boost_union_courses', get_string('coursestab', 'theme_boost_union', null, true));
+
+    // Create course related hints heading.
+    $name = 'theme_boost_union/courserelatedhintsheading';
+    $title = get_string('courserelatedhintsheading', 'theme_boost_union', null, true);
+    $setting = new admin_setting_heading($name, $title, null);
+    $page->add($setting);
+
+    // Setting: Position of switch role information.
+    $name = 'theme_boost_union/showswitchedroleincourse';
+    $title = get_string('showswitchedroleincoursesetting', 'theme_boost_union', null, true);
+    $description = get_string('showswitchedroleincoursesetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
+    // Setting: Show hint in hidden courses.
+    $name = 'theme_boost_union/showhintcoursehidden';
+    $title = get_string('showhintcoursehiddensetting', 'theme_boost_union', null, true);
+    $description = get_string('showhintcoursehiddensetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+    $page->add($setting);
+
+    // Setting: Show hint guest for access.
+    $name = 'theme_boost_union/showhintcourseguestaccess';
+    $title = get_string('showhintcoursguestaccesssetting', 'theme_boost_union', null, true);
+    $description = get_string('showhintcourseguestaccesssetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+    $page->add($setting);
+
+    // Setting: Show hint for self enrolment without enrolment key.
+    $name = 'theme_boost_union/showhintcourseselfenrol';
+    $title = get_string('showhintcourseselfenrolsetting', 'theme_boost_union', null, true);
+    $description = get_string('showhintcourseselfenrolsetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+    $page->add($setting);
+
+    // Add tab to settings page.
+    $settings->add($page);
+
+
     // Create footer tab.
     $page = new admin_settingpage('theme_boost_union_footer', get_string('footertab', 'theme_boost_union', null, true));
 
@@ -177,7 +227,7 @@ if ($ADMIN->fulltree) {
     $setting = new admin_setting_heading($name, $title, null);
     $page->add($setting);
 
-    // Footnote setting.
+    // Setting: Footnote.
     $name = 'theme_boost_union/footnote';
     $title = get_string('footnotesetting', 'theme_boost_union', null, true);
     $description = get_string('footnotesetting_desc', 'theme_boost_union', null, true);

--- a/templates/columns2.mustache
+++ b/templates/columns2.mustache
@@ -51,6 +51,7 @@
 
     Modifications compared to this template:
     * Include theme_boost_union/footnote template
+    * Added the possibility to show course related hints.
 }}
 {{> theme_boost/head }}
 
@@ -89,6 +90,7 @@
                     {{#overflow}}
                         {{> core/url_select}}
                     {{/overflow}}
+                    {{{courserelatedhints}}}
                     {{{ output.main_content }}}
                     {{{ output.activity_navigation }}}
                     {{{ output.course_content_footer }}}

--- a/templates/course-hint-guestaccess.mustache
+++ b/templates/course-hint-guestaccess.mustache
@@ -1,0 +1,44 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/course-hint-guestaccess
+
+    Boost Union template for outputting the guestaccess course hint.
+
+    Context variables required for this template:
+    * courseid - The course ID
+    * role - The role name
+    * showselfenrollink - The fact if a link to self enrolment should be shown or not
+
+    Example context (json):
+    {
+        "courseid": "123",
+        "role": "Guest",
+        "showselfenrollink": true
+    }
+}}
+<div class="course-hint-guestaccess alert alert-warning">
+    <div class="media">
+        <div class="mr-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
+        <div class="media-body align-self-center">
+            {{#str}} showhintcourseguestaccessgeneral, theme_boost_union, { "role": "{{role}}" } {{/str}}
+            {{#showselfenrollink}}
+                <br />{{#str}} showhintcourseguestaccesslink, theme_boost_union, { "url": "{{config.wwwroot}}/enrol/index.php?id={{courseid}}" } {{/str}}
+            {{/showselfenrollink}}
+        </div>
+    </div>
+</div>

--- a/templates/course-hint-hidden.mustache
+++ b/templates/course-hint-hidden.mustache
@@ -1,0 +1,42 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/course-hint-hidden
+
+    Boost Union template for outputting the hidden course hint.
+
+    Context variables required for this template:
+    * courseid - The course ID
+    * showcoursesettingslink - The fact if a link to the course settings should be shown or not
+
+    Example context (json):
+    {
+        "courseid": "123",
+        "showcoursesettingslink": true
+    }
+}}
+<div class="course-hint-hidden alert alert-warning">
+    <div class="media">
+        <div class="mr-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
+        <div class="media-body align-self-center">
+            {{#str}} showhintcoursehiddengeneral, theme_boost_union {{/str}}
+            {{#showcoursesettingslink}}
+                <br />{{#str}} showhintcoursehiddensettingslink, theme_boost_union, { "url": "{{config.wwwroot}}/course/edit.php?id={{courseid}}" } {{/str}}
+            {{/showcoursesettingslink}}
+        </div>
+    </div>
+</div>

--- a/templates/course-hint-selfenrol.mustache
+++ b/templates/course-hint-selfenrol.mustache
@@ -1,0 +1,47 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/course-hint-selfenrol
+
+    Boost Union template for outputting the selfenrol course hint.
+
+    Context variables required for this template:
+    * selfenrolhintstart - The string which is displayed at the start of this hint
+    * selfenrolinstances - The array of self enrolment instance strings
+    * calltoaction - The fact if the call to action should be shown or not
+
+    Example context (json):
+    {
+        "selfenrolhintstart": "This course is currently visible and <strong>self enrolment without enrolment key</strong> is currently possible.",
+        "selfenrolinstances": [ "The <strong>Foo</strong> enrolment instance allows unrestricted self enrolment infinitely." ],
+        "calltoaction": true
+    }
+}}
+<div class="course-hint-selfenrol alert alert-info">
+    <div class="media">
+        <div class="mr-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
+        <div class="media-body align-self-center">
+            {{{selfenrolhintstart}}}
+            {{#selfenrolinstances}}
+                <br />{{{.}}}
+            {{/selfenrolinstances}}
+            {{#calltoaction}}
+                <br />{{#str}} showhintcourseselfenrolinstancecallforaction, theme_boost_union {{/str}}
+            {{/calltoaction}}
+        </div>
+    </div>
+</div>

--- a/templates/course-hint-switchedrole.mustache
+++ b/templates/course-hint-switchedrole.mustache
@@ -1,0 +1,42 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/course-hint-switchedrole
+
+    Boost Union template for outputting the switchedrole course hint.
+
+    Context variables required for this template:
+    * courseid - The course ID
+    * role - The role name
+    * showcoursesettingslink - The fact if a link to the course settings should be shown or not
+
+    Example context (json):
+    {
+        "courseid": "123",
+        "role": "Student",
+        "showcoursesettingslink": true
+    }
+}}
+<div class="course-hint-switchedrole alert alert-info">
+    <div class="media">
+        <div class="mr-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
+        <div class="media-body align-self-center">
+            {{#str}} switchedroleto, theme_boost_union, { "role": "{{role}}" } {{/str}}
+            <br /><a href="{{{url}}}" class="switched-role-backlink">{{#str}} switchrolereturn, core {{/str}}</a>
+        </div>
+    </div>
+</div>

--- a/templates/drawers.mustache
+++ b/templates/drawers.mustache
@@ -54,6 +54,7 @@
 
     Modifications compared to this template:
     * Include theme_boost_union/footnote template
+    * Added the possibility to show course related hints.
 }}
 {{> theme_boost/head }}
 
@@ -161,6 +162,7 @@
                                 </div>
                             </div>
                         {{/overflow}}
+                        {{{courserelatedhints}}}
                         {{{ output.main_content }}}
                         {{{ output.activity_navigation }}}
                         {{{ output.course_content_footer }}}

--- a/tests/behat/theme_boost_union_course_settings.feature
+++ b/tests/behat/theme_boost_union_course_settings.feature
@@ -1,0 +1,373 @@
+@theme @theme_boost_union @theme_boost_union_course_settings
+Feature: Configuring the theme_boost_union plugin for the "Course" tab
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+  Background:
+    Given the following "users" exist:
+      | username |
+      | student1 |
+      | teacher1 |
+    And the following "courses" exist:
+      | fullname | shortname |
+      | Course 1 | C1        |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+
+  Scenario: Enable "Position of switch role information"
+    Given the following config values are set as admin:
+      | config                   | value | plugin             |
+      | showswitchedroleincourse | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I follow "Switch role to..." in the user menu
+    And I click on "Student" "button"
+    Then I should see "You are viewing this course currently with the role:" in the ".course-hint-switchedrole" "css_element"
+    When I click on "Return to my normal role" "link" in the ".course-hint-switchedrole" "css_element"
+    Then I should not see "You are viewing this course currently with the role:"
+    And ".course-hint-switchedrole" "css_element" should not exist
+
+  Scenario: Enable "Show hint in hidden courses"
+    Given the following config values are set as admin:
+      | config               | value | plugin             |
+      | showhintcoursehidden | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    When I navigate to "Settings" in current page administration
+    And I set the following fields to these values:
+      | Course visibility | Hide |
+    And I click on "Save and display" "button"
+    Then I should see "This course is currently hidden. Only enrolled teachers can access this course when hidden." in the ".course-hint-hidden" "css_element"
+    When I am on "Course 1" course homepage
+    When I navigate to "Settings" in current page administration
+    And I set the following fields to these values:
+      | Course visibility | Show |
+    And I click on "Save and display" "button"
+    Then I should not see "This course is currently hidden. Only enrolled teachers can access this course when hidden."
+    And ".course-hint-hidden" "css_element" should not exist
+
+  Scenario: Enable "Show hint for guest access"
+    Given the following config values are set as admin:
+      | config                    | value | plugin             |
+      | showhintcourseguestaccess | yes   | theme_boost_union |
+    And the following "users" exist:
+      | username |
+      | student2 |
+    When I log in as "teacher1"
+    And I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Guest access" "table_row"
+    And I set the following fields to these values:
+      | Allow guest access | Yes |
+    And I press "Save changes"
+    And I log out
+    When I log in as "student2"
+    And I am on "Course 1" course homepage
+    Then I should see "You are currently viewing this course as Guest." in the ".course-hint-guestaccess" "css_element"
+    And I log out
+    And I log in as "teacher1"
+    And I am on the "Course 1" "enrolment methods" page
+    And I click on "Enable" "link" in the "Self enrolment (Student)" "table_row"
+    And I log out
+    When I log in as "student2"
+    And I am on "Course 1" course homepage
+    Then I should see "To have full access to the course, you can self enrol into this course." in the ".course-hint-guestaccess" "css_element"
+    And I click on "self enrol into this course" "link" in the ".course-hint-guestaccess" "css_element"
+    And I click on "Enrol me" "button"
+    Then I should not see "You are currently viewing this course as Guest."
+    And ".course-hint-guestaccess" "css_element" should not exist
+    And I log out
+    When I log in as "teacher1"
+    And I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Guest access" "table_row"
+    And I set the following fields to these values:
+      | Allow guest access | No |
+    And I press "Save changes"
+    And I log out
+    When I log in as "student2"
+    And I am on "Course 1" course homepage
+    Then I should not see "You are currently viewing this course as Guest."
+    And ".course-hint-guestaccess" "css_element" should not exist
+
+  Scenario: Enable "Show hint for self enrolment without enrolment key"
+    Given the following config values are set as admin:
+      | config                  | value | plugin             |
+      | showhintcourseselfenrol | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+    And I am on the "Course 1" "enrolment methods" page
+    When I click on "Enable" "link" in the "Self enrolment (Student)" "table_row"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should exist
+    And I log out
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+
+  Scenario: Enable "Show hint for self enrolment without enrolment key" and check that the call for action is shown
+    Given the following config values are set as admin:
+      | config                  | value | plugin             |
+      | showhintcourseselfenrol | yes   | theme_boost_union |
+    And the following "users" exist:
+      | username |
+      | teacher2 |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | teacher2 | C1     | teacher |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And I should not see "If you don't want that any Moodle user can enrol into this course freely, please restrict the self enrolment settings."
+    And ".course-hint-selfenrol" "css_element" should not exist
+    And I am on the "Course 1" "enrolment methods" page
+    When I click on "Enable" "link" in the "Self enrolment (Student)" "table_row"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is"
+    And I should see "If you don't want that any Moodle user can enrol into this course freely, please restrict the self enrolment settings."
+    And ".course-hint-selfenrol" "css_element" should exist
+    And I log out
+    When I log in as "teacher2"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is"
+    And I should not see "If you don't want that any Moodle user can enrol into this course freely, please restrict the self enrolment settings."
+    And ".course-hint-selfenrol" "css_element" should exist
+    And I log out
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And I should not see "If you don't want that any Moodle user can enrol into this course freely, please restrict the self enrolment settings."
+    And ".course-hint-selfenrol" "css_element" should not exist
+
+  Scenario: Enable "Show hint for self enrolment without enrolment key" and check that it is hidden when new enrolments are disabled
+    Given the following config values are set as admin:
+      | config                  | value | plugin             |
+      | showhintcourseselfenrol | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+    And I am on the "Course 1" "enrolment methods" page
+    When I click on "Enable" "link" in the "Self enrolment (Student)" "table_row"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I click on "Self enrolment (Student)" "link" in the ".course-hint-selfenrol" "css_element"
+    And I set the following fields to these values:
+      | Allow new enrolments | 0 |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+
+  Scenario: Enable "Show hint for self enrolment without enrolment key" and check that it is hidden when a password is set
+    Given the following config values are set as admin:
+      | config                  | value | plugin             |
+      | showhintcourseselfenrol | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+    And I am on the "Course 1" "enrolment methods" page
+    When I click on "Enable" "link" in the "Self enrolment (Student)" "table_row"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I click on "Self enrolment (Student)" "link" in the ".course-hint-selfenrol" "css_element"
+    And I set the following fields to these values:
+      | Enrolment key | 1234 |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+
+  Scenario: Enable "Show hint for self enrolment without enrolment key" and check the hints depending on the configured start and / or end dates
+    Given the following config values are set as admin:
+      | config                  | value | plugin             |
+      | showhintcourseselfenrol | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+    And I am on the "Course 1" "enrolment methods" page
+    When I click on "Enable" "link" in the "Self enrolment (Student)" "table_row"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is currently possible."
+    And I should see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment infinitely."
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I click on "Self enrolment (Student)" "link" in the ".course-hint-selfenrol" "css_element"
+    And I set the following fields to these values:
+      | id_enrolstartdate_enabled | 0             |
+      | id_enrolenddate_enabled   | 1             |
+    # We can't use the ##yesterday## notation here.
+      | id_enrolenddate_day       | 1             |
+      | id_enrolenddate_month     | January       |
+      | id_enrolenddate_year      | 2019          |
+      | id_enrolenddate_hour      | 00            |
+      | id_enrolenddate_minute    | 00            |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+    When I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Self enrolment (Student)" "table_row"
+    And I set the following fields to these values:
+      | id_enrolstartdate_enabled | 0             |
+      | id_enrolenddate_enabled   | 1             |
+    # We can't use the ##tomorrow## notation here. This test will break in the year 2050.
+      | id_enrolenddate_day       | 1             |
+      | id_enrolenddate_month     | January       |
+      | id_enrolenddate_year      | 2050          |
+      | id_enrolenddate_hour      | 00            |
+      | id_enrolenddate_minute    | 00            |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is currently possible."
+    And I should see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment until Saturday, 1 January 2050, 12:00 AM."
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Self enrolment (Student)" "table_row"
+    And I set the following fields to these values:
+      | id_enrolstartdate_enabled | 1             |
+    # We can't use the ##yesterday## notation here.
+      | id_enrolstartdate_day     | 1             |
+      | id_enrolstartdate_month   | January       |
+      | id_enrolstartdate_year    | 2019          |
+      | id_enrolstartdate_hour    | 00            |
+      | id_enrolstartdate_minute  | 00            |
+      | id_enrolenddate_enabled   | 0             |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is currently possible."
+    And I should see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment currently."
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Self enrolment (Student)" "table_row"
+    And I set the following fields to these values:
+      | id_enrolstartdate_enabled | 1             |
+    # We can't use the ##tomorrow## notation here. This test will break in the year 2050.
+      | id_enrolstartdate_day     | 1             |
+      | id_enrolstartdate_month   | January       |
+      | id_enrolstartdate_year    | 2050          |
+      | id_enrolstartdate_hour    | 00            |
+      | id_enrolstartdate_minute  | 00            |
+      | id_enrolenddate_enabled   | 0             |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is planned to become possible."
+    And I should see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment from Saturday, 1 January 2050, 12:00 AM on."
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Self enrolment (Student)" "table_row"
+    And I set the following fields to these values:
+      | id_enrolstartdate_enabled | 1             |
+    # We can't use the ##Monday next week## notation here. This test will break in the year 2050.
+      | id_enrolstartdate_day     | 1             |
+      | id_enrolstartdate_month   | January       |
+      | id_enrolstartdate_year    | 2050          |
+      | id_enrolstartdate_hour    | 00            |
+      | id_enrolstartdate_minute  | 00            |
+      | id_enrolenddate_enabled   | 1             |
+    # We can't use the ##Tuesday next week## notation here. This test will break in the year 2050.
+      | id_enrolenddate_day       | 2             |
+      | id_enrolenddate_month     | January       |
+      | id_enrolenddate_year      | 2050          |
+      | id_enrolenddate_hour      | 00            |
+      | id_enrolenddate_minute    | 00            |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is planned to become possible."
+    And I should see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment from Saturday, 1 January 2050, 12:00 AM until Sunday, 2 January 2050, 12:00 AM."
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Self enrolment (Student)" "table_row"
+    And I set the following fields to these values:
+      | id_enrolstartdate_enabled | 1             |
+    # We can't use the ##yesterday## notation here.
+      | id_enrolstartdate_day     | 1             |
+      | id_enrolstartdate_month   | January       |
+      | id_enrolstartdate_year    | 2019          |
+      | id_enrolstartdate_hour    | 00            |
+      | id_enrolstartdate_minute  | 00            |
+      | id_enrolenddate_enabled   | 1             |
+    # We can't use the ##tomorrow## notation here. This test will break in the year 2050.
+      | id_enrolenddate_day       | 1             |
+      | id_enrolenddate_month     | January       |
+      | id_enrolenddate_year      | 2050          |
+      | id_enrolenddate_hour      | 00            |
+      | id_enrolenddate_minute    | 00            |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is currently possible."
+    And I should see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment until Saturday, 1 January 2050, 12:00 AM."
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Self enrolment (Student)" "table_row"
+    And I set the following fields to these values:
+      | id_enrolstartdate_enabled | 1             |
+    # We can't use the ##3 days ago## notation here.
+      | id_enrolstartdate_day     | 1             |
+      | id_enrolstartdate_month   | January       |
+      | id_enrolstartdate_year    | 2018          |
+      | id_enrolstartdate_hour    | 00            |
+      | id_enrolstartdate_minute  | 00            |
+      | id_enrolenddate_enabled   | 1             |
+    # We can't use the ##2 days ago## notation here.
+      | id_enrolenddate_day       | 1             |
+      | id_enrolenddate_month     | January       |
+      | id_enrolenddate_year      | 2019          |
+      | id_enrolenddate_hour      | 00            |
+      | id_enrolenddate_minute    | 00            |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+
+  Scenario: Enable "Show hint for self enrolment without enrolment key" and add more than one self enrolment instance
+    Given the following config values are set as admin:
+      | config                  | value | plugin             |
+      | showhintcourseselfenrol | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    Then I should not see "This course is currently visible and self enrolment without enrolment key is"
+    And ".course-hint-selfenrol" "css_element" should not exist
+    And I am on the "Course 1" "enrolment methods" page
+    When I click on "Enable" "link" in the "Self enrolment (Student)" "table_row"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is"
+    And I should see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment infinitely."
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I add "Self enrolment" enrolment method in "Course 1" with:
+      | Custom instance name | Custom self enrolment |
+    And I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Custom self enrolment" "table_row"
+    And I set the following fields to these values:
+      | id_enrolstartdate_enabled | 0             |
+      | id_enrolenddate_enabled   | 1             |
+    # We can't use the ##tomorrow## notation here. This test will break in the year 2050.
+      | id_enrolenddate_day       | 1             |
+      | id_enrolenddate_month     | January       |
+      | id_enrolenddate_year      | 2050          |
+      | id_enrolenddate_hour      | 00            |
+      | id_enrolenddate_minute    | 00            |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is currently possible."
+    And I should see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment infinitely."
+    And I should see "The Custom self enrolment enrolment instance allows unrestricted self enrolment until Saturday, 1 January 2050, 12:00 AM."
+    And ".course-hint-selfenrol" "css_element" should exist
+    When I am on the "Course 1" "enrolment methods" page
+    And I click on "Edit" "link" in the "Self enrolment (Student)" "table_row"
+    And I set the following fields to these values:
+      | Enrolment key | 1234 |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should see "This course is currently visible and self enrolment without enrolment key is currently possible."
+    And I should not see "The Self enrolment (Student) enrolment instance allows unrestricted self enrolment infinitely."
+    And I should see "The Custom self enrolment enrolment instance allows unrestricted self enrolment until Saturday, 1 January 2050, 12:00 AM."
+    And ".course-hint-selfenrol" "css_element" should exist


### PR DESCRIPTION
This patch ports the 'course related hints' feature from Boost Campus to Boost Union.

With this patch, four new settings are introduced:
* Position of switch role information
* Show hint in hidden courses
* Show hint guest for access
* Show hint for self enrolment without enrolment key

The implementation is more or less the same as it was in Boost Campus, but the rendering of the hints are changed from html_writer to Mustache templates.