### PR TITLE
Feature: Allow non-admins to edit theme settings, solves #28

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-07-05 - Feature: Allow non-admins to edit theme settings, solves #28
 * 2022-07-05 - Feature: Back to top button, solves #7
 * 2022-07-05 - Adopt changes in Boost core for MDL-74634
 * 2022-06-21 - Add course related hints feature, solves #5

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Capabilities
 
 This plugin also introduces these additional capabilities:
 
+### theme/boost_union:configure
+
+This capability is used to control who is able to configure the theme as non-admin. By default, it is assigned to no role at all.
+
 ### theme/boost_union:viewhintcourseselfenrol
 
 This capability is used to control who is able to see a hint for unrestricted self enrolment in a visible course (if this feature was enabled in the theme settings). By default, it is assigned to teachers, non-editing teachers and managers.

--- a/db/access.php
+++ b/db/access.php
@@ -26,6 +26,12 @@ defined('MOODLE_INTERNAL') || die();
 
 $capabilities = array(
 
+    // Ability to configure the theme as non-admin.
+        'theme/boost_union:configure' => array(
+                'captype' => 'write',
+                'contextlevel' => CONTEXT_SYSTEM,
+                'riskbitmask' => RISK_XSS | RISK_CONFIG
+        ),
     // Ability to see a hint for unrestricted self enrolment in a visible course.
         'theme/boost_union:viewhintcourseselfenrol' => array(
                 'captype' => 'read',

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -92,5 +92,6 @@ $string['footnotesetting_desc'] = 'Whatever you add to this textarea will be dis
 $string['privacy:metadata'] = 'The Boost Union theme does not store any personal data about any user.';
 
 // Capabilities.
+$string['boost_union:configure'] = 'To be able to configure the theme as non-admin';
 $string['boost_union:viewhintcourseselfenrol'] = 'To be able to see a hint for unrestricted self enrolment in a visible course.';
 $string['boost_union:viewhintinhiddencourse'] = 'To be able to see a hint in a hidden course.';

--- a/settings.php
+++ b/settings.php
@@ -34,9 +34,10 @@ if ($ADMIN->fulltree) {
     $yesnooption = array(THEME_BOOST_UNION_SETTING_SELECT_YES => get_string('yes'),
             THEME_BOOST_UNION_SETTING_SELECT_NO => get_string('no'));
 
-    // Create settings page with tabs.
+    // Create settings page with tabs (and allow users with the theme/boost_union:configure capability to access it).
     $settings = new theme_boost_admin_settingspage_tabs('themesettingboost_union',
-            get_string('configtitle', 'theme_boost_union', null, true));
+            get_string('configtitle', 'theme_boost_union', null, true),
+            'theme/boost_union:configure');
 
 
     // Create general settings tab.
@@ -257,4 +258,30 @@ if ($ADMIN->fulltree) {
 
     // Add tab to settings page.
     $settings->add($page);
+}
+
+// Above, we made the theme setting not only available to admins but also
+// to non-admins who have the theme/boost_union:configure as well.
+// This was done when the theme_boost_admin_settingspage_tabs object is instantiated.
+// However, for unknown reasons, Moodle allows users with this capability to access the theme settings on
+// /admin/settings.php?section=themesettingboost_union without any problems,
+// but it does not add the settings page to the site administration tree
+// (even though and especially if the user has the moodle/site:configview capability as well).
+// This means that these users won't find the theme settings unless they have the direct URL.
+//
+// To overcome this strange issue, we add an external admin page link to the site navigation
+// for all non-admin users with this capability. This is only necessary if the Admin fulltree
+// is not expanded yet.
+$systemcontext = context_system::instance();
+if ($ADMIN->fulltree == false &&
+        has_capability('moodle/site:config', $systemcontext) == false&&
+        has_capability('theme/boost_union:configure', $systemcontext) == true) {
+    // Create new external settings page.
+    $externalpage = new admin_externalpage('themesettingboost_union_formanagers',
+            get_string('configtitle', 'theme_boost_union', null, true),
+            new moodle_url('/admin/settings.php', array('section' => 'themesettingboost_union')),
+            'theme/boost_union:configure');
+
+    // Add external settings page to themes category.
+    $ADMIN->add('themes', $externalpage);
 }

--- a/tests/behat/theme_boost_union_managers.feature
+++ b/tests/behat/theme_boost_union_managers.feature
@@ -1,0 +1,33 @@
+@theme @theme_boost_union @theme_boost_union_managers
+Feature: Configuring the theme_boost_union plugin as manager
+  In order to use the features
+  As manager
+  I need to be able to configure the theme Boost Union plugin
+
+  Background:
+    Given the following "users" exist:
+      | username |
+      | manager  |
+    Given the following "system role assigns" exist:
+      | user    | role    | contextlevel |
+      | manager | manager | System       |
+
+  Scenario: Allow managers to configure Boost Union
+    Given the following "permission overrides" exist:
+      | capability                  | permission | role    | contextlevel | reference |
+      | theme/boost_union:configure | Allow      | manager | System       |           |
+    And I log in as "manager"
+    And I follow "Site administration"
+    Then ".secondary-navigation li[data-key='appearance']" "css_element" should exist
+    And I navigate to "Appearance > Themes > Boost Union" in site administration
+    And "body#page-admin-setting-themesettingboost_union" "css_element" should exist
+    And I should see "Boost Union" in the "#region-main" "css_element"
+    And I should see "General settings" in the "#region-main" "css_element"
+
+  Scenario: Do not allow managers to configure Boost Union (countercheck)
+    Given the following "permission overrides" exist:
+      | capability                  | permission | role    | contextlevel | reference |
+      | theme/boost_union:configure | Prevent    | manager | System       |           |
+    And I log in as "manager"
+    And I follow "Site administration"
+    Then ".secondary-navigation li[data-key='appearance']" "css_element" should not exist

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2022031706;
+$plugin->version = 2022031707;
 $plugin->release = 'v4.0-r1';
 $plugin->requires = 2022041900;
 $plugin->supported = [400, 400];


### PR DESCRIPTION
This patch introduces the theme/boost_union:configure capability which allows managers to configure the theme as non-admin. By default, the capability is assigned to no role at all.

----

Please note that this PR is built on top of PR #31 and should be merged in line.