### PR TITLE
Feature: Show a warning banner if JavaScript is disabled, solves #46

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-07-07 - Feature: Show a warning banner if JavaScript is disabled, solves #46
 * 2022-07-07 - Feature: Make the course content column width configurable, helps to resolve #18.
 * 2022-07-06 - Feature: Built-in imprint, solves #32
 * 2022-07-05 - Feature: Configurable favicon, solves #34

--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ In this tab there are the following settings:
 
 With these settings, you can add rich text content which will be shown on the imprint page.
 
+### Tab "Miscellaneous"
+
+In this tab there are the following settings:
+
+#### JavaScript
+
+##### JavaScript disabled hint
+
+With this setting, a hint will appear at the top of the Moodle page if JavaScript is not enabled. This is particularly helpful as several Moodle features do not work without JavaScript.
+
 
 Capabilities
 ------------

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -115,6 +115,14 @@ $string['imprintlinkpositionboth'] = 'Add a link to the imprint page to the foot
 $string['imprintlinkpositionsetting'] = 'Imprint link position';
 $string['imprintlinkpositionsetting_desc'] = 'In this setting, you can configure if a link to the imprint page should be added automatically to the Moodle page. If you do not want to show a link automatically, you can add a link to {$a->url} from anywhere in Moodle manually.';
 
+// Settings: Misc tab.
+$string['misctab'] = 'Miscellaneous';
+$string['javascriptheading'] = 'JavaScript';
+// ... Setting: JavaScript disabled hint:
+$string['javascriptdisabledhint'] = 'JavaScript disabled hint';
+$string['javascriptdisabledhint_desc'] = 'With this setting, a hint will appear at the top of the Moodle page if JavaScript is not enabled. This is particularly helpful as several Moodle features do not work without JavaScript.';
+$string['javascriptdisabledhinttext'] = 'JavaScript is disabled in your browser.<br />Many features of Moodle will be not usable or will appear to be broken.<br />Please enable JavaScript for the full Moodle experience.';
+
 // Privacy API.
 $string['privacy:metadata'] = 'The Boost Union theme does not store any personal data about any user.';
 

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -98,5 +98,8 @@ require_once(__DIR__ . '/includes/footnote.php');
 // Include the template content for the static pages.
 require_once(__DIR__ . '/includes/staticpages.php');
 
+// Include the template content for the JavaScript disabled hint.
+require_once(__DIR__ . '/includes/javascriptdisabledhint.php');
+
 // Render columns2.mustache from boost_union.
 echo $OUTPUT->render_from_template('theme_boost_union/columns2', $templatecontext);

--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -137,5 +137,8 @@ require_once(__DIR__ . '/includes/footnote.php');
 // Include the template content for the static pages.
 require_once(__DIR__ . '/includes/staticpages.php');
 
+// Include the template content for the JavaScript disabled hint.
+require_once(__DIR__ . '/includes/javascriptdisabledhint.php');
+
 // Render drawers.mustache from boost_union.
 echo $OUTPUT->render_from_template('theme_boost_union/drawers', $templatecontext);

--- a/layout/includes/javascriptdisabledhint.php
+++ b/layout/includes/javascriptdisabledhint.php
@@ -15,19 +15,19 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Theme Boost Union - Version file
+ * Theme Boost Union - JavaScript disabled hint layout include.
  *
- * @package    theme_boost_union
- * @copyright  2022 Moodle an Hochschulen e.V. <kontakt@moodle-an-hochschulen.de>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package   theme_boost_union
+ * @copyright 2022 Moodle an Hochschulen e.V. <kontakt@moodle-an-hochschulen.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'theme_boost_union';
-$plugin->version = 2022031711;
-$plugin->release = 'v4.0-r1';
-$plugin->requires = 2022041900;
-$plugin->supported = [400, 400];
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = array('theme_boost' => 2022041900);
+$hintsetting = get_config('theme_boost_union', 'javascriptdisabledhint');
+
+// If the feature is enabled.
+if ($hintsetting == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+    // Add marker to show the hint to templatecontext.
+    $templatecontext['showjavascriptdisabledhint'] = true;
+}

--- a/settings.php
+++ b/settings.php
@@ -350,6 +350,26 @@ if ($ADMIN->fulltree) {
 
     // Add tab to settings page.
     $settings->add($page);
+
+
+    // Create misc tab.
+    $page = new admin_settingpage('theme_boost_union_misc', get_string('misctab', 'theme_boost_union', null, true));
+
+    // Create JavaScript heading.
+    $name = 'theme_boost_union/javascriptheading';
+    $title = get_string('javascriptheading', 'theme_boost_union', null, true);
+    $setting = new admin_setting_heading($name, $title, null);
+    $page->add($setting);
+
+    // Setting: JavaScript disabled hint.
+    $name = 'theme_boost_union/javascriptdisabledhint';
+    $title = get_string('javascriptdisabledhint', 'theme_boost_union', null, true);
+    $description = get_string('javascriptdisabledhint_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+    $page->add($setting);
+
+    // Add tab to settings page.
+    $settings->add($page);
 }
 
 // Above, we made the theme setting not only available to admins but also

--- a/templates/columns2.mustache
+++ b/templates/columns2.mustache
@@ -66,6 +66,7 @@
     {{> theme_boost/navbar }}
 
     <div id="page" class="container-fluid d-print-block">
+        {{> theme_boost_union/javascriptdisabledhint }}
         {{{ output.full_header }}}
             {{#secondarymoremenu}}
                 <div class="secondary-navigation">

--- a/templates/drawers.mustache
+++ b/templates/drawers.mustache
@@ -134,6 +134,7 @@
                     </div>
                 {{/hasblocks}}
             </div>
+            {{> theme_boost_union/javascriptdisabledhint }}
             {{{ output.full_header }}}
             {{#secondarymoremenu}}
                 <div class="secondary-navigation d-print-none">

--- a/templates/javascriptdisabledhint.mustache
+++ b/templates/javascriptdisabledhint.mustache
@@ -1,0 +1,37 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/javascriptdisabledhint
+
+    Boost Union JavaScript disabled hint layout template.
+
+    Context variables required for this template:
+    * showjavascriptdisabledhint - The fact if the JavaScript disabled hint should be shown or not
+
+    Example context (json):
+    {
+        "showjavascriptdisabledhint": true
+    }
+}}
+
+{{# showjavascriptdisabledhint }}
+    <noscript>
+        <div id="javascriptdisabledhint" class="alert alert-danger mt-2 mb-5 p-4" role="alert">
+            {{#str}}javascriptdisabledhinttext,theme_boost_union{{/str}}
+        </div>
+    </noscript>
+{{/ showjavascriptdisabledhint }}

--- a/tests/behat/theme_boost_union_misc_settings.feature
+++ b/tests/behat/theme_boost_union_misc_settings.feature
@@ -1,0 +1,28 @@
+@theme @theme_boost_union @theme_boost_union_misc_settings
+Feature: Configuring the theme_boost_union plugin for the "Miscellaneous" tab
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+  Scenario: Enable the JavaScript disabled hint (and make sure it is shown when JavaScript is disabled)
+    Given the following config values are set as admin:
+      | config                 | value | plugin            |
+      | javascriptdisabledhint | yes   | theme_boost_union |
+    When I log in as "admin"
+    Then "#javascriptdisabledhint" "css_element" should exist
+    And I should see "JavaScript is disabled in your browser" in the "#javascriptdisabledhint" "css_element"
+
+  @javascript
+  Scenario: Enable the JavaScript disabled hint (and make sure it is not shown when JavaScript is enabled)
+    Given the following config values are set as admin:
+      | config                 | value | plugin            |
+      | javascriptdisabledhint | yes   | theme_boost_union |
+    When I log in as "admin"
+    Then "#javascriptdisabledhint" "css_element" should not exist
+
+  Scenario: Disable the JavaScript disabled hint (and make sure it is not shown when JavaScript is disabled)
+    Given the following config values are set as admin:
+      | config                 | value | plugin            |
+      | javascriptdisabledhint | no    | theme_boost_union |
+    When I log in as "admin"
+    Then "#javascriptdisabledhint" "css_element" should not exist


### PR DESCRIPTION
With this patch, the admin can enable a hint which will appear at the top of the Moodle page if JavaScript is not enabled. This is particularly helpful as several Moodle features do not work without JavaScript.

----

Please note that this PR is built on top of PR #45 and should be merged in line.