### PR TITLE
Move back to top button when right drawer is shown

### DIFF
--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -21,10 +21,16 @@
     }
     /* Make sure that the back to top button is not covered by anything else. */
     z-index: $zindex-dropdown;
+    /* Animate position together with footer button. */
+    @include transition(0.2s);
 }
 #back-to-top i::before {
     /* Move the caret icon slightly up for a nicer look. */
     vertical-align: 0.3rem;
+}
+#page.drawers.show-drawer-right #back-to-top {
+    /* Move the back to top button when right drawer is shown. */
+    right: calc(#{$drawer-right-width} + 2rem);
 }
 
 


### PR DESCRIPTION
Currently the "Back to top" button floats over the right drawer when it is shown (see screenshot).
This pull request moves it over the main content to line up with the floating footer button.

![image](https://user-images.githubusercontent.com/5475686/177949978-5dd906e8-5298-4b31-a08f-b889e53feae3.png)