### PR TITLE
Feature: Customize activity icon background colors, solves #49

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-07-08 - Feature: Customize activity icon background colors, solves #49
 * 2022-07-07 - Feature: Show a warning banner if JavaScript is disabled, solves #46
 * 2022-07-07 - Feature: Make the course content column width configurable, helps to resolve #18.
 * 2022-07-06 - Feature: Built-in imprint, solves #32

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ This setting is already available in the Moodle core theme Boost. For more infor
 
 This setting is already available in the Moodle core theme Boost. For more information how to use it, please have a look at the official Moodle documentation: http://docs.moodle.org/en/Boost_theme
 
+#### Activity icon colors
+
+With these settings, you can overwrite the activity icon colors which are used within courses.
+
 ### Tab "Blocks"
 
 In this tab there are the following settings:

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -62,6 +62,26 @@ $string['faviconsetting_desc'] = 'Here, you can upload a custom image (.ico or .
 $string['backgroundimagesheading'] = 'Background images';
 // ... Section: Brand colors.
 $string['brandcolorsheading'] = 'Brand colors';
+// ... Section: Activity icon colors.
+$string['activityiconcolorsheading'] = 'Activity icon colors';
+// ... ... Setting: Activity icon color for 'Administration'.
+$string['activityiconcoloradministrationsetting'] = 'Activity icon color for "Administration"';
+$string['activityiconcoloradministrationsetting_desc'] = 'The activity icon color for "Administration"';
+// ... ... Setting: Activity icon color for 'Assessment'.
+$string['activityiconcolorassessmentsetting'] = 'Activity icon color for "Assessment"';
+$string['activityiconcolorassessmentsetting_desc'] = 'The activity icon color for "Assessment"';
+// ... ... Setting: Activity icon color for 'Collaboration'.
+$string['activityiconcolorcollaborationsetting'] = 'Activity icon color for "Collaboration"';
+$string['activityiconcolorcollaborationsetting_desc'] = 'The activity icon color for "Collaboration"';
+// ... ... Setting: Activity icon color for 'Communication'.
+$string['activityiconcolorcommunicationsetting'] = 'Activity icon color for "Communication"';
+$string['activityiconcolorcommunicationsetting_desc'] = 'The activity icon color for "Communication"';
+// ... ... Setting: Activity icon color for 'Content'.
+$string['activityiconcolorcontentsetting'] = 'Activity icon color for "Content"';
+$string['activityiconcolorcontentsetting_desc'] = 'The activity icon color for "Content"';
+// ... ... Setting: Activity icon color for 'Interface'.
+$string['activityiconcolorinterfacesetting'] = 'Activity icon color for "Interface"';
+$string['activityiconcolorinterfacesetting_desc'] = 'The activity icon color for "Interface"';
 
 // Settings: Blocks tab.
 $string['blockstab'] = 'Blocks';

--- a/lib.php
+++ b/lib.php
@@ -95,6 +95,34 @@ function theme_boost_union_get_pre_scss($theme) {
         $scss .= '$course-content-maxwidth: '.$theme->settings->coursecontentmaxwidth.";\n";
     }
 
+    // Overwrite Boost core SCSS variables which are stored in a SCSS map and thus couldn't be added to $configurable above.
+    // Set variables for the activity icon colors.
+    $activityiconcolors = array();
+    if (!empty($theme->settings->activityiconcoloradministration)) {
+        $activityiconcolors[] = '"administration": '.$theme->settings->activityiconcoloradministration;
+    }
+    if (!empty($theme->settings->activityiconcolorassessment)) {
+        $activityiconcolors[] = '"assessment": '.$theme->settings->activityiconcolorassessment;
+    }
+    if (!empty($theme->settings->activityiconcolorcollaboration)) {
+        $activityiconcolors[] = '"collaboration": '.$theme->settings->activityiconcolorcollaboration;
+    }
+    if (!empty($theme->settings->activityiconcolorcommunication)) {
+        $activityiconcolors[] = '"communication": '.$theme->settings->activityiconcolorcommunication;
+    }
+    if (!empty($theme->settings->activityiconcolorcontent)) {
+        $activityiconcolors[] = '"content": '.$theme->settings->activityiconcolorcontent;
+    }
+    if (!empty($theme->settings->activityiconcolorinterface)) {
+        $activityiconcolors[] = '"interface": '.$theme->settings->activityiconcolorinterface;
+    }
+    if (count($activityiconcolors) > 0) {
+        $activityiconscss = '$activity-icon-colors: ('."\n";
+        $activityiconscss .= implode(",\n", $activityiconcolors);
+        $activityiconscss .= ');';
+        $scss .= $activityiconscss."\n";
+    }
+
     // Prepend pre-scss.
     if (!empty($theme->settings->scsspre)) {
         $scss .= $theme->settings->scsspre;

--- a/settings.php
+++ b/settings.php
@@ -207,6 +207,60 @@ if ($ADMIN->fulltree) {
     $setting->set_updatedcallback('theme_reset_all_caches');
     $page->add($setting);
 
+    // Create activity icon colors heading.
+    $name = 'theme_boost_union/activityiconcolorsheading';
+    $title = get_string('activityiconcolorsheading', 'theme_boost_union', null, true);
+    $setting = new admin_setting_heading($name, $title, null);
+    $page->add($setting);
+
+    // Setting: Activity icon color for 'administration'.
+    $name = 'theme_boost_union/activityiconcoloradministration';
+    $title = get_string('activityiconcoloradministrationsetting', 'theme_boost_union', null, true);
+    $description = get_string('activityiconcoloradministrationsetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
+    // Setting: Activity icon color for 'assessment'.
+    $name = 'theme_boost_union/activityiconcolorassessment';
+    $title = get_string('activityiconcolorassessmentsetting', 'theme_boost_union', null, true);
+    $description = get_string('activityiconcolorassessmentsetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
+    // Setting: Activity icon color for 'collaboration'.
+    $name = 'theme_boost_union/activityiconcolorcollaboration';
+    $title = get_string('activityiconcolorcollaborationsetting', 'theme_boost_union', null, true);
+    $description = get_string('activityiconcolorcollaborationsetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
+    // Setting: Activity icon color for 'communication'.
+    $name = 'theme_boost_union/activityiconcolorcommunication';
+    $title = get_string('activityiconcolorcommunicationsetting', 'theme_boost_union', null, true);
+    $description = get_string('activityiconcolorcommunicationsetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
+    // Setting: Activity icon color for 'content'.
+    $name = 'theme_boost_union/activityiconcolorcontent';
+    $title = get_string('activityiconcolorcontentsetting', 'theme_boost_union', null, true);
+    $description = get_string('activityiconcolorcontentsetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
+    // Setting: Activity icon color for 'interface'.
+    $name = 'theme_boost_union/activityiconcolorinterface';
+    $title = get_string('activityiconcolorinterfacesetting', 'theme_boost_union', null, true);
+    $description = get_string('activityiconcolorinterfacesetting_desc', 'theme_boost_union', null, true);
+    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $page->add($setting);
+
     // Add tab to settings page.
     $settings->add($page);
 

--- a/tests/behat/theme_boost_union_branding_settings.feature
+++ b/tests/behat/theme_boost_union_branding_settings.feature
@@ -33,3 +33,21 @@ Feature: Configuring the theme_boost_union plugin for the "Branding" tab
     When I log in as "admin"
     Then "//head//link[contains(@rel, 'shortcut')][contains(@href, 'theme/image.php/boost_union/theme')][contains(@href, 'favicon')]" "xpath_element" should exist
     And "//head//link[contains(@rel, 'shortcut')][contains(@href, 'pluginfile.php/1/theme_boost_union/favicon')][contains(@href, 'favicon.ico')]" "xpath_element" should not exist
+
+  # Unfortunately, this can't be tested with Behat yet
+  # Scenario: Setting: Activity icon color for "Administration" - Setting the color
+
+  # Unfortunately, this can't be tested with Behat yet
+  # Scenario: Setting: Activity icon color for "Assessment" - Setting the color
+
+  # Unfortunately, this can't be tested with Behat yet
+  # Scenario: Setting: Activity icon color for "Collaboration" - Setting the color
+
+  # Unfortunately, this can't be tested with Behat yet
+  # Scenario: Setting: Activity icon color for "Communication" - Setting the color
+
+  # Unfortunately, this can't be tested with Behat yet
+  # Scenario: Setting: Activity icon color for "Content" - Setting the color
+
+  # Unfortunately, this can't be tested with Behat yet
+  # Scenario: Setting: Activity icon color for "Interface" - Setting the color

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2022031711;
+$plugin->version = 2022031712;
 $plugin->release = 'v4.0-r1';
 $plugin->requires = 2022041900;
 $plugin->supported = [400, 400];


### PR DESCRIPTION
With this patch, the admin can customize the activity icon background colors which were introduced in Moodle 4.0