### PR TITLE
Settings: Divide theme settings into multiple pages, solves #52

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-07-15 - Settings: Divide theme settings into multiple pages, solves #52
 * 2022-07-13 - Release: Add contributors to README.md, solves #44
 * 2022-07-13 - Release: Add UPGRADE.md, solves #29
 * 2022-07-08 - Feature: Customize activity icon background colors, solves #49

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -29,6 +29,9 @@ $string['pluginname'] = 'Boost Union';
 $string['choosereadme'] = 'Theme Boost Union is an enhanced child theme of Boost provided by Moodle an Hochschulen e.V.';
 $string['configtitle'] = 'Boost Union';
 
+// Settings: Look page.
+$string['configtitlelook'] = 'Look';
+
 // Settings: General settings tab.
 // ... Section: Theme presets.
 $string['presetheading'] = 'Theme presets';
@@ -44,12 +47,6 @@ $string['layoutheading'] = 'Layout';
 // ... ... Setting: Course content max width.
 $string['coursecontentmaxwidthsetting'] = 'Course content max width';
 $string['coursecontentmaxwidthsetting_desc'] = 'With this setting, you can override Moodle\'s default content width without manual SCSS modifications. By default, Moodle uses a course content max width of 830px. You can enter other pixel-based values like 1200px, but you can also enter a percentage-based value like 100% or a viewport-width value like 90vw.';
-// ... Section: Navigation.
-$string['navigationheading'] = 'Navigation';
-// ... ... Setting: Back to top button.
-$string['backtotop'] = 'Back to top';
-$string['backtotopbuttonsetting'] = 'Back to top button';
-$string['backtotopbuttonsetting_desc'] = 'With this setting a back to top button will appear in the bottom right corner of the page as soon as the user scrolls down the page. A button like this existed already on Boost in Moodle Core until Moodle 3.11, but was removed in 4.0. With Boost Union, you can bring it back.';
 
 // Settings: Branding tab.
 $string['brandingtab'] = 'Branding';
@@ -83,41 +80,34 @@ $string['activityiconcolorcontentsetting_desc'] = 'The activity icon color for "
 $string['activityiconcolorinterfacesetting'] = 'Activity icon color for "Interface"';
 $string['activityiconcolorinterfacesetting_desc'] = 'The activity icon color for "Interface"';
 
+// Settings: Feel page.
+$string['configtitlefeel'] = 'Feel';
+
+// Settings: Navigation tab.
+$string['navigationtab'] = 'Navigation';
+// ... Section: Navigation.
+$string['navigationheading'] = 'Navigation';
+// ... ... Setting: Back to top button.
+$string['backtotop'] = 'Back to top';
+$string['backtotopbuttonsetting'] = 'Back to top button';
+$string['backtotopbuttonsetting_desc'] = 'With this setting a back to top button will appear in the bottom right corner of the page as soon as the user scrolls down the page. A button like this existed already on Boost in Moodle Core until Moodle 3.11, but was removed in 4.0. With Boost Union, you can bring it back.';
+
 // Settings: Blocks tab.
 $string['blockstab'] = 'Blocks';
 // ... Section: General blocks.
 $string['blocksgeneralheading'] = 'General blocks';
 
-// Settings: Courses tab.
-$string['coursestab'] = 'Courses';
-// ... Section: Course related hints.
-$string['courserelatedhintsheading'] = 'Course related hints';
-// ... ... Setting: Show hint for switched role setting.
-$string['showswitchedroleincoursesetting'] = 'Show hint for switched role';
-$string['showswitchedroleincoursesetting_desc'] = 'With this setting a hint will appear in the course header if the user has switched the role in the course. By default, this information is only displayed right near the user\'s avatar in the user menu. By enabling this option, you can show this information - together with a link to switch back - within the course page as well.';
-$string['switchedroleto'] = 'You are viewing this course currently with the role: <strong>{$a->role}</strong>';
-// ... ... Setting: Show hint for hidden course.
-$string['showhintcoursehiddensetting'] = 'Show hint in hidden courses';
-$string['showhintcoursehiddensetting_desc'] = 'With this setting a hint will appear in the course header as long as the visibility of the course is hidden. This helps to identify the visibility state of a course at a glance without the need for looking at the course settings.';
-$string['showhintcoursehiddengeneral'] = 'This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.';
-$string['showhintcoursehiddensettingslink'] = 'You can change the visibility in the <a href="{$a->url}">course settings</a>.';
-// ... ... Setting: Show hint for guest access.
-$string['showhintcoursguestaccesssetting'] = 'Show hint for guest access';
-$string['showhintcourseguestaccesssetting_desc'] = 'With this setting a hint will appear in the course header when a user is accessing it with the guest access feature. If the course provides an active self enrolment, a link to that page is also presented to the user.';
-$string['showhintcourseguestaccessgeneral'] = 'You are currently viewing this course as <strong>{$a->role}</strong>.';
-$string['showhintcourseguestaccesslink'] = 'To have full access to the course, you can <a href="{$a->url}">self enrol into this course</a>.';
-// ... ... Setting: Show hint for unrestricted self enrolment.
-$string['showhintcourseselfenrolsetting'] = 'Show hint for self enrolment without enrolment key';
-$string['showhintcourseselfenrolsetting_desc'] = 'With this setting a hint will appear in the course header if the course is visible and an enrolment without enrolment key is currently possible.';
-$string['showhintcourseselfenrolstartcurrently'] = 'This course is currently visible and <strong>self enrolment without enrolment key</strong> is currently possible.';
-$string['showhintcourseselfenrolstartfuture'] = 'This course is currently visible and <strong>self enrolment without enrolment key</strong> is planned to become possible.';
-$string['showhintcourseselfenrolunlimited'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment infinitely.';
-$string['showhintcourseselfenroluntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment until {$a->until}.';
-$string['showhintcourseselfenrolfrom'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment from {$a->from} on.';
-$string['showhintcourseselfenrolsince'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment currently.';
-$string['showhintcourseselfenrolfromuntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment from {$a->from} until {$a->until}.';
-$string['showhintcourseselfenrolsinceuntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment until {$a->until}.';
-$string['showhintcourseselfenrolinstancecallforaction'] = 'If you don\'t want that any Moodle user can enrol into this course freely, please restrict the self enrolment settings.';
+// Settings: Misc tab.
+$string['misctab'] = 'Miscellaneous';
+// ... Section: JavaScript.
+$string['javascriptheading'] = 'JavaScript';
+// ... ... Setting: JavaScript disabled hint.
+$string['javascriptdisabledhint'] = 'JavaScript disabled hint';
+$string['javascriptdisabledhint_desc'] = 'With this setting, a hint will appear at the top of the Moodle page if JavaScript is not enabled. This is particularly helpful as several Moodle features do not work without JavaScript.';
+$string['javascriptdisabledhinttext'] = 'JavaScript is disabled in your browser.<br />Many features of Moodle will be not usable or will appear to be broken.<br />Please enable JavaScript for the full Moodle experience.';
+
+// Settings: Content page.
+$string['configtitlecontent'] = 'Content';
 
 // Settings: Footer tab.
 $string['footertab'] = 'Footer';
@@ -149,14 +139,39 @@ $string['imprintlinkpositionboth'] = 'Add a link to the imprint page to the foot
 $string['imprintlinkpositionsetting'] = 'Imprint link position';
 $string['imprintlinkpositionsetting_desc'] = 'In this setting, you can configure if a link to the imprint page should be added automatically to the Moodle page. If you do not want to show a link automatically, you can add a link to {$a->url} from anywhere in Moodle manually.';
 
-// Settings: Misc tab.
-$string['misctab'] = 'Miscellaneous';
-// ... Section: JavaScript.
-$string['javascriptheading'] = 'JavaScript';
-// ... ... Setting: JavaScript disabled hint.
-$string['javascriptdisabledhint'] = 'JavaScript disabled hint';
-$string['javascriptdisabledhint_desc'] = 'With this setting, a hint will appear at the top of the Moodle page if JavaScript is not enabled. This is particularly helpful as several Moodle features do not work without JavaScript.';
-$string['javascriptdisabledhinttext'] = 'JavaScript is disabled in your browser.<br />Many features of Moodle will be not usable or will appear to be broken.<br />Please enable JavaScript for the full Moodle experience.';
+// Settings: Functionality page.
+$string['configtitlefunctionality'] = 'Functionality';
+
+// Settings: Courses tab.
+$string['coursestab'] = 'Courses';
+// ... Section: Course related hints.
+$string['courserelatedhintsheading'] = 'Course related hints';
+// ... ... Setting: Show hint for switched role setting.
+$string['showswitchedroleincoursesetting'] = 'Show hint for switched role';
+$string['showswitchedroleincoursesetting_desc'] = 'With this setting a hint will appear in the course header if the user has switched the role in the course. By default, this information is only displayed right near the user\'s avatar in the user menu. By enabling this option, you can show this information - together with a link to switch back - within the course page as well.';
+$string['switchedroleto'] = 'You are viewing this course currently with the role: <strong>{$a->role}</strong>';
+// ... ... Setting: Show hint for hidden course.
+$string['showhintcoursehiddensetting'] = 'Show hint in hidden courses';
+$string['showhintcoursehiddensetting_desc'] = 'With this setting a hint will appear in the course header as long as the visibility of the course is hidden. This helps to identify the visibility state of a course at a glance without the need for looking at the course settings.';
+$string['showhintcoursehiddengeneral'] = 'This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.';
+$string['showhintcoursehiddensettingslink'] = 'You can change the visibility in the <a href="{$a->url}">course settings</a>.';
+// ... ... Setting: Show hint for guest access.
+$string['showhintcoursguestaccesssetting'] = 'Show hint for guest access';
+$string['showhintcourseguestaccesssetting_desc'] = 'With this setting a hint will appear in the course header when a user is accessing it with the guest access feature. If the course provides an active self enrolment, a link to that page is also presented to the user.';
+$string['showhintcourseguestaccessgeneral'] = 'You are currently viewing this course as <strong>{$a->role}</strong>.';
+$string['showhintcourseguestaccesslink'] = 'To have full access to the course, you can <a href="{$a->url}">self enrol into this course</a>.';
+// ... ... Setting: Show hint for unrestricted self enrolment.
+$string['showhintcourseselfenrolsetting'] = 'Show hint for self enrolment without enrolment key';
+$string['showhintcourseselfenrolsetting_desc'] = 'With this setting a hint will appear in the course header if the course is visible and an enrolment without enrolment key is currently possible.';
+$string['showhintcourseselfenrolstartcurrently'] = 'This course is currently visible and <strong>self enrolment without enrolment key</strong> is currently possible.';
+$string['showhintcourseselfenrolstartfuture'] = 'This course is currently visible and <strong>self enrolment without enrolment key</strong> is planned to become possible.';
+$string['showhintcourseselfenrolunlimited'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment infinitely.';
+$string['showhintcourseselfenroluntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment until {$a->until}.';
+$string['showhintcourseselfenrolfrom'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment from {$a->from} on.';
+$string['showhintcourseselfenrolsince'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment currently.';
+$string['showhintcourseselfenrolfromuntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment from {$a->from} until {$a->until}.';
+$string['showhintcourseselfenrolsinceuntil'] = 'The <strong>{$a->name}</strong> enrolment instance allows unrestricted self enrolment until {$a->until}.';
+$string['showhintcourseselfenrolinstancecallforaction'] = 'If you don\'t want that any Moodle user can enrol into this course freely, please restrict the self enrolment settings.';
 
 // Privacy API.
 $string['privacy:metadata'] = 'The Boost Union theme does not store any personal data about any user.';

--- a/settings.php
+++ b/settings.php
@@ -24,433 +24,506 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-// Require the necessary libraries.
-require_once($CFG->dirroot.'/theme/boost_union/lib.php');
-require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
+if ($hassiteconfig || has_capability('theme/boost_union:configure', context_system::instance())) {
 
-if ($ADMIN->fulltree) {
+    // How this file works:
+    // This theme's settings are divided into multiple settings pages.
+    // This is quite unusual as Boost themes would have a nice tabbed settings interface.
+    // However, as we are using many hide_if constraints for our settings, we would run into the
+    // stupid "Too much data passed as arguments to js_call_amd..." debugging message if we would
+    // pack all settings onto just one settings page.
+    // To achieve this goal, we create a custom admin settings category and fill it with several settings pages.
+    // However, there is still the $settings variable which is expected by Moodle coreto be filled with the theme
+    // settings and which is automatically added to the admin settings tree in one settings page.
+    // To avoid that there appears an empty "Boost Union" settings page near our own custom settings category,
+    // we set $settings to null.
 
-    // Prepare options array for select settings.
-    // Due to MDL-58376, we will use binary select settings instead of checkbox settings throughout this theme.
-    $yesnooption = array(THEME_BOOST_UNION_SETTING_SELECT_YES => get_string('yes'),
-            THEME_BOOST_UNION_SETTING_SELECT_NO => get_string('no'));
+    // Avoid that the theme settings page is auto-created.
+    $settings = null;
 
-    // Create settings page with tabs (and allow users with the theme/boost_union:configure capability to access it).
-    $settings = new theme_boost_admin_settingspage_tabs('themesettingboost_union',
-            get_string('configtitle', 'theme_boost_union', null, true),
-            'theme/boost_union:configure');
+    // Create custom admin settings category.
+    $ADMIN->add('themes', new admin_category('theme_boost_union',
+            get_string('pluginname', 'theme_boost_union', null, true)));
 
+    // Create empty settings page structure to make the site administration work on non-admin pages.
+    if (!$ADMIN->fulltree) {
+        // Create Look settings page
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $tab = new admin_settingpage('theme_boost_union_look',
+                get_string('configtitlelook', 'theme_boost_union', null, true),
+                'theme/boost_union:configure');
+        $ADMIN->add('theme_boost_union', $tab);
 
-    // Create general settings tab.
-    $page = new admin_settingpage('theme_boost_union_general', get_string('generalsettings', 'theme_boost', null, true));
+        // Create Feel settings page
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $tab = new admin_settingpage('theme_boost_union_feel',
+                get_string('configtitlefeel', 'theme_boost_union', null, true),
+                'theme/boost_union:configure');
+        $ADMIN->add('theme_boost_union', $tab);
 
-    // Create theme presets heading.
-    $name = 'theme_boost_union/presetheading';
-    $title = get_string('presetheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
+        // Create Content settings page
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $tab = new admin_settingpage('theme_boost_union_content',
+                get_string('configtitlecontent', 'theme_boost_union', null, true),
+                'theme/boost_union:configure');
+        $ADMIN->add('theme_boost_union', $tab);
 
-    // Replicate the preset setting from theme_boost, but use our own file area.
-    $name = 'theme_boost_union/preset';
-    $title = get_string('preset', 'theme_boost', null, true);
-    $description = get_string('preset_desc', 'theme_boost', null, true);
-    $default = 'default.scss';
-
-    $context = context_system::instance();
-    $fs = get_file_storage();
-    $files = $fs->get_area_files($context->id, 'theme_boost_union', 'preset', 0, 'itemid, filepath, filename', false);
-
-    $choices = [];
-    foreach ($files as $file) {
-        $choices[$file->get_filename()] = $file->get_filename();
+        // Create Functionality settings page
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $tab = new admin_settingpage('theme_boost_union_functionality',
+                get_string('configtitlefunctionality', 'theme_boost_union', null, true),
+                'theme/boost_union:configure');
+        $ADMIN->add('theme_boost_union', $tab);
     }
-    $choices['default.scss'] = 'default.scss';
-    $choices['plain.scss'] = 'plain.scss';
-
-    $setting = new admin_setting_configthemepreset($name, $title, $description, $default, $choices, 'boost_union');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Replicate the preset files setting from theme_boost.
-    $name = 'theme_boost_union/presetfiles';
-    $title = get_string('presetfiles', 'theme_boost', null, true);
-    $description = get_string('presetfiles_desc', 'theme_boost', null, true);
-    $setting = new admin_setting_configstoredfile($name, $title, $description, 'preset', 0,
-            array('maxfiles' => 20, 'accepted_types' => array('.scss')));
-    $page->add($setting);
-
-    // Add tab to settings page.
-    $settings->add($page);
-
-
-    // Create advanced settings tab.
-    $page = new admin_settingpage('theme_boost_union_advanced', get_string('advancedsettings', 'theme_boost', null, true));
-
-    // Create Raw SCSS heading.
-    $name = 'theme_boost_union/scssheading';
-    $title = get_string('scssheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Replicate the Raw initial SCSS setting from theme_boost.
-    $name = 'theme_boost_union/scsspre';
-    $title = get_string('rawscsspre', 'theme_boost', null, true);
-    $description = get_string('rawscsspre_desc', 'theme_boost', null, true);
-    $default = '';
-    $setting = new admin_setting_scsscode($name, $title, $description, $default, PARAM_RAW);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Replicate the Raw SCSS setting from theme_boost.
-    $name = 'theme_boost_union/scss';
-    $title = get_string('rawscss', 'theme_boost', null, true);
-    $description = get_string('rawscss_desc', 'theme_boost', null, true);
-    $default = '';
-    $setting = new admin_setting_scsscode($name, $title, $description, $default, PARAM_RAW);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Add tab to settings page.
-    $settings->add($page);
-
-
-    // Create page tab.
-    $page = new admin_settingpage('theme_boost_union_page', get_string('pagetab', 'theme_boost_union', null, true));
-
-    // Create layout heading.
-    $name = 'theme_boost_union/layoutheading';
-    $title = get_string('layoutheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Setting: Course content max width.
-    $name = 'theme_boost_union/coursecontentmaxwidth';
-    $title = get_string('coursecontentmaxwidthsetting', 'theme_boost_union', null, true);
-    $description = get_string('coursecontentmaxwidthsetting_desc', 'theme_boost_union', null, true);
-    $default = '830px';
-    // Regular expression for checking if the value is a percent number (from 0% to 100%) or a pixel number (with 3 or 4 digits)
-    // or a viewport width number (from 0 to 100).
-    $regex = '/^((\d{1,2}|100)%)|((\d{1,2}|100)vw)|(\d{3,4}px)$/';
-    $setting = new admin_setting_configtext($name, $title, $description, $default, $regex, 6);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Create navigation heading.
-    $name = 'theme_boost_union/navigationheading';
-    $title = get_string('navigationheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Setting: back to top button.
-    $name = 'theme_boost_union/backtotopbutton';
-    $title = get_string('backtotopbuttonsetting', 'theme_boost_union', null, true);
-    $description = get_string('backtotopbuttonsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Add tab to settings page.
-    $settings->add($page);
-
-
-    // Create branding tab.
-    $page = new admin_settingpage('theme_boost_union_branding', get_string('brandingtab', 'theme_boost_union', null, true));
-
-    // Create favicon heading.
-    $name = 'theme_boost_union/faviconheading';
-    $title = get_string('faviconheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Setting: Favicon.
-    $name = 'theme_boost_union/favicon';
-    $title = get_string('faviconsetting', 'theme_boost_union', null, true);
-    $description = get_string('faviconsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configstoredfile($name, $title, $description, 'favicon', 0,
-            array('maxfiles' => 1, 'accepted_types' => array('.ico', '.png')));
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Create background images heading.
-    $name = 'theme_boost_union/backgroundimagesheading';
-    $title = get_string('backgroundimagesheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Replicate the Background image setting from theme_boost.
-    $name = 'theme_boost_union/backgroundimage';
-    $title = get_string('backgroundimage', 'theme_boost', null, true);
-    $description = get_string('backgroundimage_desc', 'theme_boost', null, true);
-    $setting = new admin_setting_configstoredfile($name, $title, $description, 'backgroundimage');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Replicate the Login Background image setting from theme_boost.
-    $name = 'theme_boost_union/loginbackgroundimage';
-    $title = get_string('loginbackgroundimage', 'theme_boost', null, true);
-    $description = get_string('loginbackgroundimage_desc', 'theme_boost', null, true);
-    $setting = new admin_setting_configstoredfile($name, $title, $description, 'loginbackgroundimage');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Create brand colors heading.
-    $name = 'theme_boost_union/brandcolorsheading';
-    $title = get_string('brandcolorsheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Replicate the Variable $body-color setting from theme_boost.
-    $name = 'theme_boost_union/brandcolor';
-    $title = get_string('brandcolor', 'theme_boost', null, true);
-    $description = get_string('brandcolor_desc', 'theme_boost', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Create activity icon colors heading.
-    $name = 'theme_boost_union/activityiconcolorsheading';
-    $title = get_string('activityiconcolorsheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Setting: Activity icon color for 'administration'.
-    $name = 'theme_boost_union/activityiconcoloradministration';
-    $title = get_string('activityiconcoloradministrationsetting', 'theme_boost_union', null, true);
-    $description = get_string('activityiconcoloradministrationsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Setting: Activity icon color for 'assessment'.
-    $name = 'theme_boost_union/activityiconcolorassessment';
-    $title = get_string('activityiconcolorassessmentsetting', 'theme_boost_union', null, true);
-    $description = get_string('activityiconcolorassessmentsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Setting: Activity icon color for 'collaboration'.
-    $name = 'theme_boost_union/activityiconcolorcollaboration';
-    $title = get_string('activityiconcolorcollaborationsetting', 'theme_boost_union', null, true);
-    $description = get_string('activityiconcolorcollaborationsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Setting: Activity icon color for 'communication'.
-    $name = 'theme_boost_union/activityiconcolorcommunication';
-    $title = get_string('activityiconcolorcommunicationsetting', 'theme_boost_union', null, true);
-    $description = get_string('activityiconcolorcommunicationsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Setting: Activity icon color for 'content'.
-    $name = 'theme_boost_union/activityiconcolorcontent';
-    $title = get_string('activityiconcolorcontentsetting', 'theme_boost_union', null, true);
-    $description = get_string('activityiconcolorcontentsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Setting: Activity icon color for 'interface'.
-    $name = 'theme_boost_union/activityiconcolorinterface';
-    $title = get_string('activityiconcolorinterfacesetting', 'theme_boost_union', null, true);
-    $description = get_string('activityiconcolorinterfacesetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Add tab to settings page.
-    $settings->add($page);
-
-
-    // Create blocks tab.
-    $page = new admin_settingpage('theme_boost_union_blocks', get_string('blockstab', 'theme_boost_union', null, true));
-
-    // Create blocks general heading.
-    $name = 'theme_boost_union/blocksgeneralheading';
-    $title = get_string('blocksgeneralheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Replicate the Unaddable blocks setting from theme_boost.
-    $name = 'theme_boost_union/unaddableblocks';
-    $title = get_string('unaddableblocks', 'theme_boost', null, true);
-    $description = get_string('unaddableblocks_desc', 'theme_boost', null, true);
-    $default = 'navigation,settings,course_list,section_links';
-    $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_TEXT);
-    $page->add($setting);
-
-    // Add tab to settings page.
-    $settings->add($page);
-
-
-    // Create courses tab.
-    $page = new admin_settingpage('theme_boost_union_courses', get_string('coursestab', 'theme_boost_union', null, true));
-
-    // Create course related hints heading.
-    $name = 'theme_boost_union/courserelatedhintsheading';
-    $title = get_string('courserelatedhintsheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Setting: Show hint for switched role.
-    $name = 'theme_boost_union/showswitchedroleincourse';
-    $title = get_string('showswitchedroleincoursesetting', 'theme_boost_union', null, true);
-    $description = get_string('showswitchedroleincoursesetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $page->add($setting);
-
-    // Setting: Show hint in hidden courses.
-    $name = 'theme_boost_union/showhintcoursehidden';
-    $title = get_string('showhintcoursehiddensetting', 'theme_boost_union', null, true);
-    $description = get_string('showhintcoursehiddensetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
-    $page->add($setting);
-
-    // Setting: Show hint guest for access.
-    $name = 'theme_boost_union/showhintcourseguestaccess';
-    $title = get_string('showhintcoursguestaccesssetting', 'theme_boost_union', null, true);
-    $description = get_string('showhintcourseguestaccesssetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
-    $page->add($setting);
-
-    // Setting: Show hint for self enrolment without enrolment key.
-    $name = 'theme_boost_union/showhintcourseselfenrol';
-    $title = get_string('showhintcourseselfenrolsetting', 'theme_boost_union', null, true);
-    $description = get_string('showhintcourseselfenrolsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
-    $page->add($setting);
-
-    // Add tab to settings page.
-    $settings->add($page);
-
-
-    // Create footer tab.
-    $page = new admin_settingpage('theme_boost_union_footer', get_string('footertab', 'theme_boost_union', null, true));
-
-    // Create footnote heading.
-    $name = 'theme_boost_union/footnoteheading';
-    $title = get_string('footnoteheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Setting: Footnote.
-    $name = 'theme_boost_union/footnote';
-    $title = get_string('footnotesetting', 'theme_boost_union', null, true);
-    $description = get_string('footnotesetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_confightmleditor($name, $title, $description, '');
-    $page->add($setting);
-
-    // Add tab to settings page.
-    $settings->add($page);
-
-
-    // Create static pages tab.
-    $page = new admin_settingpage('theme_boost_union_staticpages', get_string('staticpagestab', 'theme_boost_union', null, true));
-
-    // Create imprint heading.
-    $name = 'theme_boost_union/imprintheading';
-    $title = get_string('imprintheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Setting: Enable imprint.
-    $name = 'theme_boost_union/enableimprint';
-    $title = get_string('enableimprintsetting', 'theme_boost_union', null, true);
-    $description = '';
-    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
-    $page->add($setting);
-
-    // Setting: Imprint content.
-    $name = 'theme_boost_union/imprintcontent';
-    $title = get_string('imprintcontentsetting', 'theme_boost_union', null, true);
-    $description = get_string('imprintcontentsetting_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_confightmleditor($name, $title, $description, '');
-    $page->add($setting);
-    $settings->hide_if('theme_boost_union/imprintcontent', 'theme_boost_union/enableimprint', 'neq',
-            THEME_BOOST_UNION_SETTING_SELECT_YES);
-
-    // Setting: Imprint page title.
-    $name = 'theme_boost_union/imprintpagetitle';
-    $title = get_string('imprintpagetitlesetting', 'theme_boost_union', null, true);
-    $description = get_string('imprintpagetitlesetting_desc', 'theme_boost_union', null, true);
-    $default = get_string('imprintpagetitledefault', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configtext($name, $title, $description, $default);
-    $page->add($setting);
-    $settings->hide_if('theme_boost_union/imprintpagetitle', 'theme_boost_union/enableimprint', 'neq',
-            THEME_BOOST_UNION_SETTING_SELECT_YES);
-
-    // Setting: Imprint link position.
-    $name = 'theme_boost_union/imprintlinkposition';
-    $title = get_string('imprintlinkpositionsetting', 'theme_boost_union', null, true);
-    $imprinturl = theme_boost_union_get_imprint_link();
-    $description = get_string('imprintlinkpositionsetting_desc', 'theme_boost_union', array('url' => $imprinturl), true);
-    $imprintlinkpositionoption =
-            // Don't use string lazy loading (= false) because the string will be directly used and would produce a
-            // PHP warning otherwise.
-            array(THEME_BOOST_UNION_SETTING_IMPRINTLINKPOSITION_NONE =>
-                    get_string('imprintlinkpositionnone', 'theme_boost_union', null, false),
-                  THEME_BOOST_UNION_SETTING_IMPRINTLINKPOSITION_FOOTNOTE =>
-                    get_string('imprintlinkpositionfootnote', 'theme_boost_union', null, false),
-                  THEME_BOOST_UNION_SETTING_IMPRINTLINKPOSITION_FOOTER =>
-                    get_string('imprintlinkpositionfooter', 'theme_boost_union', null, false),
-                  THEME_BOOST_UNION_SETTING_IMPRINTLINKPOSITION_BOTH =>
-                    get_string('imprintlinkpositionboth', 'theme_boost_union', null, false));
-    $default = 'none';
-    $setting = new admin_setting_configselect($name, $title, $description, $default, $imprintlinkpositionoption);
-    $page->add($setting);
-    $settings->hide_if('theme_boost_union/imprintlinkposition', 'theme_boost_union/enableimprint', 'neq',
-            THEME_BOOST_UNION_SETTING_SELECT_YES);
-
-    // Add tab to settings page.
-    $settings->add($page);
-
-
-    // Create misc tab.
-    $page = new admin_settingpage('theme_boost_union_misc', get_string('misctab', 'theme_boost_union', null, true));
-
-    // Create JavaScript heading.
-    $name = 'theme_boost_union/javascriptheading';
-    $title = get_string('javascriptheading', 'theme_boost_union', null, true);
-    $setting = new admin_setting_heading($name, $title, null);
-    $page->add($setting);
-
-    // Setting: JavaScript disabled hint.
-    $name = 'theme_boost_union/javascriptdisabledhint';
-    $title = get_string('javascriptdisabledhint', 'theme_boost_union', null, true);
-    $description = get_string('javascriptdisabledhint_desc', 'theme_boost_union', null, true);
-    $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
-    $page->add($setting);
-
-    // Add tab to settings page.
-    $settings->add($page);
-}
-
-// Above, we made the theme setting not only available to admins but also
-// to non-admins who have the theme/boost_union:configure as well.
-// This was done when the theme_boost_admin_settingspage_tabs object is instantiated.
-// However, for unknown reasons, Moodle allows users with this capability to access the theme settings on
-// /admin/settings.php?section=themesettingboost_union without any problems,
-// but it does not add the settings page to the site administration tree
-// (even though and especially if the user has the moodle/site:configview capability as well).
-// This means that these users won't find the theme settings unless they have the direct URL.
-//
-// To overcome this strange issue, we add an external admin page link to the site navigation
-// for all non-admin users with this capability. This is only necessary if the Admin fulltree
-// is not expanded yet.
-$systemcontext = context_system::instance();
-if ($ADMIN->fulltree == false &&
-        has_capability('moodle/site:config', $systemcontext) == false&&
-        has_capability('theme/boost_union:configure', $systemcontext) == true) {
-    // Create new external settings page.
-    $externalpage = new admin_externalpage('themesettingboost_union_formanagers',
-            get_string('configtitle', 'theme_boost_union', null, true),
-            new moodle_url('/admin/settings.php', array('section' => 'themesettingboost_union')),
-            'theme/boost_union:configure');
-
-    // Add external settings page to themes category.
-    $ADMIN->add('themes', $externalpage);
+
+    // Create full settings page structure.
+    // @codingStandardsIgnoreLine
+    else if ($ADMIN->fulltree) {
+
+        // Require the necessary libraries.
+        require_once($CFG->dirroot . '/theme/boost_union/lib.php');
+        require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
+
+        // Prepare options array for select settings.
+        // Due to MDL-58376, we will use binary select settings instead of checkbox settings throughout this theme.
+        $yesnooption = array(THEME_BOOST_UNION_SETTING_SELECT_YES => get_string('yes'),
+                THEME_BOOST_UNION_SETTING_SELECT_NO => get_string('no'));
+
+
+        // Create Look settings page with tabs
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $page = new theme_boost_admin_settingspage_tabs('theme_boost_union_look',
+                get_string('configtitlelook', 'theme_boost_union', null, true),
+                'theme/boost_union:configure');
+
+
+        // Create general settings tab.
+        $tab = new admin_settingpage('theme_boost_union_look_general', get_string('generalsettings', 'theme_boost', null, true));
+
+        // Create theme presets heading.
+        $name = 'theme_boost_union/presetheading';
+        $title = get_string('presetheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Replicate the preset setting from theme_boost, but use our own file area.
+        $name = 'theme_boost_union/preset';
+        $title = get_string('preset', 'theme_boost', null, true);
+        $description = get_string('preset_desc', 'theme_boost', null, true);
+        $default = 'default.scss';
+
+        $context = context_system::instance();
+        $fs = get_file_storage();
+        $files = $fs->get_area_files($context->id, 'theme_boost_union', 'preset', 0, 'itemid, filepath, filename', false);
+
+        $choices = [];
+        foreach ($files as $file) {
+            $choices[$file->get_filename()] = $file->get_filename();
+        }
+        $choices['default.scss'] = 'default.scss';
+        $choices['plain.scss'] = 'plain.scss';
+
+        $setting = new admin_setting_configthemepreset($name, $title, $description, $default, $choices, 'boost_union');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Replicate the preset files setting from theme_boost.
+        $name = 'theme_boost_union/presetfiles';
+        $title = get_string('presetfiles', 'theme_boost', null, true);
+        $description = get_string('presetfiles_desc', 'theme_boost', null, true);
+        $setting = new admin_setting_configstoredfile($name, $title, $description, 'preset', 0,
+                array('maxfiles' => 20, 'accepted_types' => array('.scss')));
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Create advanced settings tab.
+        $tab = new admin_settingpage('theme_boost_union_look_advanced', get_string('advancedsettings', 'theme_boost', null, true));
+
+        // Create Raw SCSS heading.
+        $name = 'theme_boost_union/scssheading';
+        $title = get_string('scssheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Replicate the Raw initial SCSS setting from theme_boost.
+        $name = 'theme_boost_union/scsspre';
+        $title = get_string('rawscsspre', 'theme_boost', null, true);
+        $description = get_string('rawscsspre_desc', 'theme_boost', null, true);
+        $default = '';
+        $setting = new admin_setting_scsscode($name, $title, $description, $default, PARAM_RAW);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Replicate the Raw SCSS setting from theme_boost.
+        $name = 'theme_boost_union/scss';
+        $title = get_string('rawscss', 'theme_boost', null, true);
+        $description = get_string('rawscss_desc', 'theme_boost', null, true);
+        $default = '';
+        $setting = new admin_setting_scsscode($name, $title, $description, $default, PARAM_RAW);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Create page tab.
+        $tab = new admin_settingpage('theme_boost_union_look_page', get_string('pagetab', 'theme_boost_union', null, true));
+
+        // Create layout heading.
+        $name = 'theme_boost_union/layoutheading';
+        $title = get_string('layoutheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Course content max width.
+        $name = 'theme_boost_union/coursecontentmaxwidth';
+        $title = get_string('coursecontentmaxwidthsetting', 'theme_boost_union', null, true);
+        $description = get_string('coursecontentmaxwidthsetting_desc', 'theme_boost_union', null, true);
+        $default = '830px';
+        // Regular expression for checking if the value is a percent number (from 0% to 100%) or a pixel number (with 3 or 4 digits)
+        // or a viewport width number (from 0 to 100).
+        $regex = '/^((\d{1,2}|100)%)|((\d{1,2}|100)vw)|(\d{3,4}px)$/';
+        $setting = new admin_setting_configtext($name, $title, $description, $default, $regex, 6);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Create branding tab.
+        $tab = new admin_settingpage('theme_boost_union_look_branding', get_string('brandingtab', 'theme_boost_union', null, true));
+
+        // Create favicon heading.
+        $name = 'theme_boost_union/faviconheading';
+        $title = get_string('faviconheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Favicon.
+        $name = 'theme_boost_union/favicon';
+        $title = get_string('faviconsetting', 'theme_boost_union', null, true);
+        $description = get_string('faviconsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configstoredfile($name, $title, $description, 'favicon', 0,
+                array('maxfiles' => 1, 'accepted_types' => array('.ico', '.png')));
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Create background images heading.
+        $name = 'theme_boost_union/backgroundimagesheading';
+        $title = get_string('backgroundimagesheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Replicate the Background image setting from theme_boost.
+        $name = 'theme_boost_union/backgroundimage';
+        $title = get_string('backgroundimage', 'theme_boost', null, true);
+        $description = get_string('backgroundimage_desc', 'theme_boost', null, true);
+        $setting = new admin_setting_configstoredfile($name, $title, $description, 'backgroundimage');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Replicate the Login Background image setting from theme_boost.
+        $name = 'theme_boost_union/loginbackgroundimage';
+        $title = get_string('loginbackgroundimage', 'theme_boost', null, true);
+        $description = get_string('loginbackgroundimage_desc', 'theme_boost', null, true);
+        $setting = new admin_setting_configstoredfile($name, $title, $description, 'loginbackgroundimage');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Create brand colors heading.
+        $name = 'theme_boost_union/brandcolorsheading';
+        $title = get_string('brandcolorsheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Replicate the Variable $body-color setting from theme_boost.
+        $name = 'theme_boost_union/brandcolor';
+        $title = get_string('brandcolor', 'theme_boost', null, true);
+        $description = get_string('brandcolor_desc', 'theme_boost', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Create activity icon colors heading.
+        $name = 'theme_boost_union/activityiconcolorsheading';
+        $title = get_string('activityiconcolorsheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Activity icon color for 'administration'.
+        $name = 'theme_boost_union/activityiconcoloradministration';
+        $title = get_string('activityiconcoloradministrationsetting', 'theme_boost_union', null, true);
+        $description = get_string('activityiconcoloradministrationsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Setting: Activity icon color for 'assessment'.
+        $name = 'theme_boost_union/activityiconcolorassessment';
+        $title = get_string('activityiconcolorassessmentsetting', 'theme_boost_union', null, true);
+        $description = get_string('activityiconcolorassessmentsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Setting: Activity icon color for 'collaboration'.
+        $name = 'theme_boost_union/activityiconcolorcollaboration';
+        $title = get_string('activityiconcolorcollaborationsetting', 'theme_boost_union', null, true);
+        $description = get_string('activityiconcolorcollaborationsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Setting: Activity icon color for 'communication'.
+        $name = 'theme_boost_union/activityiconcolorcommunication';
+        $title = get_string('activityiconcolorcommunicationsetting', 'theme_boost_union', null, true);
+        $description = get_string('activityiconcolorcommunicationsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Setting: Activity icon color for 'content'.
+        $name = 'theme_boost_union/activityiconcolorcontent';
+        $title = get_string('activityiconcolorcontentsetting', 'theme_boost_union', null, true);
+        $description = get_string('activityiconcolorcontentsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Setting: Activity icon color for 'interface'.
+        $name = 'theme_boost_union/activityiconcolorinterface';
+        $title = get_string('activityiconcolorinterfacesetting', 'theme_boost_union', null, true);
+        $description = get_string('activityiconcolorinterfacesetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Add settings page to the admin settings category.
+        $ADMIN->add('theme_boost_union', $page);
+
+        // Create Feel settings page with tabs
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $page = new theme_boost_admin_settingspage_tabs('theme_boost_union_feel',
+                get_string('configtitlefeel', 'theme_boost_union', null, true),
+                'theme/boost_union:configure');
+
+
+        // Create navigation tab.
+        $tab = new admin_settingpage('theme_boost_union_feel_navigation',
+                get_string('navigationtab', 'theme_boost_union', null, true));
+
+        // Create navigation heading.
+        $name = 'theme_boost_union/navigationheading';
+        $title = get_string('navigationheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: back to top button.
+        $name = 'theme_boost_union/backtotopbutton';
+        $title = get_string('backtotopbuttonsetting', 'theme_boost_union', null, true);
+        $description = get_string('backtotopbuttonsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Create blocks tab.
+        $tab = new admin_settingpage('theme_boost_union_feel_blocks', get_string('blockstab', 'theme_boost_union', null, true));
+
+        // Create blocks general heading.
+        $name = 'theme_boost_union/blocksgeneralheading';
+        $title = get_string('blocksgeneralheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Replicate the Unaddable blocks setting from theme_boost.
+        $name = 'theme_boost_union/unaddableblocks';
+        $title = get_string('unaddableblocks', 'theme_boost', null, true);
+        $description = get_string('unaddableblocks_desc', 'theme_boost', null, true);
+        $default = 'navigation,settings,course_list,section_links';
+        $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_TEXT);
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Create misc tab.
+        $tab = new admin_settingpage('theme_boost_union_feel_misc', get_string('misctab', 'theme_boost_union', null, true));
+
+        // Create JavaScript heading.
+        $name = 'theme_boost_union/javascriptheading';
+        $title = get_string('javascriptheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: JavaScript disabled hint.
+        $name = 'theme_boost_union/javascriptdisabledhint';
+        $title = get_string('javascriptdisabledhint', 'theme_boost_union', null, true);
+        $description = get_string('javascriptdisabledhint_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Add settings page to the admin settings category.
+        $ADMIN->add('theme_boost_union', $page);
+
+        // Create Content settings page with tabs
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $page = new theme_boost_admin_settingspage_tabs('theme_boost_union_content',
+                get_string('configtitlecontent', 'theme_boost_union', null, true),
+                'theme/boost_union:configure');
+
+        // Create footer tab.
+        $tab = new admin_settingpage('theme_boost_union_content_footer', get_string('footertab', 'theme_boost_union', null, true));
+
+        // Create footnote heading.
+        $name = 'theme_boost_union/footnoteheading';
+        $title = get_string('footnoteheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Footnote.
+        $name = 'theme_boost_union/footnote';
+        $title = get_string('footnotesetting', 'theme_boost_union', null, true);
+        $description = get_string('footnotesetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_confightmleditor($name, $title, $description, '');
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Create static pages tab.
+        $tab = new admin_settingpage('theme_boost_union_content_staticpages',
+                get_string('staticpagestab', 'theme_boost_union', null, true));
+
+        // Create imprint heading.
+        $name = 'theme_boost_union/imprintheading';
+        $title = get_string('imprintheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Enable imprint.
+        $name = 'theme_boost_union/enableimprint';
+        $title = get_string('enableimprintsetting', 'theme_boost_union', null, true);
+        $description = '';
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Setting: Imprint content.
+        $name = 'theme_boost_union/imprintcontent';
+        $title = get_string('imprintcontentsetting', 'theme_boost_union', null, true);
+        $description = get_string('imprintcontentsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_confightmleditor($name, $title, $description, '');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/imprintcontent', 'theme_boost_union/enableimprint', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+        // Setting: Imprint page title.
+        $name = 'theme_boost_union/imprintpagetitle';
+        $title = get_string('imprintpagetitlesetting', 'theme_boost_union', null, true);
+        $description = get_string('imprintpagetitlesetting_desc', 'theme_boost_union', null, true);
+        $default = get_string('imprintpagetitledefault', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configtext($name, $title, $description, $default);
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/imprintpagetitle', 'theme_boost_union/enableimprint', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+        // Setting: Imprint link position.
+        $name = 'theme_boost_union/imprintlinkposition';
+        $title = get_string('imprintlinkpositionsetting', 'theme_boost_union', null, true);
+        $imprinturl = theme_boost_union_get_imprint_link();
+        $description = get_string('imprintlinkpositionsetting_desc', 'theme_boost_union', array('url' => $imprinturl), true);
+        $imprintlinkpositionoption =
+                // Don't use string lazy loading (= false) because the string will be directly used and would produce a
+                // PHP warning otherwise.
+                array(THEME_BOOST_UNION_SETTING_IMPRINTLINKPOSITION_NONE =>
+                        get_string('imprintlinkpositionnone', 'theme_boost_union', null, false),
+                        THEME_BOOST_UNION_SETTING_IMPRINTLINKPOSITION_FOOTNOTE =>
+                                get_string('imprintlinkpositionfootnote', 'theme_boost_union', null, false),
+                        THEME_BOOST_UNION_SETTING_IMPRINTLINKPOSITION_FOOTER =>
+                                get_string('imprintlinkpositionfooter', 'theme_boost_union', null, false),
+                        THEME_BOOST_UNION_SETTING_IMPRINTLINKPOSITION_BOTH =>
+                                get_string('imprintlinkpositionboth', 'theme_boost_union', null, false));
+        $default = 'none';
+        $setting = new admin_setting_configselect($name, $title, $description, $default, $imprintlinkpositionoption);
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/imprintlinkposition', 'theme_boost_union/enableimprint', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Add settings page to the admin settings category.
+        $ADMIN->add('theme_boost_union', $page);
+
+        // Create Functionality settings page with tabs
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $page = new theme_boost_admin_settingspage_tabs('theme_boost_union_functionality',
+                get_string('configtitlefunctionality', 'theme_boost_union', null, true),
+                'theme/boost_union:configure');
+
+        // Create courses tab.
+        $tab = new admin_settingpage('theme_boost_union_functionality_courses',
+                get_string('coursestab', 'theme_boost_union', null, true));
+
+        // Create course related hints heading.
+        $name = 'theme_boost_union/courserelatedhintsheading';
+        $title = get_string('courserelatedhintsheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Show hint for switched role.
+        $name = 'theme_boost_union/showswitchedroleincourse';
+        $title = get_string('showswitchedroleincoursesetting', 'theme_boost_union', null, true);
+        $description = get_string('showswitchedroleincoursesetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Setting: Show hint in hidden courses.
+        $name = 'theme_boost_union/showhintcoursehidden';
+        $title = get_string('showhintcoursehiddensetting', 'theme_boost_union', null, true);
+        $description = get_string('showhintcoursehiddensetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Setting: Show hint guest for access.
+        $name = 'theme_boost_union/showhintcourseguestaccess';
+        $title = get_string('showhintcoursguestaccesssetting', 'theme_boost_union', null, true);
+        $description = get_string('showhintcourseguestaccesssetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Setting: Show hint for self enrolment without enrolment key.
+        $name = 'theme_boost_union/showhintcourseselfenrol';
+        $title = get_string('showhintcourseselfenrolsetting', 'theme_boost_union', null, true);
+        $description = get_string('showhintcourseselfenrolsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Add settings page to the admin settings category.
+        $ADMIN->add('theme_boost_union', $page);
+    }
 }

--- a/tests/behat/theme_boost_union_branding_settings.feature
+++ b/tests/behat/theme_boost_union_branding_settings.feature
@@ -20,7 +20,7 @@ Feature: Configuring the theme_boost_union plugin for the "Branding" tab
   @javascript @_file_upload
   Scenario: Setting: Favicon - Upload a custom favicon
     When I log in as "admin"
-    And I navigate to "Appearance > Boost Union" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Branding" "link"
     And I upload "theme/boost_union/tests/fixtures/favicon.ico" file to "Favicon" filemanager
     And I press "Save changes"

--- a/tests/behat/theme_boost_union_managers.feature
+++ b/tests/behat/theme_boost_union_managers.feature
@@ -19,9 +19,9 @@ Feature: Configuring the theme_boost_union plugin as manager
     And I log in as "manager"
     And I follow "Site administration"
     Then ".secondary-navigation li[data-key='appearance']" "css_element" should exist
-    And I navigate to "Appearance > Themes > Boost Union" in site administration
-    And "body#page-admin-setting-themesettingboost_union" "css_element" should exist
-    And I should see "Boost Union" in the "#region-main" "css_element"
+    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And "body#page-admin-setting-theme_boost_union_look" "css_element" should exist
+    And I should see "Look" in the "#region-main" "css_element"
     And I should see "General settings" in the "#region-main" "css_element"
 
   Scenario: Capabilities - Do not allow managers to configure Boost Union (countercheck)


### PR DESCRIPTION
Currently, this theme's settings are combined within one single tabbed settings page as Boost theme settings are built normally.
However, as we are and will be using many hide_if constraints for our settings, we would run into the
stupid "Too much data passed as arguments to js_call_amd..." debugging message if we would
continue to pack all settings onto just one settings page.
To achieve this goal, we will create a custom admin settings category and fill it with several settings pages.