### PR TITLE
Footnote and Login background - Bugfixes for #106 and #107

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-10-14 - Bugfix: Make login page background and footnote work together, solves #107.
 * 2022-10-13 - Bugfix: Footnote did not have a white background, solves #106.
 * 2022-10-13 - Bugfix: Custom SCSS and background image SCSS was included twice, solves #103 #104.
 * 2022-10-12 - Settings: screenshot image for theme chooser solves #33.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-10-13 - Bugfix: Footnote did not have a white background, solves #106.
 * 2022-10-13 - Bugfix: Custom SCSS and background image SCSS was included twice, solves #103 #104.
 * 2022-10-12 - Settings: screenshot image for theme chooser solves #33.
 

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -48,4 +48,27 @@ class core_renderer extends \theme_boost\output\core_renderer {
             return $this->image_url('favicon', 'theme');
         }
     }
+
+    /**
+     * Returns HTML attributes to use within the body tag. This includes an ID and classes.
+     *
+     * This renderer function is copied and modified from /lib/outputrenderers.php
+     *
+     * @since Moodle 2.5.1 2.6
+     * @param string|array $additionalclasses Any additional classes to give the body tag,
+     * @return string
+     */
+    public function body_attributes($additionalclasses = array()) {
+        if (!is_array($additionalclasses)) {
+            $additionalclasses = explode(' ', $additionalclasses);
+        }
+
+        // If the page has a background image, add a class to the body attributes.
+        if (!empty(get_config('theme_boost_union', 'backgroundimage'))) {
+            $additionalclasses[] = 'backgroundimage';
+        }
+
+        return ' id="'. $this->body_id().'" class="'.$this->body_css_classes($additionalclasses).'"';
+    }
+
 }

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -63,9 +63,16 @@ class core_renderer extends \theme_boost\output\core_renderer {
             $additionalclasses = explode(' ', $additionalclasses);
         }
 
-        // If the page has a background image, add a class to the body attributes.
-        if (!empty(get_config('theme_boost_union', 'backgroundimage'))) {
-            $additionalclasses[] = 'backgroundimage';
+        // If this isn't the login page and the page has a background image, add a class to the body attributes.
+        if ($this->page->pagelayout != 'login') {
+            if (!empty(get_config('theme_boost_union', 'backgroundimage'))) {
+                $additionalclasses[] = 'backgroundimage';
+            }
+        }
+
+        // If this is the login page and the page has a login background image, add a class to the body attributes.
+        if ($this->page->pagelayout == 'login' && !empty(get_config('theme_boost_union', 'loginbackgroundimage'))) {
+            $additionalclasses[] = 'loginbackgroundimage';
         }
 
         return ' id="'. $this->body_id().'" class="'.$this->body_css_classes($additionalclasses).'"';

--- a/lib.php
+++ b/lib.php
@@ -164,6 +164,38 @@ function theme_boost_union_get_extra_scss($theme) {
     // We have to accept this fact here and must not copy the code from theme_boost_get_extra_scss into this function.
     // Instead, we must only add additionally CSS code which is based on any Boost Union-only functionality.
 
+    // In contrast to Boost core, Boost Union should add the login page background to the body element as well.
+    // That's why we first have to revert the background which is set to #page on the login page by Boost core already as soon as a
+    // login background image is set. Doing this, we also have to make the background of the #page element transparent on the login
+    // page.
+    $loginbackgroundimageurl = $theme->setting_file_url('loginbackgroundimage', 'loginbackgroundimage');
+    if (!empty($loginbackgroundimageurl)) {
+        $content .= 'body.pagelayout-login #page { ';
+        $content .= "background-image: none !important;";
+        $content .= "background-color: transparent !important;";
+        $content .= '}';
+        $content .= 'body.pagelayout-login { ';
+        $content .= "background-image: url('$loginbackgroundimageurl'); background-size: cover;";
+        $content .= '}';
+    }
+
+    // Boost core has the behaviour that the normal background image is not shown on the login page, only the login background image
+    // is shown on the login page.
+    // This is fine, but it is done improperly as the normal background image is still there on the login page and just overlaid
+    // with a grey color in the #page element. This can result in flickering during the page load.
+    // We try to avoid this by removing the background image from the body tag if no login background image is set.
+    if (empty($loginbackgroundimageurl)) {
+        $content .= 'body.pagelayout-login { ';
+        $content .= "background-image: none !important;";
+        $content .= '}';
+    }
+
+    // Lastly, we make sure that the background image is fixed and not repeated. Just to be sure.
+    $content .= 'body { ';
+    $content .= "background-repeat: no-repeat;";
+    $content .= "background-attachment: fixed;";
+    $content .= '}';
+
     return $content;
 }
 

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -38,11 +38,16 @@
  * Settings: Content -> Footnote.
  ======================================*/
 
-/* The footnote styles are different on larger and smaller screens. */
+/* The footnote styles are different on the login page and on all non-login pages.
+   They are also different on larger and smaller screens.
+   We will deal with the overall cases for all screen sizes first and will then overwrite the things which need
+   to be different on the login page. */
+
 /* On larger screens. */
 @include media-breakpoint-up(md) {
-    /* If there is a background image configured. */
-    body.backgroundimage #footnote {
+    /* If there is a background image or a loginbackground image configured. */
+    body.backgroundimage #footnote,
+    body.loginbackgroundimage #footnote {
         /* Add horizontal padding to align the footnote with the main page content.
            The numbers are basically adopted from the main content areas of the Moodle page. */
         padding-left: calc(15px + .5rem);
@@ -55,8 +60,8 @@
         margin-bottom: 1rem;
     }
 
-    /* If there isn't a background image configured. */
-    body:not(.backgroundimage) #footnote {
+    /* If there isn't a background image nor a loginbackground image configured. */
+    body:not(.backgroundimage):not(.loginbackgroundimage) #footnote {
         /* Add horizontal margin to align the footnote with the main page content.
            The numbers are basically adopted from the main content areas of the Moodle page. */
         margin-left: calc(15px + .5rem);
@@ -66,7 +71,6 @@
         border-top: $border-width solid $border-color;
     }
 }
-
 
 /* And on smaller screens. */
 @include media-breakpoint-only(sm) {
@@ -94,8 +98,7 @@
 
         /* Add horizontal margin and padding to align the footnote with the main page content.
            The numbers are adopted from the main content areas of the Moodle page.
-           Add another right padding as well to avoid that the content gets covered by the footer and back-to-top
-           buttons. */
+           Add another right padding as well to avoid that the content gets covered by the back-to-top button. */
         margin-left: 15px;
         padding-left: 1rem;
         margin-right: 15px;
@@ -106,13 +109,64 @@
     }
 }
 
-/* On the login page, the footnote does not need a border-top as the login page has a grey background already.
-   Only on really small screens, the border top is helpful there. */
+/* As said, the login needs some more adjustments. */
+
+/* On larger screens. */
 @include media-breakpoint-up(sm) {
-    #page-login-index #footnote {
-        /* stylelint-disable-next-line declaration-no-important */
-        border-top: none !important;
+    /* If there is a loginbackground image configured. */
+    body.pagelayout-login.loginbackgroundimage #footnote {
+        /* Add a box shadow to the footnote to match the look of the login box. */
+        box-shadow: $logincontainer-shadow;
+
+        /* Add horizontal margin as the page does not have a margin itself. */
+        margin-left: 15px;
+        margin-right: 15px;
+
+        /* Add another right padding as well to avoid that the content gets covered by the footer button. */
+        padding-right: calc(.5rem + 51px); /* The underlying calculation is 15px + .5rem + 36px. */
     }
+}
+
+/* On smaller screens. */
+@include media-breakpoint-only(sm) {
+    /* If there is a loginbackground image configured. */
+    body.pagelayout-login.loginbackgroundimage #footnote {
+        /* Add white background color and a small bottom margin
+           to make the footnote work with background images.
+           This is necessary as this isn't covered by the normal background styles already
+           (which are only applied to pages > 768px.
+           Note that there isn't a border-radius added as the login box doesn't have a border radius as well
+           on this screen size. */
+        background-color: $white;
+        margin-bottom: 1rem;
+    }
+}
+
+/* And on really small screens. */
+@include media-breakpoint-down(xs) {
+    body.pagelayout-login.loginbackgroundimage #footnote {
+        /* Add white background color and a small bottom margin
+           to make the footnote work with background images.
+           This is necessary as this isn't covered by the normal background styles already
+           (which are only applied to pages > 768px. */
+        background-color: $white;
+
+        /* Change horizontal margin and padding to
+           to make the footnote work with background images.
+           We do not need any additional right padding as there isn't a back-to-top button nor a footer button
+           on the login page on this screen size. */
+        margin-left: 0;
+        padding-left: calc(15px + 1rem);
+        margin-right: 0;
+        padding-right: calc(15px + 1rem);
+    }
+}
+
+/* On all screen sizes. */
+/* If there isn't a loginbackground image configured. */
+body.pagelayout-login:not(.loginbackgroundimage) #footnote {
+    /* Remove the top border as there is the gradient in #page. */
+    border-top: none;
 }
 
 

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -38,24 +38,74 @@
  * Settings: Content -> Footnote.
  ======================================*/
 
-/* Add horizontal margin to align the footnote with the main page content. */
-#footnote {
-    /* On larger screens. */
-    @include media-breakpoint-up(md) {
+/* The footnote styles are different on larger and smaller screens. */
+/* On larger screens. */
+@include media-breakpoint-up(md) {
+    /* If there is a background image configured. */
+    body.backgroundimage #footnote {
+        /* Add horizontal padding to align the footnote with the main page content.
+           The numbers are basically adopted from the main content areas of the Moodle page. */
+        padding-left: calc(15px + .5rem);
+        padding-right: calc(15px + .5rem);
+
+        /* Add white background color, border radius and a small bottom margin
+           to make the footnote work with background images. */
+        @include border-radius();
+        background-color: $white;
+        margin-bottom: 1rem;
+    }
+
+    /* If there isn't a background image configured. */
+    body:not(.backgroundimage) #footnote {
+        /* Add horizontal margin to align the footnote with the main page content.
+           The numbers are basically adopted from the main content areas of the Moodle page. */
         margin-left: calc(15px + .5rem);
         margin-right: calc(15px + .5rem);
-    }
-    /* And on smaller screens. */
-    @include media-breakpoint-down(sm) {
-        margin-left: 15px;
-        margin-right: 15px;
-    }
-    /* And on really small screens, a left padding is added as well as the footer links appear then instead of the
-       footer icons and everything should align well. */
-    @include media-breakpoint-down(sm) {
-        padding-left: 1rem;
+
+        /* Add top border. */
+        border-top: $border-width solid $border-color;
     }
 }
+
+
+/* And on smaller screens. */
+@include media-breakpoint-only(sm) {
+    #footnote {
+        /* On smaller screens, there isn't any background image, so there's no need for a white background. */
+
+        /* Add horizontal margin and padding to align the footnote with the main page content.
+           The numbers are adopted from the main content areas of the Moodle page.
+           Add another right padding as well to avoid that the content gets covered by the footer and back-to-top
+           buttons. */
+        margin-left: .5rem;
+        padding-left: 15px;
+        margin-right: .5rem;
+        padding-right: 51px; /* The underlying calculation is 15px + 36px. */
+
+        /* Add top border. */
+        border-top: $border-width solid $border-color;
+    }
+}
+
+/* And on really small screens. */
+@include media-breakpoint-down(xs) {
+    #footnote {
+        /* On really small screens, there isn't any background image, so there's no need for a white background. */
+
+        /* Add horizontal margin and padding to align the footnote with the main page content.
+           The numbers are adopted from the main content areas of the Moodle page.
+           Add another right padding as well to avoid that the content gets covered by the footer and back-to-top
+           buttons. */
+        margin-left: 15px;
+        padding-left: 1rem;
+        margin-right: 15px;
+        padding-right: calc(1rem + 36px);
+
+        /* Add top border. */
+        border-top: $border-width solid $border-color;
+    }
+}
+
 /* On the login page, the footnote does not need a border-top as the login page has a grey background already.
    Only on really small screens, the border top is helpful there. */
 @include media-breakpoint-up(sm) {

--- a/templates/footnote.mustache
+++ b/templates/footnote.mustache
@@ -33,7 +33,7 @@
 }}
 
 {{# showfootnote }}
-    <div id="footnote" class="mt-3 pt-3 pb-6 pr-6 border-top">
+    <div id="footnote" class="py-3">
         <div class="container-fluid">
             <div class="row">
                 {{{ footnotesetting }}}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2022080905;
+$plugin->version = 2022080906;
 $plugin->release = 'v4.0-r3';
 $plugin->requires = 2022041900;
 $plugin->supported = [400, 400];


### PR DESCRIPTION
#106 - This patch solves the problem that the footnote content was not really readable as soon as a background image was configured. Additionally, it improves the margins and paddings of the footnote on the various screen sizes.

#107 - This patch changes the way how the login page background is added to the page from the #page element to the body element.
Additionally, it introduces several adjustments to make sure that the footnote works well with background images on the login page.

Here's how it looks like now:

# Course page without any background images configured

## Large screen
![grafik](https://user-images.githubusercontent.com/1092118/195782069-eec8f1a1-e263-46c8-8594-8bb6dafa5bd3.png)

## Smaller screen
![grafik](https://user-images.githubusercontent.com/1092118/195782295-35c4c9c5-1fe3-48f5-9a6c-6a456f5b1d7c.png)

## Really small screen
![grafik](https://user-images.githubusercontent.com/1092118/195782348-849e2644-2e8a-4482-a253-c91c741de69d.png)

# Course page with a background image configured

## Large screen
![grafik](https://user-images.githubusercontent.com/1092118/195782611-dbf09fc3-c6ce-45b3-a17c-1d95c1d86656.png)

## Smaller screen (which does not have a background image as Boost Core built it)
![grafik](https://user-images.githubusercontent.com/1092118/195782690-75d82107-c614-4cbf-a718-57ac315c143b.png)

## Really small screen (which does not have a background image as Boost Core built it)
![grafik](https://user-images.githubusercontent.com/1092118/195782802-b4ab5503-a253-4207-82ae-ead6138e86ca.png)

# Login page with a normal background image configured

## Large screen
![grafik](https://user-images.githubusercontent.com/1092118/195803909-a6476b43-ffd7-46ba-bf5f-6a3e8d03128c.png)

## Smaller screen
![grafik](https://user-images.githubusercontent.com/1092118/195803951-4624c984-deff-4496-b738-595f134e9f59.png)

## Really small screen
![grafik](https://user-images.githubusercontent.com/1092118/195804018-dd5adcc8-7694-4244-b251-4f37cc04d4a2.png)


# Login page with a login background image configured

## Large screen
![grafik](https://user-images.githubusercontent.com/1092118/195804143-3940f2b5-fcaa-4705-9ef1-86baf0d0b903.png)

## Smaller screen
![grafik](https://user-images.githubusercontent.com/1092118/195804187-c0391712-5da7-4bc0-baf0-2bb0f619546e.png)

## Really small screen
![grafik](https://user-images.githubusercontent.com/1092118/195804272-78c9ab58-5c2c-481c-af3d-6e35e00d3a6d.png)

# Login page with both login background image and normal background image configured

## Large screen
![grafik](https://user-images.githubusercontent.com/1092118/195804143-3940f2b5-fcaa-4705-9ef1-86baf0d0b903.png)

## Smaller screen
![grafik](https://user-images.githubusercontent.com/1092118/195804187-c0391712-5da7-4bc0-baf0-2bb0f619546e.png)

## Really small screen
![grafik](https://user-images.githubusercontent.com/1092118/195804272-78c9ab58-5c2c-481c-af3d-6e35e00d3a6d.png)


# Login page without any background images configured

## Large screen
![grafik](https://user-images.githubusercontent.com/1092118/195803630-3b44206c-8fb0-4580-99cf-88b485fc9196.png)

## Smaller screen
![grafik](https://user-images.githubusercontent.com/1092118/195803683-86512d0e-b6b5-4429-98e0-a45b4fb6cf9a.png)

## Really small screen
![grafik](https://user-images.githubusercontent.com/1092118/195803778-77028652-00cc-4a20-ab72-4b7aff151eeb.png)


