### PR TITLE
Additional nitpicky hidden course hint on forum pages

### DIFF
--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -218,7 +218,7 @@ $string['switchedroleto'] = 'You are viewing this course currently with the role
 $string['showhintcoursehiddensetting'] = 'Show hint in hidden courses';
 $string['showhintcoursehiddensetting_desc'] = 'With this setting a hint will appear in the course header as long as the visibility of the course is hidden. This helps to identify the visibility state of a course at a glance without the need for looking at the course settings.';
 $string['showhintcoursehiddengeneral'] = 'This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.';
-$string['showhintcoursehiddennotificationforum'] = 'This course is currently <strong>hidden</strong>. Therefore students will not get any notifications from here.';
+$string['showhintcoursehiddennotificationforum'] = 'This course is currently <strong>hidden</strong>. Please note that because of this, students will not be notified of messages online or via email that you post in this forum.';
 $string['showhintcoursehiddensettingslink'] = 'You can change the visibility in the <a href="{$a->url}">course settings</a>.';
 // ... ... Setting: Show hint for guest access.
 $string['showhintcoursguestaccesssetting'] = 'Show hint for guest access';

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -218,6 +218,7 @@ $string['switchedroleto'] = 'You are viewing this course currently with the role
 $string['showhintcoursehiddensetting'] = 'Show hint in hidden courses';
 $string['showhintcoursehiddensetting_desc'] = 'With this setting a hint will appear in the course header as long as the visibility of the course is hidden. This helps to identify the visibility state of a course at a glance without the need for looking at the course settings.';
 $string['showhintcoursehiddengeneral'] = 'This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.';
+$string['showhintcoursehiddennotificationforum'] = 'This course is currently <strong>hidden</strong>. Therefore students will not get any notifications from here.';
 $string['showhintcoursehiddensettingslink'] = 'You can change the visibility in the <a href="{$a->url}">course settings</a>.';
 // ... ... Setting: Show hint for guest access.
 $string['showhintcoursguestaccesssetting'] = 'Show hint for guest access';

--- a/locallib.php
+++ b/locallib.php
@@ -40,7 +40,7 @@ function theme_boost_union_get_course_related_hints() {
     // Initialize HTML code.
     $html = '';
 
-    // If the setting showhintcoursehidden is set and the visibility of the course is hidden and
+    // If the setting showhintcoursehidden is set and the visibility of the course is hidden
     // a hint for the visibility will be shown.
     if (get_config('theme_boost_union', 'showhintcoursehidden') == THEME_BOOST_UNION_SETTING_SELECT_YES
             && has_capability('theme/boost_union:viewhintinhiddencourse', \context_course::instance($COURSE->id))
@@ -62,8 +62,8 @@ function theme_boost_union_get_course_related_hints() {
         $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-hidden', $templatecontext);
     }
 
-    // If the setting showhintcoursehidden is set and the visibility of the course is hidden and
-    // a hint for the visibility will be shown.
+    // If the setting showhintcoursehidden is set and the visibility of the course is hidden
+    // a hint will be shown that no notifications via forums will be sent out to students.
     if (get_config('theme_boost_union', 'showhintcoursehidden') == THEME_BOOST_UNION_SETTING_SELECT_YES
             && has_capability('theme/boost_union:viewhintinhiddencourse', \context_course::instance($COURSE->id))
             && $PAGE->has_set_url()

--- a/locallib.php
+++ b/locallib.php
@@ -62,6 +62,28 @@ function theme_boost_union_get_course_related_hints() {
         $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-hidden', $templatecontext);
     }
 
+    // If the setting showhintcoursehidden is set and the visibility of the course is hidden and
+    // a hint for the visibility will be shown.
+    if (get_config('theme_boost_union', 'showhintcoursehidden') == THEME_BOOST_UNION_SETTING_SELECT_YES
+            && has_capability('theme/boost_union:viewhintinhiddencourse', \context_course::instance($COURSE->id))
+            && $PAGE->has_set_url()
+            && $PAGE->url->compare(new moodle_url('/mod/forum/view.php'), URL_MATCH_BASE)
+            && $COURSE->visible == false) {
+
+        // Prepare template context.
+        $templatecontext = array('courseid' => $COURSE->id);
+
+        // If the user has the capability to change the course settings, an additional link to the course settings is shown.
+        if (has_capability('moodle/course:update', context_course::instance($COURSE->id))) {
+            $templatecontext['showcoursesettingslink'] = true;
+        } else {
+            $templatecontext['showcoursesettingslink'] = false;
+        }
+
+        // Render template and add it to HTML code.
+        $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-hidden-forum', $templatecontext);
+    }
+
     // If the setting showhintcourseguestaccess is set and the user is accessing the course with guest access,
     // a hint for users is shown.
     // We also check that the user did not switch the role. This is a special case for roles that can fully access the course

--- a/templates/course-hint-hidden-forum.mustache
+++ b/templates/course-hint-hidden-forum.mustache
@@ -15,18 +15,20 @@
     along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 }}
 {{!
-    @template theme_boost_union/course-hint-hidden
+    @template theme_boost_union/course-hint-hidden-forum
 
-    Boost Union template for outputting the hidden course hint.
+    Boost Union template for outputting the hidden course hint on forum pages.
 
     Context variables required for this template:
     * courseid - The course ID
+    * showhintcoursehiddennotificationforum - The info text shown at forum pages inside hidden courses
     * showcoursesettingslink - The fact if a link to the course settings should be shown or not
 
     Example context (json):
     {
         "courseid": "123",
-        "showcoursesettingslink": true
+        "showcoursesettingslink": true,
+        "showhintcoursehiddennotificationforum": "This course is currently <strong>hidden</strong>. Please note that because of this, students will not be notified of messages online or via email that you post in this forum.""
     }
 }}
 <div class="course-hint-hidden alert alert-warning">

--- a/templates/course-hint-hidden-forum.mustache
+++ b/templates/course-hint-hidden-forum.mustache
@@ -1,0 +1,42 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/course-hint-hidden
+
+    Boost Union template for outputting the hidden course hint.
+
+    Context variables required for this template:
+    * courseid - The course ID
+    * showcoursesettingslink - The fact if a link to the course settings should be shown or not
+
+    Example context (json):
+    {
+        "courseid": "123",
+        "showcoursesettingslink": true
+    }
+}}
+<div class="course-hint-hidden alert alert-warning">
+    <div class="media">
+        <div class="mr-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
+        <div class="media-body align-self-center">
+            {{#str}} showhintcoursehiddennotificationforum, theme_boost_union {{/str}}
+            {{#showcoursesettingslink}}
+                <br />{{#str}} showhintcoursehiddensettingslink, theme_boost_union, { "url": "{{config.wwwroot}}/course/edit.php?id={{courseid}}" } {{/str}}
+            {{/showcoursesettingslink}}
+        </div>
+    </div>
+</div>

--- a/templates/course-hint-hidden.mustache
+++ b/templates/course-hint-hidden.mustache
@@ -21,11 +21,13 @@
 
     Context variables required for this template:
     * courseid - The course ID
+    * showhintcoursehiddengeneral - The info text shown on hidden courses below the course title,
     * showcoursesettingslink - The fact if a link to the course settings should be shown or not
 
     Example context (json):
     {
         "courseid": "123",
+        "showhintcoursehiddengeneral: "This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.",
         "showcoursesettingslink": true
     }
 }}

--- a/tests/behat/theme_boost_union_functionalitysettings_courses.feature
+++ b/tests/behat/theme_boost_union_functionalitysettings_courses.feature
@@ -33,7 +33,12 @@ Feature: Configuring the theme_boost_union plugin for the "Courses" tab on the "
   Scenario: Setting: Show hint in hidden courses - Enable the setting
     Given the following config values are set as admin:
       | config               | value | plugin             |
-      | showhintcoursehidden | yes   | theme_boost_union |
+      | showhintcoursehidden | yes   | theme_boost_union  |
+    And the following "activity" exists:
+      | course   | C1            |
+      | activity | forum         |
+      | idnumber | Announcements |
+      | name     | Announcements |
     When I log in as "teacher1"
     And I am on "Course 1" course homepage
     When I navigate to "Settings" in current page administration
@@ -41,8 +46,10 @@ Feature: Configuring the theme_boost_union plugin for the "Courses" tab on the "
       | Course visibility | Hide |
     And I click on "Save and display" "button"
     Then I should see "This course is currently hidden. Only enrolled teachers can access this course when hidden." in the ".course-hint-hidden" "css_element"
+    When I am on the "Announcements" "forum activity" page
+    Then I should see "This course is currently hidden. Therefore students will not get any notifications from here." in the ".course-hint-hidden" "css_element"
     When I am on "Course 1" course homepage
-    When I navigate to "Settings" in current page administration
+    And I navigate to "Settings" in current page administration
     And I set the following fields to these values:
       | Course visibility | Show |
     And I click on "Save and display" "button"

--- a/tests/behat/theme_boost_union_functionalitysettings_courses.feature
+++ b/tests/behat/theme_boost_union_functionalitysettings_courses.feature
@@ -47,7 +47,7 @@ Feature: Configuring the theme_boost_union plugin for the "Courses" tab on the "
     And I click on "Save and display" "button"
     Then I should see "This course is currently hidden. Only enrolled teachers can access this course when hidden." in the ".course-hint-hidden" "css_element"
     When I am on the "Announcements" "forum activity" page
-    Then I should see "This course is currently hidden. Therefore students will not get any notifications from here." in the ".course-hint-hidden" "css_element"
+    Then I should see "This course is currently hidden. Please note that because of this, students will not be notified of messages online or via email that you post in this forum." in the ".course-hint-hidden" "css_element"
     When I am on "Course 1" course homepage
     And I navigate to "Settings" in current page administration
     And I set the following fields to these values:


### PR DESCRIPTION
See Issue https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues/98

This PR currently copies the logic of the hiddencoursehint and uses a seperate similar mustache template.
I thought of using the same template file with an additional templatecontext to choose which string to use.

It currently provides no additional setting for controlling this additional but related hint, which has to/may be discussed.

