### PR TITLE
Feature: Filearea for additional resources, solves #113

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2022-10-15 - Feature: Filearea for additional resources, solves #113.
+
 ### v4.0-r4
 
 * 2022-10-15 - Feature: Random login background image with text, solves #36.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ With these settings, you can overwrite the Bootstrap colors which are used withi
 
 With these settings, you can overwrite the activity icon colors which are used within courses.
 
+#### Tab "Resources"
+
+##### Additional resources
+
+With this setting you can upload additional resources to the theme. The advantage of uploading files to this file area is that those files can be delivered without a check if the user is logged in. This is also why you should only add files that are uncritical and everyone should be allowed to access and don't need be protected with a valid login. As soon as you have uploaded at least one file to this filearea and have stored the settings, a list will appear underneath which will give you the URL which you can use to reference a particular file.
+
 ### Settings page "Feel"
 
 #### Tab "Navigation"

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -104,6 +104,19 @@ $string['activityiconcolorcontentsetting_desc'] = 'The activity icon color for "
 // ... ... Setting: Activity icon color for 'Interface'.
 $string['activityiconcolorinterfacesetting'] = 'Activity icon color for "Interface"';
 $string['activityiconcolorinterfacesetting_desc'] = 'The activity icon color for "Interface"';
+// Settings: Resources.
+$string['resourcestab'] = 'Resources';
+$string['resourcescachecontrolnote'] = 'Please note that the files are shipped to the browser with the \'Cache-Control\' header set which tells the browser to cache the file. If you are sure that you won\'t change the file in the near future, you can use the persistent URL to link to the file. However, if you plan to modify a file but keep the same filename every now and then, you should rather use the revisioned URL and re-link the file where you have used it everytime you update the file to avoid that the browsers will show cached outdated versions of the file.';
+// ... Section: Additional resources.
+$string['additionalresourcesheading'] = 'Additional resources';
+// ... ... Setting: Additional resources.
+$string['additionalresourcessetting'] = 'Additional resources';
+$string['additionalresourcessetting_desc'] = 'With this setting you can upload additional resources to the theme. The advantage of uploading files to this file area is that those files can be delivered without a check if the user is logged in. This is also why you should only add files that are uncritical and everyone should be allowed to access and don\'t need be protected with a valid login. As soon as you have uploaded at least one file to this filearea and have stored the settings, a list will appear underneath which will give you the URL which you can use to reference a particular file.';
+// ... ... Information: Additional resources list.
+$string['additionalresourceslistsetting'] = 'Additional resources list';
+$string['additionalresourceslistsetting_desc'] = 'This is the list of files which you have uploaded to the additional resources filearea. The given URLs can be used to link to these files from within your custom CSS, from the footnote or whereever you need to use uploaded files but can\'t upload files in place.';
+$string['additionalresourcesfileurlpersistent'] = 'URL (persistent)';
+$string['additionalresourcesfileurlrevisioned'] = 'URL (revisioned)';
 
 // Settings: Feel page.
 $string['configtitlefeel'] = 'Feel';

--- a/lib.php
+++ b/lib.php
@@ -232,7 +232,7 @@ function theme_boost_union_get_precompiled_css() {
  */
 function theme_boost_union_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array()) {
     if ($context->contextlevel == CONTEXT_SYSTEM && ($filearea === 'logo' || $filearea === 'backgroundimage' ||
-        $filearea === 'loginbackgroundimage' || $filearea === 'favicon')) {
+        $filearea === 'loginbackgroundimage' || $filearea === 'favicon' || $filearea === 'additionalresources')) {
         $theme = theme_config::load('boost_union');
         // By default, theme files must be cache-able by both browsers and proxies.
         if (!array_key_exists('cacheability', $options)) {

--- a/locallib.php
+++ b/locallib.php
@@ -610,3 +610,47 @@ function theme_boost_union_get_loginbackgroundimage_text() {
 
     return '';
 }
+
+/**
+ * Return the files from the additionalresources file area as templatecontext structure.
+ * It was designed to compose the files for the settings-additionalresources-filelist.mustache template.
+ * This function always loads the files from the filearea which is not really performant.
+ * Thus, you have to take care where and how often you use it (or add some caching).
+ *
+ * @return array|null
+ * @throws coding_exception
+ * @throws dml_exception
+ */
+function theme_boost_union_get_additionalresources_templatecontext() {
+    global $OUTPUT;
+
+    // Static variable to remember the files for subsequent calls of this function.
+    static $filesforcontext = null;
+
+    if ($filesforcontext == null) {
+        // Get the system context.
+        $systemcontext = \context_system::instance();
+
+        // Get filearea.
+        $fs = get_file_storage();
+
+        // Get all files from filearea.
+        $files = $fs->get_area_files($systemcontext->id, 'theme_boost_union', 'additionalresources', false, 'itemid', false);
+
+        // Iterate over the files and fill the templatecontext of the file list.
+        $filesforcontext = array();
+        foreach ($files as $af) {
+            $urlpersistent = new moodle_url('/pluginfile.php/1/theme_boost_union/additionalresources/0/'.$af->get_filename());
+            $urlrevisioned = new moodle_url('/pluginfile.php/1/theme_boost_union/additionalresources/'.theme_get_revision().
+                    '/'.$af->get_filename());
+            $filesforcontext[] = array('filename' => $af->get_filename(),
+                                        'filetype' => $af->get_mimetype(),
+                                        'filesize' => display_size($af->get_filesize()),
+                                        'fileicon' => $OUTPUT->image_icon(file_file_icon($af, 64), get_mimetype_description($af)),
+                                        'fileurlpersistent' => $urlpersistent->out(),
+                                        'fileurlrevisioned' => $urlrevisioned->out());
+        }
+    }
+
+    return $filesforcontext;
+}

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -1,4 +1,19 @@
 /*=======================================
+ * Settings: Look -> Branding
+ ======================================*/
+
+/*---------------------------------------
+ * Setting: Additional resources.
+ --------------------------------------*/
+
+/* Enlarge the icons in the settings file list. */
+.settings-additionalresources-filelist .icon {
+    height: 64px;
+    width: 64px;
+}
+
+
+/*=======================================
  * Settings: Feel -> Navigation.
  ======================================*/
 

--- a/settings.php
+++ b/settings.php
@@ -361,6 +361,48 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $page->add($tab);
 
 
+        // Create resources tab.
+        $tab = new admin_settingpage('theme_boost_union_look_resources',
+                get_string('resourcestab', 'theme_boost_union', null, true));
+
+        // Create additional resources heading.
+        $name = 'theme_boost_union/additionalresourcesheading';
+        $title = get_string('additionalresourcesheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Additional resources.
+        $name = 'theme_boost_union/additionalresources';
+        $title = get_string('additionalresourcessetting', 'theme_boost_union', null, true);
+        $description = get_string('additionalresourcessetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configstoredfile($name, $title, $description, 'additionalresources', 0,
+                array('maxfiles' => -1));
+        $tab->add($setting);
+
+        // Information: Additional resources list.
+        // If there is at least one file uploaded.
+        if (!empty(get_config('theme_boost_union', 'additionalresources'))) {
+            // Prepare the widget.
+            $name = 'theme_boost_union/additionalresourceslist';
+            $title = get_string('additionalresourceslistsetting', 'theme_boost_union', null, true);
+            $description = get_string('additionalresourceslistsetting_desc', 'theme_boost_union', null, true).'<br /><br />'.
+                    get_string('resourcescachecontrolnote', 'theme_boost_union', null, true);
+
+            // Append the file list to the description.
+            $templatecontext = array('files' => theme_boost_union_get_additionalresources_templatecontext());
+            $description .= $OUTPUT->render_from_template('theme_boost_union/settings-additionalresources-filelist',
+                    $templatecontext);
+
+            // Finish the widget.
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
+
+        }
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
         // Add settings page to the admin settings category.
         $ADMIN->add('theme_boost_union', $page);
 

--- a/templates/settings-additionalresources-filelist.mustache
+++ b/templates/settings-additionalresources-filelist.mustache
@@ -1,0 +1,55 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/settings-additionalresources-filelist
+
+    Boost Union settingsfilelist layout template.
+
+    Context variables required for this template:
+    * files - Array of files
+
+    Example context (json):
+    {
+        "files": [
+            {
+                "fileicon": "<img class='icon ' alt='Image (JPEG)' title='Image (JPEG)' src='/theme/image.php/boost_union/core/1666077095/f/jpeg-64'>",
+                "filename": "foo.jpg",
+                "filetype": "image/jpeg",
+                "filesize": "38.5 KB",
+                "fileurlpersistent": "http://localhost/pluginfile.php/1/theme_boost_union/additionalresources/0/foo.jpg",
+                "fileurlrevisioned": "http://localhost/pluginfile.php/1/theme_boost_union/additionalresources/1666077095/foo.jpg"
+            }
+        ]
+    }
+}}
+
+<ul class="list-group my-3 settings-additionalresources-filelist">
+    {{#files}}
+        <li class="list-group-item d-flex justify-content-between">
+            <div class="d-flex flex-row">
+                {{{fileicon}}}
+                <div class="ml-2">
+                    <h6 class="mb-0">{{filename}}</h6>
+                    <small>{{#str}}mimetype, tool_filetypes{{/str}}: {{filetype}}</small><br />
+                    <small>{{#str}}size, repository{{/str}}: {{filesize}}</small><br />
+                    <small>{{#str}}additionalresourcesfileurlpersistent, theme_boost_union{{/str}}: <a href="{{fileurlpersistent}}">{{fileurlpersistent}}</a></small><br />
+                    <small>{{#str}}additionalresourcesfileurlrevisioned, theme_boost_union{{/str}}: <a href="{{fileurlrevisioned}}">{{fileurlrevisioned}}</a></small>
+                </div>
+            </div>
+        </li>
+    {{/files}}
+</ul>

--- a/tests/behat/theme_boost_union_looksettings_resources.feature
+++ b/tests/behat/theme_boost_union_looksettings_resources.feature
@@ -1,0 +1,33 @@
+@theme @theme_boost_union @theme_boost_union_looksettings @theme_boost_union_looksettings_resources
+Feature: Configuring the theme_boost_union plugin for the "Resources" tab on the "Look" page
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+  @javascript @_file_upload
+  Scenario: Setting: Additional resources - Upload additional resources files
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Resources" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Additional resources" filemanager
+    And I press "Save changes"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Resources" "link"
+    Then I should see "Additional resources list"
+    And ".settings-additionalresources-filelist" "css_element" should exist
+    And ".settings-additionalresources-filelist .list-group-item .icon[title='Image (JPEG)']" "css_element" should exist
+    And ".settings-additionalresources-filelist .list-group-item .icon[src$='/f/jpeg-64']" "css_element" should exist
+    And I should see "MIME type: image/jpeg" in the ".settings-additionalresources-filelist" "css_element"
+    And I should see "Size: 38.5" in the ".settings-additionalresources-filelist" "css_element"
+    And I should see "URL (persistent):" in the ".settings-additionalresources-filelist" "css_element"
+    And I should see "/pluginfile.php/1/theme_boost_union/additionalresources/0/login_bg1.jpg" in the ".settings-additionalresources-filelist" "css_element"
+    And I should see "URL (revisioned):" in the ".settings-additionalresources-filelist" "css_element"
+    # Checking the revisioned URL is not possible currently with Behat without writing a custom step. We accept this for now.
+
+  @javascript @_file_upload
+  Scenario: Setting: Additional resources - Do not upload any file (countercheck)
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Resources" "link"
+    Then I should not see "Additional resources list"
+    And ".settings-additionalresources-filelist" "css_element" should not exist

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2022080907;
+$plugin->version = 2022080908;
 $plugin->release = 'v4.0-r4';
 $plugin->requires = 2022041900;
 $plugin->supported = [400, 400];


### PR DESCRIPTION
With this patch, a setting is added where the admin can upload additional resources to the theme which can be linked from anywhere in Moodle (especially from custom CSS).