### PR TITLE
Feature: Allow admins to override the email templates within the theme, solves #60

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2022-11-08 - Feature: Allow admins to override the email templates within the theme, solves #60.
+
 ### v4.0-r7
 
 * 2022-11-09 - Bugfix: Site administration was broken if customfiletypes were set in config.php, solves #133.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ With these settings, you can overwrite the Bootstrap colors which are used withi
 
 With these settings, you can overwrite the activity icon colors which are used within courses.
 
+#### Tab "E-Mail branding"
+
+In this tab, you find a feature which you can use to apply branding to all E-Mails which Moodle is sending out.
+
+Please note: This is an advanced functionality which uses some workarounds to provide E-Mail branding options. Please follow the instructions closely.
+
 #### Tab "Resources"
 
 ##### Additional resources

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -104,6 +104,52 @@ $string['activityiconcolorcontentsetting_desc'] = 'The activity icon color for "
 // ... ... Setting: Activity icon color for 'Interface'.
 $string['activityiconcolorinterfacesetting'] = 'Activity icon color for "Interface"';
 $string['activityiconcolorinterfacesetting_desc'] = 'The activity icon color for "Interface"';
+// Settings: E-Mail branding.
+$string['emailbrandingtab'] = 'E-Mail branding';
+$string['templateemailhtmlprefix'] = '';
+$string['templateemailhtmlsuffix'] = '';
+$string['templateemailtextprefix'] = '';
+$string['templateemailtextsuffix'] = '';
+// ... Section: E-Mails introduction.
+$string['emailbrandingintroheading'] = 'Introduction';
+$string['emailbrandingintronote'] = 'Please note: This is an advanced functionality which uses some workarounds to provide E-Mail branding options. Please follow the instructions closely.';
+$string['emailbrandinginstruction'] = 'How-to';
+$string['emailbrandinginstruction0'] = 'With this Boost Union feature, you can apply branding to all E-Mails which Moodle is sending out.';
+$string['emailbrandinginstructionli1'] = 'Go to the <a href="{$a->url}" target="_blank">language customization settings page</a> to open the <em>{$a->lang}</em> language pack for editing.';
+$string['emailbrandinginstructionli2'] = 'Search for and modify these strings in the <code>theme_boost_union language</code> pack:';
+$string['emailbrandinginstructionli2li1'] = '<code>templateemailhtmlprefix</code>: This snippet will be added <em>at the beginning / before the body</em> of all <em>HTML E-Mails</em> which Moodle is sending out.';
+$string['emailbrandinginstructionli2li2'] = '<code>templateemailhtmlsuffix</code>: This snippet will be added <em>at the end / after the body</em> of all <em>HTML E-Mails</em> which Moodle is sending out.';
+$string['emailbrandinginstructionli2li3'] = '<code>templateemailtextprefix</code>: This snippet will be added <em>at the beginning / before the body</em> of all <em>plaintext E-Mails</em> which Moodle is sending out.';
+$string['emailbrandinginstructionli2li4'] = '<code>templateemailtextsuffix</code>: This snippet will be added <em>at the end / after the body</em> of all <em>plaintext E-Mails</em> which Moodle is sending out.';
+$string['emailbrandinginstructionli3'] = 'Save the changes to the language pack.';
+$string['emailbrandinginstructionli4'] = 'Come back to this page and have a look at the E-Mail previews below.';
+$string['emailbrandingpitfalls'] = 'Pitfalls';
+$string['emailbrandingpitfalls0'] = 'Using this feature, there are some pitfalls which you should be aware of:';
+$string['emailbrandingpitfallsli1'] = 'It is mandatory that you modify the language pack strings of the <em>current default language</em> of this site. Even if you have multiple language packs installed, only changes to the default language will have an effect.';
+$string['emailbrandingpitfallsli2'] = 'Respecting the receipient\'s language is not possible. Thus, you should use language-agnostic terms within your E-Mail branding snippets.';
+$string['emailbrandingpitfallsli3'] = 'If you ever change the site\'s default language in the future, you will have to migrate the modified language pack strings to the new default language pack.';
+$string['emailbrandingpitfallsli4'] = 'In plaintext E-Mails, there is a line break and an empty line added automatically after the prefix and an empty line added automatically before the suffix snippet. This is to make sure that the suffix and prefix do not stick directly to the E-Mail body.';
+$string['emailbrandingpitfallsli5'] = 'In HTML E-Mails, the prefix and the suffix are directly added before and above the E-Mail body. This is to make sure that you can work with HTML tags easily, however you will have to handle all spacing around the body yourself.';
+$string['emailbrandingpitfallsli6'] = 'In HTML E-Mails, you can open a HTML tag in the prefix snippet and close the tag in the suffix snippet without problems. Just remember to create valid HTML in the resulting mail.';
+
+// ... Section: HTML E-Mails.
+$string['emailbrandinghtmlheading'] = 'HTML E-Mail preview';
+$string['emailbrandinghtmlintro'] = 'This is a preview of a HTML E-Mail based on the branding prefixes and suffixes which are currently set in the language pack.';
+$string['emailbrandinghtmlnopreview'] = 'Up to now, the HTML E-Mails haven\'t been customized within this feature. E-Mails will be composed and sent out normally.';
+$string['emailbrandinghtmldemobody'] = '<p>E-Mail body starts here.</p><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p><p>Id donec ultrices tincidunt arcu non sodales. Id volutpat lacus laoreet non curabitur gravida arcu.</p><p>Cursus turpis massa tincidunt dui. Pellentesque nec nam aliquam sem et tortor consequat id. In ornare quam viverra orci sagittis eu volutpat. Sem nulla pharetra diam sit amet nisl suscipit. Justo donec enim diam vulputate ut pharetra.</p><p>E-Mail body ends here.</p>';
+// ... Section: Plaintext E-Mails.
+$string['emailbrandingtextheading'] = 'Plaintext E-Mail preview';
+$string['emailbrandingtextintro'] = 'This is a preview of a plaintext E-Mail based on the branding prefixes and suffixes which are currently set in the language pack.';
+$string['emailbrandingtextnopreview'] = 'Up to now, the plaintext E-Mails haven\'t been customized within this feature. E-Mails will be composed and sent out normally.';
+$string['emailbrandingtextdemobody'] = 'E-Mail body starts here.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Id donec ultrices tincidunt arcu non sodales. Id volutpat lacus laoreet non curabitur gravida arcu.
+
+Cursus turpis massa tincidunt dui. Pellentesque nec nam aliquam sem et tortor consequat id. In ornare quam viverra orci sagittis eu volutpat. Sem nulla pharetra diam sit amet nisl suscipit. Justo donec enim diam vulputate ut pharetra.
+
+E-Mail body ends here.';
 // Settings: Resources.
 $string['resourcestab'] = 'Resources';
 $string['resourcescachecontrolnote'] = 'Please note that the files are shipped to the browser with the \'Cache-Control\' header set which tells the browser to cache the file. If you are sure that you won\'t change the file in the near future, you can use the persistent URL to link to the file. However, if you plan to modify a file but keep the same filename every now and then, you should rather use the revisioned URL and re-link the file where you have used it everytime you update the file to avoid that the browsers will show cached outdated versions of the file.';

--- a/locallib.php
+++ b/locallib.php
@@ -789,3 +789,66 @@ function theme_boost_union_register_webfonts_filetypes() {
 
     return true;
 }
+
+/**
+ * Helper function to render a preview of a HTML email to be shown on the theme settings page.
+ *
+ * If E-Mails have been branded, an E-Mail preview will be returned as string.
+ * Otherwise, null will be returned.
+ *
+ * @return string|null
+ */
+function theme_boost_union_get_emailbrandinghtmlpreview() {
+    global $OUTPUT;
+
+    // Get branding snippets.
+    $htmlprefix = get_string('templateemailhtmlprefix', 'theme_boost_union');
+    $htmlsuffix = get_string('templateemailhtmlsuffix', 'theme_boost_union');
+
+    // If no snippet was customized, return null.
+    if (trim($htmlprefix) == '' && trim($htmlsuffix) == '') {
+        return null;
+    }
+
+    // Otherwise, compose mail text.
+    $mailtemplatecontext = array('body' => get_string('emailbrandinghtmldemobody', 'theme_boost_union'));
+    $mail = $OUTPUT->render_from_template('core/email_html', $mailtemplatecontext);
+
+    // And compose mail preview.
+    $previewtemplatecontext = array('mail' => $mail);
+    $preview = $OUTPUT->render_from_template('theme_boost_union/emailpreview', $previewtemplatecontext);
+
+    return $preview;
+}
+
+/**
+ * Helper function to render a preview of a plaintext email to be shown on the theme settings page.
+ *
+ * If E-Mails have been branded, an E-Mail preview will be returned as string.
+ * Otherwise, null will be returned.
+ *
+ * @return string|null
+ */
+function theme_boost_union_get_emailbrandingtextpreview() {
+    global $OUTPUT;
+
+    // Get branding snippets.
+    $textprefix = get_string('templateemailtextprefix', 'theme_boost_union');
+    $textsuffix = get_string('templateemailtextsuffix', 'theme_boost_union');
+
+    // If no snippet was customized, return null.
+    if (trim($textprefix) == '' && trim($textsuffix) == '') {
+        return null;
+    }
+
+    // Otherwise, compose mail text.
+    $mailtemplatecontext = array('body' => get_string('emailbrandingtextdemobody', 'theme_boost_union'));
+    $mail = nl2br($OUTPUT->render_from_template('core/email_text', $mailtemplatecontext));
+    $mail = '<div class="text-monospace">'.$mail.'</div>';
+
+    // And compose mail preview.
+    $previewtemplatecontext = array('mail' => $mail);
+    $preview = $OUTPUT->render_from_template('theme_boost_union/emailpreview', $previewtemplatecontext);
+
+    return $preview;
+}

--- a/settings.php
+++ b/settings.php
@@ -361,6 +361,128 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $page->add($tab);
 
 
+        // Create E_Mail branding tab.
+        $tab = new admin_settingpage('theme_boost_union_look_emailbranding',
+                get_string('emailbrandingtab', 'theme_boost_union', null, true));
+
+        // Create E_Mail branding introduction heading.
+        $name = 'theme_boost_union/emailbrandingintroheading';
+        $title = get_string('emailbrandingintroheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Create E-Mail branding introduction note.
+        $name = 'theme_boost_union/emailbrandingintronote';
+        $title = '';
+        $description = '<div class="alert alert-info" role="alert">'.
+                get_string('emailbrandingintronote', 'theme_boost_union', null, true).'</div>';
+        $setting = new admin_setting_description($name, $title, $description);
+        $tab->add($setting);
+
+        // Create E-Mail branding instruction.
+        $name = 'theme_boost_union/emailbrandinginstruction';
+        $title = '';
+        $description = '<h4>'.get_string('emailbrandinginstruction', 'theme_boost_union', null, true).'</h4>';
+        $description .= '<p>'.get_string('emailbrandinginstruction0', 'theme_boost_union', null, true).'</p>';
+        $emailbrandinginstructionli1url = new moodle_url('/admin/tool/customlang/index.php', array('lng' => $CFG->lang));
+        $description .= '<ul><li>'.get_string('emailbrandinginstructionli1', 'theme_boost_union',
+                array('url' => $emailbrandinginstructionli1url->out(), 'lang' => $CFG->lang), true).'</li>';
+        $description .= '<li>'.get_string('emailbrandinginstructionli2', 'theme_boost_union', null, true).'</li>';
+        $description .= '<ul><li>'.get_string('emailbrandinginstructionli2li1', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandinginstructionli2li2', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandinginstructionli2li3', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandinginstructionli2li4', 'theme_boost_union', null, true).'</li></ul>';
+        $description .= '<li>'.get_string('emailbrandinginstructionli3', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandinginstructionli4', 'theme_boost_union', null, true).'</li></ul>';
+        $description .= '<h4>'.get_string('emailbrandingpitfalls', 'theme_boost_union', null, true).'</h4>';
+        $description .= '<p>'.get_string('emailbrandingpitfalls0', 'theme_boost_union', null, true).'</p>';
+        $description .= '<ul><li>'.get_string('emailbrandingpitfallsli1', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandingpitfallsli2', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandingpitfallsli3', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandingpitfallsli4', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandingpitfallsli5', 'theme_boost_union', null, true).'</li>';
+        $description .= '<li>'.get_string('emailbrandingpitfallsli6', 'theme_boost_union', null, true).'</li></ul>';
+        $setting = new admin_setting_description($name, $title, $description);
+        $tab->add($setting);
+
+        // Create HTML E-Mails heading.
+        $name = 'theme_boost_union/emailbrandinghtmlheading';
+        $title = get_string('emailbrandinghtmlheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Get HTML E-Mail preview.
+        $htmlpreview = theme_boost_union_get_emailbrandinghtmlpreview();
+
+        // If the HTML E-Mails are customized.
+        if ($htmlpreview != null) {
+            // Create HTML E-Mail intro.
+            $name = 'theme_boost_union/emailbrandinghtmlintro';
+            $title = '';
+            $description = '<div class="alert alert-info" role="alert">'.
+                    get_string('emailbrandinghtmlintro', 'theme_boost_union', null, true).'</div>';
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
+
+            // Create HTML E-Mail preview.
+            $name = 'theme_boost_union/emailbrandinghtmlpreview';
+            $title = '';
+            $description = $htmlpreview;
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
+
+            // Otherwise.
+        } else {
+            // Create HTML E-Mail intro.
+            $name = 'theme_boost_union/emailbrandinghtmlnopreview';
+            $title = '';
+            $description = '<div class="alert alert-info" role="alert">'.
+                    get_string('emailbrandinghtmlnopreview', 'theme_boost_union', null, true).'</div>';
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
+        }
+
+        // Create Plaintext E-Mails heading.
+        $name = 'theme_boost_union/emailbrandingtextheading';
+        $title = get_string('emailbrandingtextheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Get Plaintext E-Mail preview.
+        $textpreview = theme_boost_union_get_emailbrandingtextpreview();
+
+        // If the Plaintext E-Mails are customized.
+        if ($textpreview != null) {
+            // Create Plaintext E-Mail intro.
+            $name = 'theme_boost_union/emailbrandingtextintro';
+            $title = '';
+            $description = '<div class="alert alert-info" role="alert">'.
+                    get_string('emailbrandingtextintro', 'theme_boost_union', null, true).'</div>';
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
+
+            // Create Plaintext E-Mail preview.
+            $name = 'theme_boost_union/emailbrandingtextpreview';
+            $title = '';
+            $description = $textpreview;
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
+
+            // Otherwise.
+        } else {
+            // Create Plaintext E-Mail intro.
+            $name = 'theme_boost_union/emailbrandingtextnopreview';
+            $title = '';
+            $description = '<div class="alert alert-info" role="alert">'.
+                    get_string('emailbrandingtextnopreview', 'theme_boost_union', null, true).'</div>';
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
+        }
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
         // Create resources tab.
         $tab = new admin_settingpage('theme_boost_union_look_resources',
                 get_string('resourcestab', 'theme_boost_union', null, true));

--- a/templates/core/email_html.mustache
+++ b/templates/core/email_html.mustache
@@ -1,0 +1,51 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/email_html
+
+    Template for all html emails. Note that it may wrap content formatted
+    elsewhere in another a module template.
+
+    Context variables required for this template:
+    * sitefullname
+    * siteshortname
+    * sitewwwroot
+    * subject
+    * to
+    * toname
+    * touserid
+    * tousername
+    * from
+    * fromname
+    * replyto
+    * replytoname
+    * body
+    * prefix
+
+    Example context (json):
+    {
+        "prefix": "[Prefix Text]",
+        "body": "Email body"
+    }
+}}
+{{!
+    This template overwrites the core/email_html template in the theme
+
+    Modifications compared to this template:
+    * Include mail prefix and suffix
+}}
+{{#str}}templateemailhtmlprefix,theme_boost_union{{/str}}{{{body}}}{{#str}}templateemailhtmlsuffix,theme_boost_union{{/str}}

--- a/templates/core/email_html.mustache.upstream
+++ b/templates/core/email_html.mustache.upstream
@@ -1,0 +1,45 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/email_html
+
+    Template for all html emails. Note that it may wrap content formatted
+    elsewhere in another a module template.
+
+    Context variables required for this template:
+    * sitefullname
+    * siteshortname
+    * sitewwwroot
+    * subject
+    * to
+    * toname
+    * touserid
+    * tousername
+    * from
+    * fromname
+    * replyto
+    * replytoname
+    * body
+    * prefix
+
+    Example context (json):
+    {
+        "prefix": "[Prefix Text]",
+        "body": "Email body"
+    }
+}}
+{{{body}}}

--- a/templates/core/email_text.mustache
+++ b/templates/core/email_text.mustache
@@ -1,0 +1,54 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/email_text
+
+    Template for all html emails. Note that it may wrap content formatted
+    elsewhere in another a module template.
+
+    Context variables required for this template:
+    * sitefullname
+    * siteshortname
+    * sitewwwroot
+    * subject
+    * to
+    * toname
+    * touserid
+    * from
+    * fromname
+    * replyto
+    * replytoname
+    * body
+    * prefix
+
+    Example context (json):
+    {
+        "prefix": "[Prefix Text]",
+        "body": "Email body"
+    }
+}}
+{{!
+    This template overwrites the core/email_text template in the theme
+
+    Modifications compared to this template:
+    * Include mail prefix and suffix
+}}
+{{#str}}templateemailtextprefix,theme_boost_union{{/str}}
+
+{{{body}}}
+
+{{#str}}templateemailtextsuffix,theme_boost_union{{/str}}

--- a/templates/core/email_text.mustache.upstream
+++ b/templates/core/email_text.mustache.upstream
@@ -1,0 +1,44 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/email_text
+
+    Template for all html emails. Note that it may wrap content formatted
+    elsewhere in another a module template.
+
+    Context variables required for this template:
+    * sitefullname
+    * siteshortname
+    * sitewwwroot
+    * subject
+    * to
+    * toname
+    * touserid
+    * from
+    * fromname
+    * replyto
+    * replytoname
+    * body
+    * prefix
+
+    Example context (json):
+    {
+        "prefix": "[Prefix Text]",
+        "body": "Email body"
+    }
+}}
+{{{body}}}

--- a/templates/emailpreview.mustache
+++ b/templates/emailpreview.mustache
@@ -1,0 +1,30 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/emailpreview
+
+    Boost Union template for outputting an email preview.
+
+    Context variables required for this template:
+    * mail - The mail content
+
+    Example context (json):
+    {
+        "mail": "Lorem ipsum"
+    }
+}}
+<div class="shadow p-3 my-5 bg-white rounded">{{{mail}}}</div>

--- a/tests/behat/theme_boost_union_looksettings_emailbranding.feature
+++ b/tests/behat/theme_boost_union_looksettings_emailbranding.feature
@@ -1,0 +1,61 @@
+@theme @theme_boost_union @theme_boost_union_looksettings @theme_boost_union_looksettings_emailbranding
+Feature: Configuring the theme_boost_union plugin for the "E-Mail branding" tab on the "Look" page
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+#  Unfortunately, this can't be tested with Behat yet
+#  See https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues/140 for details
+#  @javascript
+#  Scenario: Setting: HTML E-Mail branding
+#    Given the following "language customisations" exist:
+#      | component         | stringid                | value          |
+#      | theme_boost_union | templateemailhtmlprefix | My HTML prefix |
+#      | theme_boost_union | templateemailhtmlsuffix | My HTML suffix |
+#    When I log in as "admin"
+#    And I navigate to "Appearance > Boost Union > Look" in site administration
+#    And I click on "E-Mail branding" "link"
+#    Then I should not see "Up to now, the HTML E-Mails haven't been customized within this feature"
+#    And I should see "This is a preview of a HTML E-Mail"
+#    And "My HTML prefix" "text" should appear after "HTML E-Mail preview" "text"
+#    And "My HTML suffix" "text" should appear after "HTML E-Mail preview" "text"
+#    And "Plaintext E-Mail preview" "text" should appear after "My HTML prefix" "text"
+#    And "Plaintext E-Mail preview" "text" should appear after "My HTML suffix" "text"
+#    And "My HTML prefix" "text" should appear before "Lorem ipsum dolor sit amet" "text"
+#    And "My HTML suffix" "text" should appear after "Lorem ipsum dolor sit amet" "text"
+
+  @javascript
+  Scenario: Setting: HTML E-Mail branding (countercheck)
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "E-Mail branding" "link"
+    Then I should see "Up to now, the HTML E-Mails haven't been customized within this feature"
+    And I should not see "This is a preview of a HTML E-Mail"
+
+#  Unfortunately, this can't be tested with Behat yet
+#  See https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues/140 for details
+#  @javascript
+#  Scenario: Setting: Plaintext E-Mail branding
+#    Given the following "language customisations" exist:
+#      | component         | stringid                | value               |
+#      | theme_boost_union | templateemailtextprefix | My plaintext prefix |
+#      | theme_boost_union | templateemailtextsuffix | My plaintext suffix |
+#    When I log in as "admin"
+#    And I navigate to "Appearance > Boost Union > Look" in site administration
+#    And I click on "E-Mail branding" "link"
+#    Then I should not see "Up to now, the plaintext E-Mails haven't been customized within this feature"
+#    And I should see "This is a preview of a plaintext E-Mail"
+#    And "My plaintext prefix" "text" should appear after "Plaintext E-Mail preview" "text"
+#    And "My plaintext suffix" "text" should appear after "Plaintext E-Mail preview" "text"
+#    And "HTML E-Mail preview" "text" should appear before "My HTML prefix" "text"
+#    And "HTML E-Mail preview" "text" should appear before "My HTML suffix" "text"
+#    And "My plaintext prefix" "text" should appear before "Lorem ipsum dolor sit amet" "text"
+#    And "My plaintext suffix" "text" should appear after "Lorem ipsum dolor sit amet" "text"
+
+  @javascript
+  Scenario: Setting: Plaintext E-Mail branding (countercheck)
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "E-Mail branding" "link"
+    Then I should see "Up to now, the plaintext E-Mails haven't been customized within this feature"
+    And I should not see "This is a preview of a plaintext E-Mail"

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2022080911;
+$plugin->version = 2022080912;
 $plugin->release = 'v4.0-r7';
 $plugin->requires = 2022041900;
 $plugin->supported = [400, 400];


### PR DESCRIPTION
As announced in #60, I have implemented a workaround solution to at least override the email templates within Boost Union.

This patch introduces a new settings tab with a step-by-step explanation what to do:
![Bildschirmfoto 2022-11-08 um 14 40 06](https://user-images.githubusercontent.com/1092118/200580029-ead78555-ddef-4d31-bdfc-0730a11cffe1.png)

As soon as you have customized your language pack, you will see previews of the branded emails:
![Bildschirmfoto 2022-11-08 um 14 40 18](https://user-images.githubusercontent.com/1092118/200580181-0a436861-4a7b-4555-808e-69b681567f70.png)
![Bildschirmfoto 2022-11-08 um 14 40 27](https://user-images.githubusercontent.com/1092118/200580260-1432d15f-ee89-48a1-9387-be53a7a34e7b.png)

Unfortunately, the Behat tests are still failing and I don't know why yet. It seems as if the theme's language pack strings are not registered in the language pack customization.

Maybe @lucaboesch has an idea.