### PR TITLE
Feature: Possibility to upload FA 6 Free to the theme, solves #59

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-11-15 - Feature: Possibility to upload FontAwesome 6 Free to the theme, solves #59.
 * 2022-11-08 - Feature: Allow admins to override the email templates within the theme, solves #60.
 
 ### v4.0-r7

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ With this setting you can upload additional resources to the theme. The advantag
 
 With this setting you can upload custom fonts to the theme. The advantage of uploading fonts to this file area is that those fonts can be delivered without a check if the user is logged in and can be used as locally installed fonts everywhere on the site. As soon as you have uploaded at least one font to this filearea and have stored the settings, a list will appear underneath which will give you CSS code snippets which you can use as a boilerplate to reference particular fonts in your custom SCSS.
 
+##### FontAwesome
+
+Moodle core ships with FontAwesome 4 icons which are fine, but FontAwesome has evolved since then. If you want to use more recent FontAwesome icons, you can do this with this setting. As soon as you choose another version than FontAwesome 4, additional settings will appear where you can upload more recent FontAwesome versions.
+
 ### Settings page "Feel"
 
 #### Tab "Navigation"

--- a/classes/admin_setting_configstoredfilealwayscallback.php
+++ b/classes/admin_setting_configstoredfilealwayscallback.php
@@ -1,0 +1,74 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - Settings class file
+ *
+ * @package    theme_boost_union
+ * @copyright  2022 Moodle an Hochschulen e.V. <kontakt@moodle-an-hochschulen.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace theme_boost_union;
+
+/**
+ * Admin setting class which circumvents MDL-59082.
+ *
+ * @package    theme_boost_union
+ * @copyright  2022 Moodle an Hochschulen e.V. <kontakt@moodle-an-hochschulen.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class admin_setting_configstoredfilealwayscallback extends \admin_setting_configstoredfile {
+
+    // This class is basically a admin_setting_configstoredfile class but which circumvents MDL-59082
+    // and triggers the updatecallback everytime the setting is saved regardless if any values have changed.
+    // As soon as MDL-59082 is fixed in Moodle core, this class could be removed again.
+    // (Note to myself: This comment should be the class description,
+    // but local_moodlecheck only allows one-line class descriptions).
+
+    /**
+     * Execute postupdatecallback.
+     * @param mixed $original original value before write_setting()
+     * @return bool true if changed, false if not.
+     */
+    public function post_write_settings($original) {
+        // To circument MDL-59082, we have to make sure that in this function, the updatedcallback is
+        // called in any case.
+        //
+        // This could be done by duplicating the code from the parent function and changing the
+        // conditions under which the updatedcallback is called. However, we would have to keep the
+        // duplicated code up to date.
+        //
+        // Alternatively, we could just call the updatedcallback here directly and then call the parent
+        // function. This would come with the downside that the updatedcallback is called twice if the first
+        // file in the filearea has changed (see MDL-59082 for details why this is happening like this).
+        //
+        // As this is a function just to be used in theme_boost_union for now, we accept this downside
+        // and avoid managing duplicated code.
+
+        // Call updatedcallback.
+        $callbackfunction = $this->updatedcallback;
+        if (!empty($callbackfunction) && function_exists($callbackfunction)) {
+            $callbackfunction($this->get_full_name());
+        }
+
+        // Call parent function.
+        parent::post_write_settings($original);
+
+        // Return.
+        return true;
+    }
+}

--- a/db/caches.php
+++ b/db/caches.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Theme Boost Union - Version file
+ * Theme Boost Union - Cache definitions.
  *
  * @package    theme_boost_union
  * @copyright  2022 Moodle an Hochschulen e.V. <kontakt@moodle-an-hochschulen.de>
@@ -24,10 +24,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'theme_boost_union';
-$plugin->version = 2022080913;
-$plugin->release = 'v4.0-r7';
-$plugin->requires = 2022041900;
-$plugin->supported = [400, 400];
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = array('theme_boost' => 2022041900);
+$definitions = array(
+        'fontawesome' => array(
+                'mode' => cache_store::MODE_APPLICATION,
+                'simplekeys' => true,
+                'simpledata' => true,
+                'staticacceleration' => true,
+        )
+);

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -173,6 +173,49 @@ $string['customfontslistsetting'] = 'Custom fonts list';
 $string['customfontslistsetting_desc'] = 'This is the list of fonts which you have uploaded to the custom fonts filearea. The given CSS snippets can be used to add these fonts to your custom SCSS. Please note that you will have to take care of the font format value as well as the font-family, font-style and font-weight CSS properties yourself for now as Boost Union is not able yet to parse the font files.';
 $string['customfontsfileurlpersistent'] = 'URL (persistent)';
 $string['customfontsfileurlrevisioned'] = 'URL (revisioned)';
+// ... Section: FontAwesome.
+$string['fontawesomeheading'] = 'FontAwesome';
+// ... ... Setting: FontAwesome version.
+$string['fontawesomeversionsetting'] = 'FontAwesome version';
+$string['fontawesomeversionsetting_desc'] = 'Moodle core ships with FontAwesome 4 icons which are fine, but FontAwesome has evolved since then. If you want to use more recent FontAwesome icons, you can do this with this setting. As soon as you choose another version than FontAwesome 4, additional settings will appear where you can upload more recent FontAwesome versions.';
+$string['fontawesomeversionnone'] = 'Keep FontAwesome 4 (as shipped with Moodle core)';
+$string['fontawesomeversionfa6free'] = 'Update to FontAwesome 6 Free';
+// ... ... Setting: FontAwesome files.
+$string['fontawesomefilessetting'] = 'FontAwesome files';
+$string['fontawesomefilessetting_desc'] = 'With this setting you can upload more recent FontAwesome files to Moodle. You have to upload the FontAwesome files to Moodle yourself due to licensing constraints. Just head over to <a href="https://fontawesome.com">fontawesome.com</a>, download the FontAwesome package and upload the files here.';
+$string['fontawesomefilesstructurenote'] = 'Please note that the files must be uploaded with the correct folder structure and with the correct file names. Please start by creating a <em>css</em> and a <em>webfonts</em> folder in the filepicker, upload the <em>fa-solid-900.woff2</em> file into the <em>webfonts</em> folder and save the settings page. As soon as you have done this, a file list will appear below which helps you to identify and upload the right files into these folders.';
+// ... ... Information: FontAwesome files list.
+$string['fontawesomelistsetting'] = 'FontAwesome files list';
+$string['fontawesomelistsetting_desc'] = 'This is the list of FontAwesome files which you have uploaded to the FontAwesome files filearea above. All FontAwesome files which are valid for the configured FontAwesome version are listed here, other files which you may have uploaded as well but which are not valid or needed FontAwesome files are ignored. The FontAwesome files are automatically added to the Moodle pages and have a direct effect as soon as you save this setting.';
+$string['fontawesomelistnote'] = 'Please note that, if you upload only a fraction of the mandatory files, the FontAwesome icons can appear as broken on the Moodle page. This cannot be fixed until you upload all mandatory files or remove all files again.';
+$string['fontawesomelistfileinfo-fa6free-css-fontawesome.min.css'] = 'This is the main CSS file which adds all available FontAwesome glyphs to the Moodle page.';
+$string['fontawesomelistfileinfo-fa6free-css-brands.min.css'] = 'This is an additional CSS file which adds the font for FontAwesome brand icons to the Moodle page.';
+$string['fontawesomelistfileinfo-fa6free-css-regular.min.css'] = 'This is an additional CSS file which adds the font for FontAwesome regular icons to the Moodle page.';
+$string['fontawesomelistfileinfo-fa6free-css-solid.min.css'] = 'This is an additional CSS file which adds the font for FontAwesome solid icons to the Moodle page.';
+$string['fontawesomelistfileinfo-fa6free-css-v4-font-face.min.css'] = 'This is the CSS file which makes sure that the FontAwesome 4 icons in Moodle are still displayed correctly.';
+$string['fontawesomelistfileinfo-fa6free-webfonts-fa-brands-400.woff2'] = 'This is the font file for FontAwesome brand icons (in the WOFF2 format).';
+$string['fontawesomelistfileinfo-fa6free-webfonts-fa-brands-400.ttf'] = 'This is the font file for FontAwesome brand icons (in the TTF format).';
+$string['fontawesomelistfileinfo-fa6free-webfonts-fa-regular-400.woff2'] = 'This is the font file for FontAwesome regular icons (in the WOFF2 format).';
+$string['fontawesomelistfileinfo-fa6free-webfonts-fa-regular-400.ttf'] = 'This is the font file for FontAwesome regular icons (in the TTF format).';
+$string['fontawesomelistfileinfo-fa6free-webfonts-fa-solid-900.woff2'] = 'This is the font file for FontAwesome solid icons (in the WOFF2 format).';
+$string['fontawesomelistfileinfo-fa6free-webfonts-fa-solid-900.ttf'] = 'This is the font file for FontAwesome solid icons (in the TTF format).';
+$string['fontawesomelistfileinfo-fa6free-webfonts-fa-v4compatibility.woff2'] = 'This is the font file for the FontAwesome v4 compatibility (in the WOFF2 format).';
+$string['fontawesomelistfileinfo-fa6free-webfonts-fa-v4compatibility.ttf'] = 'This is the font file for the FontAwesome v4 compatibility (in the TTF format).';
+$string['fontawesomelistmandatoryuploaded'] = 'It is a mandatory file for FontAwesome to work and it was uploaded properly.';
+$string['fontawesomelistoptionaluploaded'] = 'It is an optional file to enhance the FontAwesome iconset and it was uploaded properly.';
+$string['fontawesomelistmandatorymissing'] = 'It is a mandatory file for FontAwesome to work, but it was not uploaded properly. Please try to upload it properly.';
+$string['fontawesomelistoptionalmissing'] = 'It is an optional file to enhance the FontAwesome iconset, but it was not uploaded. This fine as long as you don\'t need it.';
+// ... ... Information: FontAwesome checks.
+$string['fontawesomecheckssetting'] = 'FontAwesome checks';
+$string['fontawesomecheckssetting_desc'] = 'Here, you can verify visually if the FontAwesome files have been uploaded and added to the Moodle page properly. If one of the checks fail, please double-check if you have uploaded all mandatory files correctly.';
+$string['fontawesomecheck-fa6free-general-title'] = 'General functionality';
+$string['fontawesomecheck-fa6free-general-description'] = 'If you see a checkmark icon on the left hand side, FontAwesome is generally working in your site.';
+$string['fontawesomecheck-fa6free-fallback-title'] = 'FontAwesome 4 fallback';
+$string['fontawesomecheck-fa6free-fallback-description'] = 'Newer FontAwesome versions use to remap older icon identifiers to newer ones or even get rid of some icons. If you see a solid map icon on the left hand side, your FontAwesome 6 version is properly showing remapped icons from FontAwesome 4.';
+$string['fontawesomecheck-fa6free-newstuff-title'] = 'FontAwesome 6 icons';
+$string['fontawesomecheck-fa6free-newstuff-description'] = 'Newer FontAwesome versions ship with additional icons compared to the FontAwesome 4 iconset. If you see a virus icon on the left hand side, your FontAwesome 6 version is properly showing new icons which are new in FontAwesome 6.';
+$string['fontawesomecheck-fa6free-filter-title'] = 'FontAwesome filter';
+$string['fontawesomecheck-fa6free-filter-description'] = 'As you have the FontAwesome filter plugin installed, you should be sure that the filter handles the new FontAwesome 6 icons correctly as well. If you see a users icon on the left hand side, the filter is working properly with the FontAwesome 6 version icons.';
 
 // Settings: Feel page.
 $string['configtitlefeel'] = 'Feel';
@@ -324,3 +367,6 @@ $string['privacy:metadata'] = 'The Boost Union theme does not store any personal
 $string['boost_union:configure'] = 'To be able to configure the theme as non-admin';
 $string['boost_union:viewhintcourseselfenrol'] = 'To be able to see a hint for unrestricted self enrolment in a visible course.';
 $string['boost_union:viewhintinhiddencourse'] = 'To be able to see a hint in a hidden course.';
+
+// Caches.
+$string['cachedef_fontawesome'] = 'FontAwesome files (which are uploaded in the Boost Union settings)';

--- a/lib.php
+++ b/lib.php
@@ -40,6 +40,11 @@ define('THEME_BOOST_UNION_SETTING_INFOBANNERPAGES_LOGIN', 'login');
 define('THEME_BOOST_UNION_SETTING_INFOBANNERMODE_PERPETUAL', 'perp');
 define('THEME_BOOST_UNION_SETTING_INFOBANNERMODE_TIMEBASED', 'time');
 
+define('THEME_BOOST_UNION_SETTING_FAVERSION_NONE', 'none');
+define('THEME_BOOST_UNION_SETTING_FAVERSION_FA6FREE', 'fa6free');
+define('THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY', 'm');
+define('THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL', 'o');
+
 
 /**
  * Returns the main SCSS content.
@@ -233,7 +238,7 @@ function theme_boost_union_get_precompiled_css() {
 function theme_boost_union_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array()) {
     if ($context->contextlevel == CONTEXT_SYSTEM && ($filearea === 'logo' || $filearea === 'backgroundimage' ||
         $filearea === 'loginbackgroundimage' || $filearea === 'favicon' || $filearea === 'additionalresources' ||
-                $filearea === 'customfonts')) {
+                $filearea === 'customfonts' || $filearea === 'fontawesome')) {
         $theme = theme_config::load('boost_union');
         // By default, theme files must be cache-able by both browsers and proxies.
         if (!array_key_exists('cacheability', $options)) {
@@ -243,4 +248,27 @@ function theme_boost_union_pluginfile($course, $cm, $context, $filearea, $args, 
     } else {
         send_file_not_found();
     }
+}
+
+/**
+ * Callback to add head elements.
+ *
+ * We use this callback to inject the FontAwesome CSS code to the page.
+ *
+ * @return string
+ */
+function theme_boost_union_before_standard_html_head() {
+    global $CFG;
+
+    // Require local library.
+    require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
+
+    // Initialize HTML (even though we do not add any HTML at this stage of the implementation).
+    $html = '';
+
+    // Add the FontAwesome icons to the page.
+    theme_boost_union_add_fontawesome_to_page();
+
+    // Return an empty string to keep the caller happy.
+    return $html;
 }

--- a/locallib.php
+++ b/locallib.php
@@ -852,3 +852,273 @@ function theme_boost_union_get_emailbrandingtextpreview() {
 
     return $preview;
 }
+
+/**
+ * Callback function which is called from settings.php if the FontAwesome files setting has changed.
+ *
+ * It gets all files from the files setting, picks all the expected files (and ignores all others)
+ * and stores them into an application cache for quicker access.
+ *
+ * @return void
+ */
+function theme_boost_union_fontawesome_checkin() {
+    // Create cache for FontAwesome files.
+    $cache = cache::make('theme_boost_union', 'fontawesome');
+
+    // Purge the existing cache values as we will refill the cache now.
+    $cache->purge();
+
+    // Get FontAwesome version config.
+    $faconfig = get_config('theme_boost_union', 'fontawesomeversion');
+
+    // If a FontAwesome version is enabled.
+    if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null) {
+
+        // Get the system context.
+        $systemcontext = \context_system::instance();
+
+        // Get filearea.
+        $fs = get_file_storage();
+
+        // Get FontAwesome file structure.
+        $filestructure = theme_boost_union_get_fontawesome_filestructure($faconfig);
+
+        // If a valid file structure could be retrieved.
+        if ($filestructure != null) {
+
+            // Iterate over the folder structure.
+            foreach ($filestructure as $folder => $files) {
+
+                // Initialize a folder list.
+                $folderlist = array();
+
+                // Iterate over the files in the folder.
+                foreach ($files as $file => $expected) {
+
+                    // Try to get the file from the filearea.
+                    $fsfile = $fs->get_file($systemcontext->id, 'theme_boost_union', 'fontawesome', 0, '/'.$folder.'/', $file);
+
+                    // If the file exists.
+                    if ($fsfile != false) {
+                        // Add the file to the folder list.
+                        $folderlist[] = $file;
+                    }
+                }
+
+                // Add the folder to the cache.
+                $cache->set($folder, $folderlist);
+            }
+        }
+    }
+
+    // Add a marker value to the cache which indicates that the files have been checked into the cache completely.
+    // This will help to decide later if the cache is really empty (and should be refilled) or if there aren't just any
+    // files uploaded.
+    $cache->set('checkedin', true);
+}
+
+/**
+ * Helper function which returns an array of accepted fontawesome file extensions (including the dots).
+ *
+ * @return array
+ */
+function theme_boost_union_get_fontawesome_extensions() {
+    return array('.css', '.eot', '.svg', '.ttf', '.woff', '.woff2');
+}
+
+/**
+ * Helper function which returns the files which are expected to be provided for a given FontAwesome version.
+ *
+ * @param string $version The FontAwesome version, given as THEME_BOOST_UNION_SETTING_FAVERSION_* constant.
+ *
+ * @return array|null The array of files or null if an invalid FontAwesome version was provided.
+ */
+function theme_boost_union_get_fontawesome_filestructure($version) {
+    // Pick the files for the selected FA version.
+    switch ($version) {
+        case THEME_BOOST_UNION_SETTING_FAVERSION_FA6FREE:
+            $files = array('css' => array('fontawesome.min.css' => THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY,
+                            'solid.min.css' => THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY,
+                            'regular.min.css' => THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL,
+                            'brands.min.css' => THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL,
+                            'v4-font-face.min.css' => THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY),
+                    'webfonts' => array('fa-solid-900.woff2' => THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY,
+                            'fa-solid-900.ttf' => THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY,
+                            'fa-regular-400.woff2' => THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL,
+                            'fa-regular-400.ttf' => THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL,
+                            'fa-brands-400.woff2' => THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL,
+                            'fa-brands-400.ttf' => THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL,
+                            'fa-v4compatibility.woff2' => THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY,
+                            'fa-v4compatibility.ttf' => THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY));
+            break;
+        default:
+            // This only happens if an invalid version was provided.
+            $files = null;
+    }
+
+    // Return the file structure.
+    return $files;
+}
+
+/**
+ * Helper function which return the files from the fontawesome file area as templatecontext structure.
+ * It was designed to compose the files for the settings-fontawesome-filelist.mustache template.
+ * This function uses the fontawesome cache definition, i.e. it does not load the files from the filearea directly.
+ * This means it uses the same data source as the theme_boost_union_add_fontawesome_to_page() function which adds
+ * the fontawesome files to the page.
+ *
+ * @return array|null
+ * @throws coding_exception
+ * @throws dml_exception
+ */
+function theme_boost_union_get_fontawesome_templatecontext() {
+    // Create cache for FontAwesome files.
+    $cache = cache::make('theme_boost_union', 'fontawesome');
+
+    // If the cache is completely empty, check the files in on-the-fly.
+    if ($cache->get('checkedin') != true) {
+        theme_boost_union_fontawesome_checkin();
+    }
+
+    // Get FontAwesome version config.
+    $faconfig = get_config('theme_boost_union', 'fontawesomeversion');
+
+    // If a FontAwesome version is enabled.
+    if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null) {
+
+        // Initialize context variable.
+        $filesforcontext = array();
+
+        // Get FontAwesome file structure.
+        $filestructure = theme_boost_union_get_fontawesome_filestructure($faconfig);
+
+        // If a valid file structure could be retrieved.
+        if ($filestructure != null) {
+
+            // Iterate over the folder structure.
+            foreach ($filestructure as $folder => $files) {
+
+                // Get the cached data for this folder.
+                $cachedfolder = $cache->get($folder);
+
+                // Iterate over the files in the folder structure.
+                foreach ($files as $file => $expected) {
+
+                    // Deduce the mandatory value.
+                    if ($expected == THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY) {
+                        $mandatory = true;
+                    } else {
+                        $mandatory = false;
+                    }
+
+                    // Compose the file path.
+                    $filepath = $folder . '/' . $file;
+
+                    // Get the description of the file.
+                    $fileidentifier = str_replace('/', '-', $filepath);
+                    $description = get_string('fontawesomelistfileinfo-' . $faconfig . '-' . $fileidentifier, 'theme_boost_union');
+
+                    // If the folder was not uploaded at all or if the folder is empty, we do not need to check if the file exists.
+                    // We can add the file as non-existent right away.
+                    if ($cachedfolder == null || ($cachedfolder == array()) && count($cachedfolder) < 1) {
+                        $exists = false;
+
+                        // Otherwise, we have to check the file it was uploaded.
+                    } else {
+                        $exists = in_array($file, $cachedfolder);
+                    }
+
+                    // Add the file to the template structure.
+                    $filesforcontext[] = array('filepath' => $filepath, 'exists' => $exists, 'mandatory' => $mandatory,
+                            'description' => $description);
+                }
+            }
+        }
+    }
+
+    return $filesforcontext;
+}
+
+/**
+ * Helper function which returns the visual checks for the configured FontAwesome version.
+ *
+ * @return array|null The array of checks or null if an invalid FontAwesome version is configured.
+ */
+function theme_boost_union_get_fontawesome_checks_templatecontext() {
+    global $CFG;
+
+    // Get FontAwesome version config.
+    $version = get_config('theme_boost_union', 'fontawesomeversion');
+
+    // Pick the checks for the selected FA version.
+    switch ($version) {
+        case THEME_BOOST_UNION_SETTING_FAVERSION_FA6FREE:
+            $checks = array(
+                    array('icon' => '<i class="fa fa-check-circle-o fa-3x fa-fw"></i>',
+                            'title' => get_string('fontawesomecheck-fa6free-general-title', 'theme_boost_union'),
+                            'description' => get_string('fontawesomecheck-fa6free-general-description', 'theme_boost_union')),
+                    array('icon' => '<i class="fa fa-map-o fa-3x fa-fw"></i>',
+                            'title' => get_string('fontawesomecheck-fa6free-fallback-title', 'theme_boost_union'),
+                            'description' => get_string('fontawesomecheck-fa6free-fallback-description', 'theme_boost_union')),
+                    array('icon' => '<i class="fa-solid fa-virus-covid fa-3x fa-fw"></i>',
+                            'title' => get_string('fontawesomecheck-fa6free-newstuff-title', 'theme_boost_union'),
+                            'description' => get_string('fontawesomecheck-fa6free-newstuff-description', 'theme_boost_union')),
+            );
+            break;
+        default:
+            // This only happens if an invalid version was provided.
+            $checks = null;
+    }
+
+    // If the filter_fontawesome plugin is installed, add a check for filtering the icons.
+    if (file_exists($CFG->dirroot.'/filter/fontawesome/version.php')) {
+        $checks[] = array('icon' => format_text('[fa-solid fa-users-line fa-3x fa-fw]'),
+                'title' => get_string('fontawesomecheck-fa6free-filter-title', 'theme_boost_union'),
+                'description' => get_string('fontawesomecheck-fa6free-filter-description', 'theme_boost_union'));
+    }
+
+    // Return the checks structure.
+    return $checks;
+}
+
+/**
+ * Helper function which adds the CSS files from the fontawesome file area to the Moodle page.
+ * This function uses the fontawesome cache definition, i.e. it does not load the files from the filearea directly.
+ * It's meant to be called by theme_boost_union_before_standard_html_head() only.
+ * *
+ * @throws coding_exception
+ * @throws dml_exception
+ * @throws moodle_exception
+ */
+function theme_boost_union_add_fontawesome_to_page() {
+    global $PAGE;
+
+    // Create cache for FontAwesome files.
+    $cache = cache::make('theme_boost_union', 'fontawesome');
+
+    // If the cache is completely empty, check the files in on-the-fly.
+    if ($cache->get('checkedin') != true) {
+        theme_boost_union_fontawesome_checkin();
+    }
+
+    // Get FontAwesome version config.
+    $faconfig = get_config('theme_boost_union', 'fontawesomeversion');
+
+    // If a FontAwesome version is enabled.
+    if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null) {
+
+        // Get the cached data for the CSS folder (we do not need to add files from any other folders in the cache).
+        $cachedfolder = $cache->get('css');
+
+        // Iterate over the files in the cached folder structure.
+        foreach ($cachedfolder as $cachedfile) {
+
+            // Build the FontAwesome CSS file URL.
+            $facssurl = new moodle_url('/pluginfile.php/1/theme_boost_union/fontawesome/' .
+                    theme_get_revision().'/css/'.$cachedfile);
+
+            // Add the CSS file to the page.
+            $PAGE->requires->css($facssurl);
+        }
+    }
+}

--- a/settings.php
+++ b/settings.php
@@ -23,6 +23,7 @@
  */
 
 use \theme_boost_union\admin_setting_configdatetime;
+use \theme_boost_union\admin_setting_configstoredfilealwayscallback;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -527,9 +528,9 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $setting = new admin_setting_heading($name, $title, null);
         $tab->add($setting);
 
-        // Register the webfonts file types for filtering the uploads in the subsequent admin setting.
+        // Register the webfonts file types for filtering the uploads in the subsequent admin settings.
         // This function call may return false. In this case, the filetypes were not registered and we
-        // can't restrict the filetypes in the subsequent admin setting unfortunately.
+        // can't restrict the filetypes in the subsequent admin settings unfortunately.
         $registerfontsresult = theme_boost_union_register_webfonts_filetypes();
 
         // Setting: Custom fonts.
@@ -561,6 +562,89 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
             $setting = new admin_setting_description($name, $title, $description);
             $tab->add($setting);
 
+        }
+
+        // Create FontAwesome heading.
+        $name = 'theme_boost_union/fontawesomeheading';
+        $title = get_string('fontawesomeheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: FontAwesome version.
+        $faversionoption =
+                // Don't use string lazy loading (= false) because the string will be directly used and would produce a
+                // PHP warning otherwise.
+                array(THEME_BOOST_UNION_SETTING_FAVERSION_NONE =>
+                        get_string('fontawesomeversionnone', 'theme_boost_union', null, false),
+                        THEME_BOOST_UNION_SETTING_FAVERSION_FA6FREE =>
+                                get_string('fontawesomeversionfa6free', 'theme_boost_union', null, false));
+        $name = 'theme_boost_union/fontawesomeversion';
+        $title = get_string('fontawesomeversionsetting', 'theme_boost_union', null, true);
+        $description = get_string('fontawesomeversionsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_FAVERSION_NONE,
+                $faversionoption);
+        $setting->set_updatedcallback('theme_boost_union_fontawesome_checkin');
+        $tab->add($setting);
+
+        // Setting: FontAwesome files.
+        $name = 'theme_boost_union/fontawesomefiles';
+        $title = get_string('fontawesomefilessetting', 'theme_boost_union', null, true);
+        $description = get_string('fontawesomefilessetting_desc', 'theme_boost_union', null, true).'<br /><br />'.
+                get_string('fontawesomefilesstructurenote', 'theme_boost_union', null, true);
+        if ($registerfontsresult == true) {
+            // Use our enhanced implementation of admin_setting_configstoredfile to circumvent MDL-59082.
+            // This can be changed back to admin_setting_configstoredfile as soon as MDL-59082 is fixed.
+            $setting = new admin_setting_configstoredfilealwayscallback($name, $title, $description, 'fontawesome', 0,
+                    array('maxfiles' => -1, 'subdirs' => 1, 'accepted_types' => theme_boost_union_get_fontawesome_extensions()));
+        } else {
+            // Use our enhanced implementation of admin_setting_configstoredfile to circumvent MDL-59082.
+            // This can be changed back to admin_setting_configstoredfile as soon as MDL-59082 is fixed.
+            $setting = new admin_setting_configstoredfilealwayscallback($name, $title, $description, 'fontawesome', 0,
+                    array('maxfiles' => -1));
+        }
+        $setting->set_updatedcallback('theme_boost_union_fontawesome_checkin');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/fontawesomefiles', 'theme_boost_union/fontawesomeversion', 'eq',
+                THEME_BOOST_UNION_SETTING_FAVERSION_NONE);
+
+        // Information: FontAwesome list.
+        $faconfig = get_config('theme_boost_union', 'fontawesomeversion');
+        // If there is at least one file uploaded and if a FontAwesome version is enabled (unfortunately, hide_if does not
+        // work for admin_setting_description up to now, that's why we have to use this workaround).
+        if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null &&
+                !empty(get_config('theme_boost_union', 'fontawesomefiles'))) {
+            // Prepare the widget.
+            $name = 'theme_boost_union/fontawesomelist';
+            $title = get_string('fontawesomelistsetting', 'theme_boost_union', null, true);
+            $description = get_string('fontawesomelistsetting_desc', 'theme_boost_union', null, true).'<br /><br />'.
+                    get_string('fontawesomelistnote', 'theme_boost_union', null, true);
+
+            // Append the file list to the description.
+            $templatecontext = array('files' => theme_boost_union_get_fontawesome_templatecontext());
+            $description .= $OUTPUT->render_from_template('theme_boost_union/settings-fontawesome-filelist', $templatecontext);
+
+            // Finish the widget.
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
+        }
+
+        // Information: FontAwesome checks.
+        // If there is at least one file uploaded and if a FontAwesome version is enabled (unfortunately, hide_if does not
+        // work for admin_setting_description up to now, that's why we have to use this workaround).
+        if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null &&
+                !empty(get_config('theme_boost_union', 'fontawesomefiles'))) {
+            // Prepare the widget.
+            $name = 'theme_boost_union/fontawesomechecks';
+            $title = get_string('fontawesomecheckssetting', 'theme_boost_union', null, true);
+            $description = get_string('fontawesomecheckssetting_desc', 'theme_boost_union', null, true);
+
+            // Append the checks to the description.
+            $templatecontext = array('checks' => theme_boost_union_get_fontawesome_checks_templatecontext());
+            $description .= $OUTPUT->render_from_template('theme_boost_union/settings-fontawesome-checks', $templatecontext);
+
+            // Finish the widget.
+            $setting = new admin_setting_description($name, $title, $description);
+            $tab->add($setting);
         }
 
         // Add tab to settings page.

--- a/templates/settings-fontawesome-checks.mustache
+++ b/templates/settings-fontawesome-checks.mustache
@@ -1,0 +1,49 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/settings-fontawesome-checks
+
+    Boost Union settingsfilelist layout template.
+
+    Context variables required for this template:
+    * checks - Array of checks
+
+    Example context (json):
+    {
+        "checks": [
+            {
+                "icon": "fa fa-check-circle-o fa-3x",
+                "title": "General functionality",
+                "description": "If you see a checkmark icon on the left hand side, FontAwesome is generally working in your site."
+            }
+        ]
+    }
+}}
+
+<ul class="list-group my-3 settings-fontawesome-checks">
+    {{#checks}}
+        <li class="list-group-item d-flex justify-content-between">
+            <div class="d-flex flex-row">
+                {{{icon}}}
+                <div class="ml-3">
+                    <h6 class="mb-0">{{title}}</h6>
+                    <small>{{description}}</small>
+                </div>
+            </div>
+        </li>
+    {{/checks}}
+</ul>

--- a/templates/settings-fontawesome-filelist.mustache
+++ b/templates/settings-fontawesome-filelist.mustache
@@ -1,0 +1,65 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/settings-fontawesome-filelist
+
+    Boost Union settingsfilelist layout template.
+
+    Context variables required for this template:
+    * files - Array of files
+
+    Example context (json):
+    {
+        "files": [
+            {
+                "exists": true,
+                "mandatory": true,
+                "filepath": "css/fontawesome.min",
+                "description": "This is the main CSS file which adds all available FontAwesome glyphs to the Moodle page."
+            },
+            {
+                "exists": false,
+                "mandatory": true,
+                "filepath": "webfonts/fa-solid-900",
+                "description": "This is the font file for FontAwesome solid icons (in the WOFF2 format)."
+            },
+            {
+                "exists": false,
+                "mandatory": false,
+                "filepath": "webfonts/fa-brands-400",
+                "description": "This is the font file for FontAwesome brand icons (in the WOFF2 format)."
+            }
+        ]
+    }
+}}
+
+<ul class="list-group my-3 settings-fontawesome-filelist">
+    {{#files}}
+        <li class="list-group-item d-flex justify-content-between">
+            <div class="d-flex flex-row">
+                {{#exists}}<span class="{{#mandatory}}text-success{{/mandatory}}{{^mandatory}}text-success{{/mandatory}}"><i class="fa fa-check-circle-o fa-3x fa-fw"></i></span>{{/exists}}
+                {{^exists}}<span class="{{#mandatory}}text-danger{{/mandatory}}{{^mandatory}}text-muted{{/mandatory}}"><i class="fa fa-times-circle-o fa-3x fa-fw"></i></span>{{/exists}}
+                <div class="ml-3">
+                    <h6 class="mb-0">{{filepath}}</h6>
+                    <small>{{description}}</small><br />
+                    {{#exists}}<small>{{#mandatory}}{{#str}}fontawesomelistmandatoryuploaded,theme_boost_union{{/str}}{{/mandatory}}{{^mandatory}}{{#str}}fontawesomelistoptionaluploaded,theme_boost_union{{/str}}{{/mandatory}}</small>{{/exists}}
+                    {{^exists}}<small>{{#mandatory}}{{#str}}fontawesomelistmandatorymissing,theme_boost_union{{/str}}{{/mandatory}}{{^mandatory}}{{#str}}fontawesomelistoptionalmissing,theme_boost_union{{/str}}{{/mandatory}}</small>{{/exists}}
+                </div>
+            </div>
+        </li>
+    {{/files}}
+</ul>

--- a/tests/behat/theme_boost_union_looksettings_resources.feature
+++ b/tests/behat/theme_boost_union_looksettings_resources.feature
@@ -54,3 +54,17 @@ Feature: Configuring the theme_boost_union plugin for the "Resources" tab on the
     And I click on "Resources" "link"
     Then I should not see "Custom fonts list"
     And ".settings-customfonts-filelist" "css_element" should not exist
+
+  # Unfortunately, this can't be tested with Behat yet as the 'And I upload file to filemanager' step does not support folders
+  # Scenario: Setting: FontAwesome - Upload FontAwesome files
+
+  @javascript @_file_upload
+  Scenario: Setting: FontAwesome - Do not upload any file (countercheck)
+    When I log in as "admin"
+    Then "head > link[rel='stylesheet'][href~='theme_boost_union/fontawesome']" "css_element" should not exist
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Resources" "link"
+    Then I should not see "FontAwesome files list"
+    And ".settings-fontawesome-filelist" "css_element" should not exist
+    Then I should not see "FontAwesome checks"
+    And ".settings-fontawesome-checks" "css_element" should not exist


### PR DESCRIPTION
This patch introduces a new setting in the Look -> Resources tab which allows the admin to upload FontAwesome 6 Free files and add them to Moodle.

![grafik](https://user-images.githubusercontent.com/1092118/201919992-5c2657d2-03b1-4463-8c62-76cf2c3df061.png)

As soon as some files are uploaded, a file list is shown which helps the admin to identify the remaining files and which tells him which files are mandatory and which are optional:
![grafik](https://user-images.githubusercontent.com/1092118/201920124-cd9e1b3f-f1ac-4d14-ac7c-03b52dd1949d.png)

Finally, there is a checks section which helps the admin to assess if everything is working correctly:
![grafik](https://user-images.githubusercontent.com/1092118/201920212-b80a77b8-6b89-402c-b05d-a8b937ba8c6f.png)

During the implementation of this patch, some decisions have been made:
* Currently, only FontAwesome 6 Free is supported. However, the architecture is already built in a way to allow the addition of FontAwesome 6 Pro quite easily. I will create a follow-up issue for that.
* Currently, FontAwesome 5 is not supported. It seemed not to make much sense to allow outdated FA versions as well if the purpush of this feature is to allow admins to use the latest icons.
* Currently, the FontAwesome 6 fonts are added to the Moodle page _in addition_ to the FontAwesome 4 fonts from Moodle core. Both reside in their own font family namespaces and I did not see any clashes in my tests. However, I will create a follow-up issue to clean this up if possible.
* Currently, adding a full set of Behat tests is not possible with Moodle core steps. I will create a follow-up issue for that as well.