### PR TITLE
Feature/advertisementtiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-01-09 - Feature: Add advertisement tiles which can be displayed on site home, solves #161.
 * 2023-01-08 - Tests: Avoid to burn too much CPU time by testing all available course image options.
 * 2023-01-08 - Bugfix: Infobanners were sometimes incorrectly ordered if the same order was given to multiple banners, solves #181.
 * 2023-01-06 - Improvement: Small language tweaks in self enrolment course banners

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ With these settings, you can add rich text content which will be shown on a main
 
 In this tab, you can enable and configure multiple information banners to be shown on selected pages.
 
+#### Tab "Advertisement tiles"
+
+In this tab, you can enable and configure multiple advertisement tiles to be shown on site home.
+
 ### Settings page "Functionality"
 
 #### Tab "Courses"

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -487,6 +487,42 @@ $string['flavourspreviewblindtext'] = 'Lorem ipsum dolor sit amet, consectetur a
 $string['flavourstitle'] = 'Title';
 $string['flavourstitle_help'] = 'The flavour\'s title is just used internally to allow you to document a particular flavour in the list of flavours.';
 
+// Settings: Advertisement tiles.
+$string['tilestab'] = 'Advertisement tiles';
+// ... Section: Advertisement tiles general.
+$string['tilesgeneralheading'] = 'Advertisement tiles general';
+$string['tilecolumnssetting'] = 'Number of advertisement tile columns per row';
+$string['tilecolumnssetting_desc'] = 'Here, you define the number of columns per row in the presented grid of advertisement tiles. Please note that this number of columns applies to desktop / larger screens. On smaller screens and mobile screens, the advertisement tile columns are automatically wrapped.';
+$string['tilefrontpagepositionsetting'] = 'Position of the advertisement tiles on site home';
+$string['tilefrontpagepositionsetting_desc'] = 'Advertisement tiles are shown on site home only. With this setting, you control if the advertisement tiles are displayed before the site home content or after the site home content. If you want to show only the advertisement tiles on site home and nothing else, all other site home content can be removed by changing the <a href="{$a->url}">site home settings</a>.';
+$string['tilefrontpagepositionsetting_before'] = 'Before the site home content';
+$string['tilefrontpagepositionsetting_after'] = 'After the site home content';
+$string['tileheightsetting'] = 'Advertisement tiles height';
+$string['tileheightsetting_desc'] = 'With this setting, you control the height of the advertisement tiles. The configured height is the minimum height of each tile. If a tile\'s content is higher than this configured height, the whole row of tiles will be automatically made higher as needed.';
+// ... Section: Advertisement tiles.
+$string['tileheading'] = 'Advertisement tile no. {$a->no}';
+$string['tilebackgroundimagepositionsetting'] = 'Advertisement tile no. {$a->no} background image position';
+$string['tilebackgroundimagepositionsetting_desc'] = 'With this setting, you control the positioning of the background image within the advertisement tile no. {$a->no} container. The first value is the horizontal position, the second value is the vertical position.';
+$string['tilebackgroundimagesetting'] = 'Advertisement tile no. {$a->no} background image';
+$string['tilebackgroundimagesetting_desc'] = 'Here, you can upload an image file which will be shown as background image behind the content of the advertisement tile no. {$a->no}. Please make sure or check that the content is still readable on the background image. This is an optional setting, the advertisement tile will work even if you do not upload any background image.';
+$string['tilecontentsetting'] = 'Advertisement tile no. {$a->no} content';
+$string['tilecontentsetting_desc'] = 'Here, you enter the content which should be displayed in the advertisement tile no. {$a->no}. The content is displayed in the middle of the tile. This is an optional setting, the advertisement tile will be shown even if you do not set any content.';
+$string['tileenabledsetting'] = 'Enable advertisement tile no. {$a->no}';
+$string['tileenabledsetting_desc'] = 'With this setting, you can enable advertisement tile no. {$a->no}.';
+$string['tilelinksetting'] = 'Advertisement tile no. {$a->no} link URL';
+$string['tilelinksetting_desc'] = 'Here, you can set a (Moodle-internal or external) URL which will be offered as link button at the end of the advertisement tile no. {$a->no}. This is an optional setting, the advertisement tile will work even if you do not set any link URL.';
+$string['tilelinktitlefallback'] = 'Link';
+$string['tilelinktitlesetting'] = 'Advertisement tile no. {$a->no} link title';
+$string['tilelinktitlesetting_desc'] = 'Here, you can set a link title which is used as label of the link button as soon as you set a link URL in the advertisement tile no. {$a->no}. Please note that if you set a link URL but do not set a link title, the link button will just be labeled with \'Link\'.';
+$string['tilelinktargetsetting'] = 'Advertisement tile no. {$a->no} link target';
+$string['tilelinktargetsetting_desc'] = 'Here, you can set the link target which is set for the link button as soon as you set a link URL in the advertisement tile no. {$a->no}.';
+$string['tilelinktargetsetting_samewindow'] = 'Same window';
+$string['tilelinktargetsetting_newtab'] = 'New tab';
+$string['tileordersetting'] = 'Advertisement tile no. {$a->no} order position';
+$string['tileordersetting_desc'] = 'With this setting, you define the order position of the advertisement tile no. {$a->no}. By default, the advertisement tiles are ordered from top to bottom and left to right like you see them on this settings page here. However, you can decide to assign another order position with this setting. If you assign the same order position to two or more advertisement tiles, they will be ordered again according to the order on this settings page.';
+$string['tiletitlesetting'] = 'Advertisement tile no. {$a->no} title';
+$string['tiletitlesetting_desc'] = 'Here, you enter the title which should be displayed in the advertisement tile no. {$a->no}. This is an optional setting, the advertisement tile will be shown even if you do not set a title.';
+
 // Privacy API.
 $string['privacy:metadata'] = 'The Boost Union theme does not store any personal data about any user.';
 

--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -153,5 +153,10 @@ require_once(__DIR__ . '/includes/javascriptdisabledhint.php');
 // Include the template content for the info banners.
 require_once(__DIR__ . '/includes/infobanners.php');
 
+// Include the template content for the advertisement tiles, but only if we are on the frontpage.
+if ($PAGE->pagelayout == 'frontpage') {
+    require_once(__DIR__ . '/includes/advertisementtiles.php');
+}
+
 // Render drawers.mustache from boost_union.
 echo $OUTPUT->render_from_template('theme_boost_union/drawers', $templatecontext);

--- a/layout/includes/advertisementtiles.php
+++ b/layout/includes/advertisementtiles.php
@@ -1,0 +1,118 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - advertisement tiles layout include.
+ *
+ * @package   theme_boost_union
+ * @copyright 2022 Nina Herrmann <nina.herrmann@gmx.de>
+ * @copyright on behalf of Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+// Require the necessary libraries.
+require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
+
+// Get theme config.
+$config = get_config('theme_boost_union');
+
+// Initialize advertisement tiles data for templatecontext.
+$advertisementtiles = array();
+
+// Getting and setting the advertisement tiles position on the frontpage.
+switch ($config->{'tilefrontpageposition'}) {
+    case THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_BEFORE:
+        $templatecontext['advtilespositionbefore'] = true;
+        $templatecontext['advtilespositionafter'] = false;
+        break;
+    case THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_AFTER:
+        $templatecontext['advtilespositionbefore'] = false;
+        $templatecontext['advtilespositionafter'] = true;
+}
+
+// Getting and setting the advertisement tiles height on the frontpage.
+$tileheight = $config->{'tileheight'};
+$templatecontext['tileheight'] = $tileheight;
+
+// Calculating and setting the col-x class from the number in the tilecolumns setting.
+$colclass = 'col-12';
+switch ($config->{'tilecolumns'}) {
+    case 1:
+        // Nothing to add in this case.
+        break;
+    case 2:
+        $colclass .= ' col-sm-6';
+        break;
+    case 3:
+        $colclass .= ' col-sm-6 col-md-4';
+        break;
+    case 4:
+        $colclass .= ' col-sm-6 col-md-3';
+}
+$templatecontext['advtileslayoutclass'] = $colclass;
+
+// Iterate over all advertisement tiles.
+for ($i = 1; $i <= THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COUNT; $i++) {
+    // If the tile is enabled? (regardless if it contains any content).
+    if ($config->{'tile'.$i.'enabled'} == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+        // Get and set the tile's title.
+        $title = $config->{'tile'.$i.'title'};
+
+        // Get and set the tile's content.
+        $formatoptions = array('noclean' => true);
+        $content = format_text($config->{'tile'.$i.'content'}, FORMAT_HTML, $formatoptions);
+
+        // Get and set the tile's link.
+        $link = $config->{'tile'.$i.'link'};
+        $linktitle = $config->{'tile'.$i.'linktitle'};
+        if ($config->{'tile'.$i.'linktarget'} == THEME_BOOST_UNION_SETTING_LINKTARGET_NEWTAB) {
+            $linktargetnewtab = true;
+        } else {
+            $linktargetnewtab = false;
+        }
+
+        // Get and set the tile's background image.
+        $bgimage = theme_boost_union_get_urloftilebackgroundimage($i);
+
+        // Get and set the tile's background image posision.
+        $bgimageposition = $config->{'tile'.$i.'backgroundimageposition'};
+
+        // Get and set the tile's order.
+        // The order is not needed for the mustache template, but the usort() method will need it later.
+        $order = $config->{'tile'.$i.'order'};
+
+        // Compose and remember this tile as templatecontext object.
+        $advtile = new stdClass();
+        $advtile->title = $title;
+        $advtile->content = $content;
+        $advtile->linktitle = $linktitle;
+        $advtile->link = $link;
+        $advtile->linktargetnewtab = $linktargetnewtab;
+        $advtile->backgroundimageurl = $bgimage;
+        $advtile->backgroundimageposition = $bgimageposition;
+        $advtile->no = $i;
+        $advtile->order = $order;
+        $advertisementtiles[$i] = $advtile;
+    }
+}
+
+// Reorder the tiles based on their order settings.
+usort($advertisementtiles, 'theme_boost_union_compare_order');
+
+// Add advertisement tiles data to templatecontext.
+$templatecontext['advtiles'] = $advertisementtiles;

--- a/layout/includes/infobanners.php
+++ b/layout/includes/infobanners.php
@@ -87,7 +87,7 @@ for ($i = 1; $i <= THEME_BOOST_UNION_SETTING_INFOBANNER_COUNT; $i++) {
 }
 
 // Reorder the info banners based on their order settings.
-usort($infobanners, 'theme_boost_union_infobanner_compare_order');
+usort($infobanners, 'theme_boost_union_compare_order');
 
 // Add info banners data to templatecontext.
 $templatecontext['infobanners'] = $infobanners;

--- a/lib.php
+++ b/lib.php
@@ -45,29 +45,37 @@ define('THEME_BOOST_UNION_SETTING_INFOBANNERPAGES_LOGIN', 'login');
 define('THEME_BOOST_UNION_SETTING_INFOBANNERMODE_PERPETUAL', 'perp');
 define('THEME_BOOST_UNION_SETTING_INFOBANNERMODE_TIMEBASED', 'time');
 
+define('THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COUNT', 12);
+define('THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COLUMN_COUNT', 4);
+define('THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_BEFORE', 1);
+define('THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_AFTER', 2);
+
 define('THEME_BOOST_UNION_SETTING_FAVERSION_NONE', 'none');
 define('THEME_BOOST_UNION_SETTING_FAVERSION_FA6FREE', 'fa6free');
 define('THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY', 'm');
 define('THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL', 'o');
 
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_100PX', '100px');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_150PX', '150px');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_200PX', '200px');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_250PX', '250px');
+define('THEME_BOOST_UNION_SETTING_HEIGHT_100PX', '100px');
+define('THEME_BOOST_UNION_SETTING_HEIGHT_150PX', '150px');
+define('THEME_BOOST_UNION_SETTING_HEIGHT_200PX', '200px');
+define('THEME_BOOST_UNION_SETTING_HEIGHT_250PX', '250px');
 
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_CENTER', 'center center');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_TOP', 'center top');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_BOTTOM', 'center bottom');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_TOP', 'left top');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_CENTER', 'left center');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_BOTTOM', 'left bottom');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_TOP', 'right top');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_CENTER', 'right center');
-define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_BOTTOM', 'right bottom');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER', 'center center');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_TOP', 'center top');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_BOTTOM', 'center bottom');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_TOP', 'left top');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_CENTER', 'left center');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_BOTTOM', 'left bottom');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_TOP', 'right top');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_CENTER', 'right center');
+define('THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_BOTTOM', 'right bottom');
 
 define('THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_STACKEDDARK', 'stackeddark');
 define('THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_STACKEDLIGHT', 'stackedlight');
 define('THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_HEADINGABOVE', 'headingabove');
+
+define('THEME_BOOST_UNION_SETTING_LINKTARGET_SAMEWINDOW', 'same');
+define('THEME_BOOST_UNION_SETTING_LINKTARGET_NEWTAB', 'new');
 
 /**
  * Returns the main SCSS content.
@@ -269,7 +277,8 @@ function theme_boost_union_pluginfile($course, $cm, $context, $filearea, $args, 
     // Serve the files from the admin settings.
     if ($context->contextlevel == CONTEXT_SYSTEM && ($filearea === 'logo' || $filearea === 'backgroundimage' ||
         $filearea === 'loginbackgroundimage' || $filearea === 'favicon' || $filearea === 'additionalresources' ||
-                $filearea === 'customfonts' || $filearea === 'fontawesome' || $filearea === 'courseheaderimagefallback')) {
+                $filearea === 'customfonts' || $filearea === 'fontawesome' || $filearea === 'courseheaderimagefallback' ||
+                preg_match("/tilebackgroundimage[2-9]|1[0-2]?/", $filearea))) {
         $theme = theme_config::load('boost_union');
         // By default, theme files must be cache-able by both browsers and proxies.
         if (!array_key_exists('cacheability', $options)) {

--- a/locallib.php
+++ b/locallib.php
@@ -402,14 +402,14 @@ function theme_boost_union_infobanner_is_shown_on_page($bannerno) {
 }
 
 /**
- * Helper function to compare two infobanner orders.
+ * Helper function to compare either infobanner or tiles orders.
  *
  * @param int $a The first value
  * @param int $b The second value
  *
  * @return boolean.
  */
-function theme_boost_union_infobanner_compare_order($a, $b) {
+function theme_boost_union_compare_order($a, $b) {
     // If the same 'order' attribute is given to both items.
     if ($a->order == $b->order) {
         // We have to compare the 'no' attribute.
@@ -537,6 +537,53 @@ function theme_boost_union_get_loginbackgroundimage_files() {
     }
 
     return $files;
+}
+
+/**
+ *
+ * Get the advertisement tile's background image URL from the filearea 'tilebackgroundimage'.tileno.
+ *
+ * Note:
+ * Calling this function for each tile separately is maybe not performant. Originally it was planed to put
+ * all files in one filearea. However, at the time of development
+ * https://github.com/moodle/moodle/blob/master/lib/outputlib.php#L2062
+ * did not support itemids in setting-files of themes.
+ *
+ * @param int $tileno The tile number.
+ * @return string|null
+ */
+function theme_boost_union_get_urloftilebackgroundimage($tileno) {
+    // If the tile number is apparently not valid, return.
+    // Note: We just check the tile's number, we do not check if the tile is enabled or not.
+    if ($tileno < 0 || $tileno > THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COUNT) {
+        return null;
+    }
+
+    // Get the background image config for this tile.
+    $bgconfig = get_config('theme_boost_union', 'tile'.$tileno.'backgroundimage');
+
+    // If a background image is configured.
+    if (!empty($bgconfig)) {
+        // Get the system context.
+        $systemcontext = context_system::instance();
+
+        // Get filearea.
+        $fs = get_file_storage();
+
+        // Get all files from filearea.
+        $files = $fs->get_area_files($systemcontext->id, 'theme_boost_union', 'tilebackgroundimage'.$tileno,
+                false, 'itemid', false);
+
+        // Just pick the first file - we are sure that there is just one file.
+        $file = reset($files);
+
+        // Build and return the image URL.
+        return moodle_url::make_pluginfile_url($file->get_contextid(), $file->get_component(), $file->get_filearea(),
+                $file->get_itemid(), $file->get_filepath(), $file->get_filename());
+    }
+
+    // As no image was found, return null.
+    return null;
 }
 
 /**

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -225,6 +225,26 @@ body.pagelayout-login:not(.loginbackgroundimage) #footnote {
     margin-bottom: 0;
 }
 
+/*=======================================
+ * Settings: Content -> Advertisement tiles.
+ ======================================*/
+
+/* Remove horizontal paddings on the tile container on smaller screens to align it with the main frontpage content. */
+@include media-breakpoint-down(sm) {
+    #themeboostunionadvtiles {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
+/* Style the advertisement tile cards. */
+#themeboostunionadvtiles [class*="col-"] .card {
+    background-size: cover;
+    /* d-flex align-items-stretch align-self-stretch classes in mustache template require to set width to inherit
+       (Otherwise width is flexible dependent on content). */
+    width: inherit;
+}
+
 
 /*=======================================
  * Settings: Functionality -> Courses.

--- a/settings.php
+++ b/settings.php
@@ -420,11 +420,11 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $title = get_string('courseheaderimageheight', 'theme_boost_union', null, true);
         $description = get_string('courseheaderimageheight_desc', 'theme_boost_union', null, true);
         $courseheaderimageheightoptions = array(
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_100PX => THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_100PX,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_150PX => THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_150PX,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_200PX => THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_200PX,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_250PX => THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_250PX);
-        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_150PX,
+                THEME_BOOST_UNION_SETTING_HEIGHT_100PX => THEME_BOOST_UNION_SETTING_HEIGHT_100PX,
+                THEME_BOOST_UNION_SETTING_HEIGHT_150PX => THEME_BOOST_UNION_SETTING_HEIGHT_150PX,
+                THEME_BOOST_UNION_SETTING_HEIGHT_200PX => THEME_BOOST_UNION_SETTING_HEIGHT_200PX,
+                THEME_BOOST_UNION_SETTING_HEIGHT_250PX => THEME_BOOST_UNION_SETTING_HEIGHT_250PX);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_HEIGHT_150PX,
                 $courseheaderimageheightoptions);
         $tab->add($setting);
         $page->hide_if('theme_boost_union/courseheaderimageheight', 'theme_boost_union/courseheaderimageenabled', 'neq',
@@ -435,26 +435,26 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $title = get_string('courseheaderimageposition', 'theme_boost_union', null, true);
         $description = get_string('courseheaderimageposition_desc', 'theme_boost_union', null, true);
         $courseheaderimagepositionoptions = array(
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_CENTER =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_CENTER,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_TOP =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_TOP,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_BOTTOM =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_BOTTOM,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_TOP =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_TOP,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_CENTER =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_CENTER,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_BOTTOM =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_BOTTOM,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_TOP =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_TOP,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_CENTER =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_CENTER,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_BOTTOM =>
-                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_BOTTOM);
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_TOP =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_TOP,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_BOTTOM,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_TOP =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_TOP,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_CENTER =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_CENTER,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_BOTTOM,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_TOP =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_TOP,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_CENTER =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_CENTER,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_BOTTOM);
         $setting = new admin_setting_configselect($name, $title, $description,
-                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_CENTER, $courseheaderimagepositionoptions);
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER, $courseheaderimagepositionoptions);
         $tab->add($setting);
         $page->hide_if('theme_boost_union/courseheaderimageposition', 'theme_boost_union/courseheaderimageenabled', 'neq',
                 THEME_BOOST_UNION_SETTING_SELECT_YES);
@@ -1121,6 +1121,182 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
                     THEME_BOOST_UNION_SETTING_SELECT_YES);
             $page->hide_if('theme_boost_union/infobanner'.$i.'dismissible', 'theme_boost_union/infobanner'.$i.'mode', 'neq',
                     THEME_BOOST_UNION_SETTING_INFOBANNERMODE_PERPETUAL);
+        }
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
+        // Create advertisement tiles tab.
+        $tab = new admin_settingpage('theme_boost_union_tiles',
+            get_string('tilestab', 'theme_boost_union', null, true));
+
+        // Create advertisement tiles general heading.
+        $name = 'theme_boost_union/tilesgeneralheading';
+        $title = get_string('tilesgeneralheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Position of the advertisement tiles on the frontpage.
+        $tilefrontpagepositionoptions = array(
+                THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_BEFORE =>
+                        get_string('tilefrontpagepositionsetting_before', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_AFTER =>
+                        get_string('tilefrontpagepositionsetting_after', 'theme_boost_union'));
+        $name = 'theme_boost_union/tilefrontpageposition';
+        $title = get_string('tilefrontpagepositionsetting', 'theme_boost_union', null, true);
+        $url = new moodle_url('/admin/settings.php', array('section' => 'frontpagesettings'));
+        $description = get_string('tilefrontpagepositionsetting_desc', 'theme_boost_union', array('url' => $url), true);
+        $setting = new admin_setting_configselect($name, $title, $description,
+                THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_BEFORE, $tilefrontpagepositionoptions);
+        $tab->add($setting);
+
+        // Setting: Number of advertisement tile columns per row.
+        $tilecolumnsoptions = array();
+        for ($i = 1; $i <= THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COLUMN_COUNT; $i++) {
+            $tilecolumnsoptions[$i] = $i;
+        }
+        $name = 'theme_boost_union/tilecolumns';
+        $title = get_string('tilecolumnssetting', 'theme_boost_union', null, true);
+        $description = get_string('tilecolumnssetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, 2, $tilecolumnsoptions);
+        $tab->add($setting);
+
+        // Setting: Advertisement tiles height.
+        $name = 'theme_boost_union/tileheight';
+        $title = get_string('tileheightsetting', 'theme_boost_union', null, true);
+        $description = get_string('tileheightsetting_desc', 'theme_boost_union', null, true);
+        $tileheightoptions = array(
+                THEME_BOOST_UNION_SETTING_HEIGHT_100PX => THEME_BOOST_UNION_SETTING_HEIGHT_100PX,
+                THEME_BOOST_UNION_SETTING_HEIGHT_150PX => THEME_BOOST_UNION_SETTING_HEIGHT_150PX,
+                THEME_BOOST_UNION_SETTING_HEIGHT_200PX => THEME_BOOST_UNION_SETTING_HEIGHT_200PX,
+                THEME_BOOST_UNION_SETTING_HEIGHT_250PX => THEME_BOOST_UNION_SETTING_HEIGHT_250PX);
+        $setting = new admin_setting_configselect($name, $title, $description,
+                THEME_BOOST_UNION_SETTING_HEIGHT_150PX, $tileheightoptions);
+        $tab->add($setting);
+
+        // Prepare options for the order settings.
+        $tilesorders = array();
+        for ($i = 1; $i <= THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COUNT; $i++) {
+            $tilesorders[$i] = $i;
+        }
+
+        // Create the hardcoded amount of advertisement tiles without code duplication.
+        for ($i = 1; $i <= THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COUNT; $i++) {
+
+            // Create advertisement tile heading.
+            $name = 'theme_boost_union/tile'.$i.'heading';
+            $title = get_string('tileheading', 'theme_boost_union', array('no' => $i), true);
+            $setting = new admin_setting_heading($name, $title, null);
+            $tab->add($setting);
+
+            // Setting: Advertisement tile enabled.
+            $name = 'theme_boost_union/tile'.$i.'enabled';
+            $title = get_string('tileenabledsetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tileenabledsetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO,
+                    $yesnooption);
+            $tab->add($setting);
+
+            // Setting: Advertisement tile title.
+            $name = 'theme_boost_union/tile'.$i.'title';
+            $title = get_string('tiletitlesetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tiletitlesetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $setting = new admin_setting_configtext($name, $title, $description, '');
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/tile'.$i.'title', 'theme_boost_union/tile'.$i.'enabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Advertisement tile content.
+            $name = 'theme_boost_union/tile'.$i.'content';
+            $title = get_string('tilecontentsetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tilecontentsetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $setting = new admin_setting_confightmleditor($name, $title, $description, '');
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/tile'.$i.'content', 'theme_boost_union/tile'.$i.'enabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Advertisement tile background image.
+            $name = 'theme_boost_union/tile'.$i.'backgroundimage';
+            $title = get_string('tilebackgroundimagesetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tilebackgroundimagesetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $setting = new admin_setting_configstoredfile($name, $title, $description, 'tilebackgroundimage'.$i, 0,
+                array('maxfiles' => 1, 'accepted_types' => 'web_image'));
+            $setting->set_updatedcallback('theme_reset_all_caches');
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/tile'.$i.'backgroundimage', 'theme_boost_union/tile'.$i.'enabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Course header image position.
+            $name = 'theme_boost_union/tile'.$i.'backgroundimageposition';
+            $title = get_string('tilebackgroundimagepositionsetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tilebackgroundimagepositionsetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $tilebackgroundimagepositionoptions = array(
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_TOP =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_TOP,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_BOTTOM =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_BOTTOM,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_TOP =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_TOP,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_CENTER =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_CENTER,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_BOTTOM =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_BOTTOM,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_TOP =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_TOP,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_CENTER =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_CENTER,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_BOTTOM =>
+                            THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_BOTTOM);
+            $setting = new admin_setting_configselect($name, $title, $description,
+                    THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER, $tilebackgroundimagepositionoptions);
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/tile'.$i.'backgroundimageposition', 'theme_boost_union/tile'.$i.'enabled', 'neq',
+                    THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Advertisement tile link URL.
+            $name = 'theme_boost_union/tile'.$i.'link';
+            $title = get_string('tilelinksetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tilelinksetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $setting = new admin_setting_configtext($name, $title, $description, '', PARAM_URL);
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/tile'.$i.'link', 'theme_boost_union/tile'.$i.'enabled', 'neq',
+                    THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Advertisement tile link title.
+            $name = 'theme_boost_union/tile'.$i.'linktitle';
+            $title = get_string('tilelinktitlesetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tilelinktitlesetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $setting = new admin_setting_configtext($name, $title, $description, '');
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/tile'.$i.'linktitle', 'theme_boost_union/tile'.$i.'enabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Advertisement tile link target.
+            $name = 'theme_boost_union/tile'.$i.'linktarget';
+            $title = get_string('tilelinktargetsetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tilelinktargetsetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $tilelinktargetnoptions = array(
+                    THEME_BOOST_UNION_SETTING_LINKTARGET_SAMEWINDOW =>
+                            get_string('tilelinktargetsetting_samewindow', 'theme_boost_union'),
+                    THEME_BOOST_UNION_SETTING_LINKTARGET_NEWTAB =>
+                            get_string('tilelinktargetsetting_newtab', 'theme_boost_union'));
+            $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_LINKTARGET_SAMEWINDOW,
+                    $tilelinktargetnoptions);
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/tile'.$i.'linktarget', 'theme_boost_union/tile'.$i.'enabled', 'neq',
+                    THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Advertisement tile order position.
+            $name = 'theme_boost_union/tile'.$i.'order';
+            $title = get_string('tileordersetting', 'theme_boost_union', array('no' => $i), true);
+            $description = get_string('tileordersetting_desc', 'theme_boost_union', array('no' => $i), true);
+            $setting = new admin_setting_configselect($name, $title, $description, $i, $tilesorders);
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/tile'.$i.'order', 'theme_boost_union/tile'.$i.'enabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
         }
 
         // Add tab to settings page.

--- a/templates/advertisementtiles.mustache
+++ b/templates/advertisementtiles.mustache
@@ -1,0 +1,93 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/advertisementtiles
+
+    Boost Union advertisement tiles layout template.
+
+    Context variables required for this template:
+    * advtileslayoutclass - The CSS class for the grid
+    * advtiles - The configured info banners list with:
+      * content - The info banner content
+      * backgroundimage = Image to be displayed behind the content;
+      * linktitle = The link title which is displayed (might be empty);
+      * link = The actual URL (might be empty);
+      * no = Order which is displayed in the settings.;
+
+    Example context (json):
+    {
+        "advtileslayoutclass" : "col-6",
+        "advtiles": [
+            {
+                "title": "This is a nice title",
+                "content": "This is a really nice content which is added in this tile.",
+                "backgroundimageurl": "",
+                "linktitle": "",
+                "link": "",
+                "no": 1,
+                "order": 1
+            },
+            {
+                "title": "",
+                "content": "Are you hungry?",
+                "backgroundimageurl": "",
+                "linktitle": "Canteen",
+                "link": "https://canteen.awesome-organisation.org/",
+                "no": 2,
+                "order": 2
+            },
+            {
+                "title": "",
+                "content": "",
+                "backgroundimageurl": "https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/master/tests/fixtures/login_bg1.jpg",
+                "linktitle": "",
+                "link": "",
+                "no": 3,
+                "order": 3
+            }
+        ]
+    }
+}}
+<div id="themeboostunionadvtiles" class="container-fluid">
+    <div class="row">
+        {{#advtiles}}
+        <div id="themeboostunionadvtile{{no}}" class="themeboostunionadvtile {{advtileslayoutclass}} d-flex align-items-stretch align-self-stretch py-3">
+            <div class="transparent-bg card"
+                style="{{#backgroundimageurl}}background-image: url('{{{backgroundimageurl}}}');{{/backgroundimageurl}}
+                        {{#backgroundimageposition}}background-position: {{{.}}};{{/backgroundimageposition}}
+                        {{#tileheight}}min-height: {{{.}}};{{/tileheight}}">
+                {{#title}}<h5 class="card-header">{{{title}}}</h5>{{/title}}
+                <div class="card-body">
+                    {{#content}}<div class="card-text">{{{content}}}</div>{{/content}}
+                </div>
+                {{#link}}
+                    <div class="card-footer">
+                        <a href={{{link}}} id="themeboostunionadvtile{{no}}link" {{#linktargetnewtab}}target="_blank" rel="noopener noreferrer"{{/linktargetnewtab}} class="btn btn-primary">
+                            {{#linktitle}}
+                                {{{linktitle}}}
+                            {{/linktitle}}
+                            {{^linktitle}}
+                                {{#str}}tilelinktitlefallback, theme_boost_union{{/str}}
+                            {{/linktitle}}
+                        </a>
+                    </div>
+                {{/link}}
+            </div>
+        </div>
+        {{/advtiles}}
+    </div>
+</div>

--- a/templates/drawers.mustache
+++ b/templates/drawers.mustache
@@ -57,6 +57,7 @@
     * Include theme_boost_union/footer template instead of theme_boost/footer
     * Added the possibility to show course related hints.
     * Added the possibility to show info banners.
+    * Include theme_boost_union/advertisementtiles template
 }}
 {{> theme_boost/head }}
 
@@ -145,6 +146,9 @@
             {{/secondarymoremenu}}
             <div id="page-content" class="pb-3 d-print-block">
                 <div id="region-main-box">
+                    {{#advtilespositionbefore}}
+                        {{> theme_boost_union/advertisementtiles }}
+                    {{/advtilespositionbefore}}
                     {{#hasregionmainsettingsmenu}}
                     <div id="region-main-settings-menu" class="d-print-none">
                         <div> {{{ regionmainsettingsmenu }}} </div>
@@ -172,6 +176,9 @@
                         {{{ output.course_content_footer }}}
 
                     </section>
+                    {{#advtilespositionafter}}
+                        {{> theme_boost_union/advertisementtiles }}
+                    {{/advtilespositionafter}}
                 </div>
             </div>
         </div>

--- a/tests/behat/theme_boost_union_contentsettings_advertisementtiles.feature
+++ b/tests/behat/theme_boost_union_contentsettings_advertisementtiles.feature
@@ -1,0 +1,274 @@
+@theme @theme_boost_union @theme_boost_union_contentsettings @theme_boost_union_contentsettings_advertisementtiles
+Feature: Configuring the theme_boost_union plugin for the "Advertisement tiles" tab on the "Content" page
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+  Background:
+    Given the following "users" exist:
+      | username |
+      | teacher1 |
+
+  Scenario: Setting: Advertisement tiles - Display the advertisement tiles on the frontpage only and nowhere else
+    Given the following config values are set as admin:
+      | config       | value                             | plugin            |
+      | tile1enabled | yes                               | theme_boost_union |
+      | tile1title   | Tile 1                            | theme_boost_union |
+      | tile1content | This is a test content for tile 1 | theme_boost_union |
+    And the following "courses" exist:
+      | fullname | shortname |
+      | Course 1 | C1        |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+    When I log in as "teacher1"
+    And I am on site homepage
+    Then "#themeboostunionadvtile1" "css_element" should exist
+    And I follow "Dashboard"
+    Then "#themeboostunionadvtile1" "css_element" should not exist
+    And I follow "My courses"
+    Then "#themeboostunionadvtile1" "css_element" should not exist
+    When I am on "Course 1" course homepage
+    Then "#themeboostunionadvtile1" "css_element" should not exist
+    When I log out
+    And I click on "Log in" "link" in the ".logininfo" "css_element"
+    Then "#themeboostunionadvtile1" "css_element" should not exist
+
+  Scenario Outline: Setting: Advertisement tiles - Display an advertisement tile only if it is enabled
+    Given the following config values are set as admin:
+      | config       | value                             | plugin            |
+      | tile1enabled | <enabled>                         | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on site homepage
+    Then "#themeboostunionadvtile1" "css_element" <shouldexist>
+
+    Examples:
+      | enabled | shouldexist      |
+      | yes     | should exist     |
+      | no      | should not exist |
+
+  Scenario Outline: Setting: Advertisement tiles - Display the advertisement tiles before or after the main output of site home
+    Given the following config values are set as admin:
+      | config                | value                             | plugin            |
+      | tilefrontpageposition | <position>                        | theme_boost_union |
+      | tile1enabled          | yes                               | theme_boost_union |
+      | tile1title            | Tile 1                            | theme_boost_union |
+      | tile1content          | This is a test content for tile 1 | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on site homepage
+    Then "#themeboostunionadvtiles" "css_element" should appear <beforeafter> "#region-main" "css_element"
+
+    Examples:
+      | position | beforeafter |
+      | 1        | before      |
+      | 2        | after       |
+
+  Scenario Outline: Setting: Advertisement tiles - When changing number of columns content is aligned accordingly.
+    Given the following config values are set as admin:
+      | config                | value                             | plugin            |
+      | tilecolumns           | <setting>                         | theme_boost_union |
+      | tile1enabled          | yes                               | theme_boost_union |
+      | tile1title            | Tile 1                            | theme_boost_union |
+      | tile1content          | This is a test content for tile 1 | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on site homepage
+    Then I should see "This is a test content for tile 1" in the "#themeboostunionadvtile1<designclass>" "css_element"
+
+    Examples:
+      | setting | designclass               |
+      | 1       | .col-12                   |
+      | 2       | .col-12.col-sm-6          |
+      | 3       | .col-12.col-sm-6.col-md-4 |
+      | 4       | .col-12.col-sm-6.col-md-3 |
+
+  Scenario: Setting: Advertisement tiles - Display the title, the content and the link in the corresponding HTML elements
+    Given the following config values are set as admin:
+      | config         | value                             | plugin            |
+      | tile1enabled   | yes                               | theme_boost_union |
+      | tile1title     | Tile 1                            | theme_boost_union |
+      | tile1content   | This is a test content for tile 1 | theme_boost_union |
+      | tile1link      | www.behat.com                     | theme_boost_union |
+      | tile1linktitle | Link to Behat                     | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on site homepage
+    Then "#themeboostunionadvtiles #themeboostunionadvtile1" "css_element" should exist
+    And I should see "This is a test content for tile 1" in the "#themeboostunionadvtile1 .card .card-body .card-text" "css_element"
+    And I should see "Tile 1" in the "#themeboostunionadvtile1 .card h5.card-header" "css_element"
+    And I should see "Link to Behat" in the "#themeboostunionadvtile1 .card .card-footer #themeboostunionadvtile1link" "css_element"
+
+  Scenario: Setting: Advertisement tiles - Display the links in the advertisement tiles
+    Given the following config values are set as admin:
+      | config          | value          | plugin            |
+      | tile1enabled    | yes            | theme_boost_union |
+      | tile1link       |                | theme_boost_union |
+      | tile1linktitle  |                | theme_boost_union |
+      | tile1linktarget | same           | theme_boost_union |
+      | tile2enabled    | yes            | theme_boost_union |
+      | tile2link       | www.behat.de   | theme_boost_union |
+      | tile2linktitle  |                | theme_boost_union |
+      | tile2linktarget | same           | theme_boost_union |
+      | tile3enabled    | yes            | theme_boost_union |
+      | tile3link       | www.behat.com  | theme_boost_union |
+      | tile3linktitle  | Link to Behat  | theme_boost_union |
+      | tile3linktarget | same           | theme_boost_union |
+      | tile4enabled    | yes            | theme_boost_union |
+      | tile4link       | www.google.com | theme_boost_union |
+      | tile4linktitle  | Link to Google | theme_boost_union |
+      | tile4linktarget | new            | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on site homepage
+    Then "#themeboostunionadvtile1link" "css_element" should not exist
+    And "#themeboostunionadvtile2link" "css_element" should exist
+    And I should see "Link" in the "#themeboostunionadvtile2link" "css_element"
+    And I should not see "www.behat.de" in the "#themeboostunionadvtile2link" "css_element"
+    And the "href" attribute of "#themeboostunionadvtile2link" "css_element" should contain "www.behat.de"
+    And "#themeboostunionadvtile3link" "css_element" should exist
+    And I should see "Link to Behat" in the "#themeboostunionadvtile3link" "css_element"
+    And I should not see "www.behat.com" in the "#themeboostunionadvtile3link" "css_element"
+    And the "href" attribute of "#themeboostunionadvtile3link" "css_element" should contain "www.behat.com"
+    And the "target" attribute of "#themeboostunionadvtile3link" "css_element" should not be set
+    And the "rel" attribute of "#themeboostunionadvtile3link" "css_element" should not be set
+    And "#themeboostunionadvtile4link" "css_element" should exist
+    And I should see "Link to Google" in the "#themeboostunionadvtile4link" "css_element"
+    And I should not see "www.google.com" in the "#themeboostunionadvtile4link" "css_element"
+    And the "href" attribute of "#themeboostunionadvtile4link" "css_element" should contain "www.google.com"
+    And the "target" attribute of "#themeboostunionadvtile4link" "css_element" should contain "_blank"
+    And the "rel" attribute of "#themeboostunionadvtile4link" "css_element" should contain "noopener"
+    And the "rel" attribute of "#themeboostunionadvtile4link" "css_element" should contain "noreferrer"
+
+  Scenario Outline: Setting: Advertisement tiles - Display the tiles according to the configured orders
+    Given the following config values are set as admin:
+      | config       | value                             | plugin            |
+      | tilecolumns  | 2                                 | theme_boost_union |
+      | tile1enabled | yes                               | theme_boost_union |
+      | tile1content | This is a test content for tile 1 | theme_boost_union |
+      | tile1order   | <ordert1>                         | theme_boost_union |
+      | tile2enabled | yes                               | theme_boost_union |
+      | tile2content | This is a test content for tile 2 | theme_boost_union |
+      | tile2order   | <ordert2>                         | theme_boost_union |
+      | tile4enabled | yes                               | theme_boost_union |
+      | tile4content | This is a test content for tile 4 | theme_boost_union |
+      | tile4order   | <ordert4>                         | theme_boost_union |
+      | tile6enabled | yes                               | theme_boost_union |
+      | tile6content | This is a test content for tile 6 | theme_boost_union |
+      | tile6order   | <ordert6>                         | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on site homepage
+    Then "//div[@id='themeboostunionadvtiles']/div[contains(@class, 'row')]/*[<positiont1>][@id='themeboostunionadvtile1']" "xpath_element" should exist
+    And "//div[@id='themeboostunionadvtiles']/div[contains(@class, 'row')]/*[<positiont2>][@id='themeboostunionadvtile2']" "xpath_element" should exist
+    And "//div[@id='themeboostunionadvtiles']/div[contains(@class, 'row')]/*[<positiont4>][@id='themeboostunionadvtile4']" "xpath_element" should exist
+    And "//div[@id='themeboostunionadvtiles']/div[contains(@class, 'row')]/*[<positiont6>][@id='themeboostunionadvtile6']" "xpath_element" should exist
+
+    Examples:
+      | ordert1  | positiont1 | ordert2  | positiont2 | ordert4  | positiont4 | ordert6  | positiont6 |
+      | 1        | 1          | 2        | 2          | 3        | 3          | 4        | 4          |
+      | 2        | 2          | 4        | 4          | 3        | 3          | 1        | 1          |
+      | 1        | 1          | 4        | 4          | 3        | 3          | 1        | 2          |
+      | 1        | 1          | 1        | 2          | 2        | 3          | 3        | 4          |
+      | 5        | 2          | 6        | 3          | 3        | 1          | 8        | 4          |
+
+  @javascript @_file_upload
+  Scenario: Setting: Advertisement tiles - Display the uploaded background image
+    Given the following config values are set as admin:
+      | config       | value                             | plugin            |
+      | tile1enabled | yes                               | theme_boost_union |
+      | tile1content | This is a test content for tile 1 | theme_boost_union |
+      | tile2enabled | no                                | theme_boost_union |
+      | tile2content | This is a test content for tile 2 | theme_boost_union |
+    When I log in as "admin"
+    # We deactivate debugging for a while as the Behat step would otherwise fail due to the
+    # stupid 'Too much data passed as arguments to js_call_amd' debugging message which can't be avoided
+    # on this settings page. This debugging message can't be avoided as we simple use too much hide_if() there.
+    And the following config values are set as admin:
+      | debug          | 0 |
+      | debugdisplay   | 0 |
+    And I navigate to "Appearance > Boost Union > Content" in site administration
+    And I click on "Advertisement tiles" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Advertisement tile no. 1 background image" filemanager
+    And I press "Save changes"
+    And I am on site homepage
+    And I log out
+    And I am on site homepage
+    And I follow "Log in"
+    And I log in as "teacher1"
+    And I am on site homepage
+    Then "//div[@id='themeboostunionadvtile1']/*[1][contains(@style, 'pluginfile.php/1/theme_boost_union/tilebackgroundimage1/0/login_bg1.jpg')]" "xpath_element" should exist
+    And "//div[@id='themeboostunionadvtile2']/*[1][contains(@style, 'pluginfile.php')]" "xpath_element" should not exist
+
+  Scenario Outline: Setting: Advertisement tiles - Define the tile (min-)height.
+    Given the following config values are set as admin:
+      | config       | value                             | plugin            |
+      | tileheight   | <height>                          | theme_boost_union |
+      | tile1enabled | yes                               | theme_boost_union |
+      | tile1content | This is a test content for tile 1 | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on site homepage
+    Then "//div[@id='themeboostunionadvtile1']/*[1][contains(@class, 'card') and contains(@style, 'min-height: <height>')]" "xpath_element" should exist
+
+    # We do not want to burn too much CPU time by testing all available options. We just test the default value and one non-default value.
+    Examples:
+      | height |
+      | 150px  |
+      | 250px  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Advertisement tiles - Define the background image position.
+    Given the following config values are set as admin:
+      | config                       | value                             | plugin            |
+      | tile1enabled                 | yes                               | theme_boost_union |
+      | tile1content                 | This is a test content for tile 1 | theme_boost_union |
+      | tile1backgroundimageposition | <position>                        | theme_boost_union |
+    When I log in as "admin"
+    # We deactivate debugging for a while as the Behat step would otherwise fail due to the
+    # stupid 'Too much data passed as arguments to js_call_amd' debugging message which can't be avoided
+    # on this settings page. This debugging message can't be avoided as we simple use too much hide_if() there.
+    And the following config values are set as admin:
+      | debug          | 0 |
+      | debugdisplay   | 0 |
+    And I navigate to "Appearance > Boost Union > Content" in site administration
+    And I click on "Advertisement tiles" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Advertisement tile no. 1 background image" filemanager
+    And I press "Save changes"
+    And I am on site homepage
+    # We reactivate debugging again.
+    And the following config values are set as admin:
+      | debug          | 32767 |
+      | debugdisplay   | 1     |
+    And I log out
+    And I am on site homepage
+    And I follow "Log in"
+    And I log in as "teacher1"
+    And I am on site homepage
+    Then "//div[@id='themeboostunionadvtile1']/*[1][contains(@class, 'card') and contains(@style, 'background-position: <position>')]" "xpath_element" should exist
+
+    # We do not want to burn too much CPU time by testing all available options. We just test the default value and one non-default value.
+    Examples:
+      | position      |
+      | center center |
+      | left top      |
+
+  @javascript
+  Scenario: Setting: Advertisement tiles - Show and hide the admin settings based on the main "Enable advertisement tile no. x" setting
+    Given the following config values are set as admin:
+      | config       | value | plugin            |
+      | tile1enabled | yes   | theme_boost_union |
+    When I log in as "admin"
+    # We deactivate debugging for a while as the Behat step would otherwise fail due to the
+    # stupid 'Too much data passed as arguments to js_call_amd' debugging message which can't be avoided
+    # on this settings page. This debugging message can't be avoided as we simple use too much hide_if() there.
+    And the following config values are set as admin:
+      | debug          | 0 |
+      | debugdisplay   | 0 |
+    And I navigate to "Appearance > Boost Union > Content" in site administration
+    And I click on "Advertisement tiles" "link" in the "#adminsettings .nav-tabs" "css_element"
+    Then "#admin-tile1title" "css_element" should be visible
+    Then "#admin-tile3title" "css_element" should not be visible
+    Then "#admin-tile4title" "css_element" should not be visible
+    And I select "Yes" from the "Enable advertisement tile no. 4" singleselect
+    Then "#admin-tile1title" "css_element" should be visible
+    Then "#admin-tile3title" "css_element" should not be visible
+    Then "#admin-tile4title" "css_element" should be visible
+    And I select "No" from the "Enable advertisement tile no. 1" singleselect
+    Then "#admin-tile1title" "css_element" should not be visible
+    Then "#admin-tile3title" "css_element" should not be visible
+    Then "#admin-tile4title" "css_element" should be visible

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2022080917;
+$plugin->version = 2022080918;
 $plugin->release = 'v4.0-r9';
 $plugin->requires = 2022041900;
 $plugin->supported = [400, 400];


### PR DESCRIPTION
Copied from issue #161 :
For first-time visitors, Moodle sites are quite boring and uninformative. If I, as site manager, want to provide some information to first-time visitors, I will most likely want to add this to the front page. However, there are only inferior tools in Moodle for managing content on the front page.

As a site manager, I want to overcome these limitations and want to be able to add advertisement tiles to the frontpage:

- I want to be able to define up to 12 advertisement tiles
    Advertisement tiles can either
    - [x] link to a particular course
    - [x] link to a particular course category
    - [x] link to a particular (internal or external URL)
    
_For the MVP, this is abstracted to adding a link._ 

- For each tile, I have
    - [x] a plain text input setting for the tile's title (which may remain empty)
    - [x] a rich text editor setting for the tile's content (which may remain empty)
    - [x] an upload setting for the tile's background image (which may remain empty)
    - [x] a setting for the link target (a course, a category, a URL - which may remain empty)
    - [x] a setting for the link title (which may remain empty if no link target is set)
    I want to be able to configure if the tiles will be shown as 1-column, 2-column, 3-column or 4-column grid
- The tiles should be shown on the frontpage, and I want to be able to configure if they should be shown before, after or instead of the frontpage content
- The tiles should come with a simple layout which fits into Boost's look (i.e. no drop shadows, gradients or something like that)

The implementation is quite close to #54.