### PR TITLE
Feature/showcourseimageincourseheader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2022-12-31 - Feature: Add settings and layouts to enable/disable showing course images or a fallback image in the header of the course page, solves #77.
 * 2022-12-31 - Feature: Allow admins to define 'flavours' (i.e. special designs) which are applied to cohorts and / or course categories, solves #25.
 * 2022-12-19 - Feature: Allow admins to hide primary navigation items, solves #65.
 * 2022-12-14 - Feature: Built-in contact, help and maintenance pages, solves #150.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ With these settings, you can overwrite the Bootstrap colors which are used withi
 
 With these settings, you can overwrite the activity icon colors which are used within courses.
 
+#### Tab "Course"
+
+##### Course Header
+
+###### Display the course image in the course header
+
+When enabled, the course image (which can be uploaded in a course's course settings) is displayed in the header of a course. The course images are shown there in addition to the 'My courses' page where they are always shown.
+
+###### Fallback course header image
+
+If you upload an image in this setting, it is used as fallback image and is displayed in the course header if no course image is uploaded in a particular course's course settings. If you do not upload an image here, a course header image is only shown in a particular course if a course image is uploaded in this particular course's course settings.
+
+###### Course header image height
+
+With this setting, you control the height of the presented course header image.
+
+###### Course header image layout
+
+With this setting, you control the layout of the course header image and the course title.
+
+###### Course header image position
+
+With this setting, you control the positioning of the course header image within the course header container. The first value is the horizontal position, the second value is the vertical position.
+
 #### Tab "E-Mail branding"
 
 In this tab, you find a feature which you can use to apply branding to all E-Mails which Moodle is sending out.

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -282,4 +282,76 @@ class core_renderer extends \theme_boost\output\core_renderer {
 
         return ' id="'. $this->body_id().'" class="'.$this->body_css_classes($additionalclasses).'"';
     }
+
+    /**
+     * Wrapper for header elements.
+     *
+     * This renderer function is copied and modified from /lib/outputrenderers.php
+     *
+     * @return string HTML to display the main header.
+     */
+    public function full_header() {
+        $pagetype = $this->page->pagetype;
+        $homepage = get_home_page();
+        $homepagetype = null;
+        // Add a special case since /my/courses is a part of the /my subsystem.
+        if ($homepage == HOMEPAGE_MY || $homepage == HOMEPAGE_MYCOURSES) {
+            $homepagetype = 'my-index';
+        } else if ($homepage == HOMEPAGE_SITE) {
+            $homepagetype = 'site-index';
+        }
+        if ($this->page->include_region_main_settings_in_header_actions() &&
+                !$this->page->blocks->is_block_present('settings')) {
+            // Only include the region main settings if the page has requested it and it doesn't already have
+            // the settings block on it. The region main settings are included in the settings block and
+            // duplicating the content causes behat failures.
+            $this->page->add_header_action(html_writer::div(
+                    $this->region_main_settings_menu(),
+                    'd-print-none',
+                    ['id' => 'region-main-settings-menu']
+            ));
+        }
+
+        $header = new \stdClass();
+        $header->settingsmenu = $this->context_header_settings_menu();
+        $header->contextheader = $this->context_header();
+        $header->hasnavbar = empty($this->page->layout_options['nonavbar']);
+        $header->navbar = $this->navbar();
+        $header->pageheadingbutton = $this->page_heading_button();
+        $header->courseheader = $this->course_header();
+        $header->headeractions = $this->page->get_header_actions();
+
+        // Add the course header image for rendering.
+        if ($this->page->pagelayout == 'course' && (get_config('theme_boost_union', 'courseheaderimageenabled')
+                        == THEME_BOOST_UNION_SETTING_SELECT_YES)) {
+            // If course header images are activated, we get the course header image url
+            // (which might be the fallback image depending on the course settings and theme settings).
+            $header->courseheaderimageurl = theme_boost_union_get_course_header_image_url();
+            // Additionally, get the course header image height.
+            $header->courseheaderimageheight = get_config('theme_boost_union', 'courseheaderimageheight');
+            // Additionally, get the course header image position.
+            $header->courseheaderimageposition = get_config('theme_boost_union', 'courseheaderimageposition');
+            // Additionally, get the template context attributes for the course header image layout.
+            $courseheaderimagelayout = get_config('theme_boost_union', 'courseheaderimagelayout');
+            switch($courseheaderimagelayout) {
+                case THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_HEADINGABOVE:
+                    $header->courseheaderimagelayoutheadingabove = true;
+                    $header->courseheaderimagelayoutstackedclass = '';
+                    break;
+                case THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_STACKEDDARK:
+                    $header->courseheaderimagelayoutheadingabove = false;
+                    $header->courseheaderimagelayoutstackedclass = 'dark';
+                    break;
+                case THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_STACKEDLIGHT:
+                    $header->courseheaderimagelayoutheadingabove = false;
+                    $header->courseheaderimagelayoutstackedclass = 'light';
+                    break;
+            }
+        }
+
+        if (!empty($pagetype) && !empty($homepagetype) && $pagetype == $homepagetype) {
+            $header->welcomemessage = \core_user::welcome_message();
+        }
+        return $this->render_from_template('core/full_header', $header);
+    }
 }

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -105,6 +105,25 @@ $string['activityiconcolorcontentsetting_desc'] = 'The activity icon color for "
 $string['activityiconcolorinterfacesetting'] = 'Activity icon color for "Interface"';
 $string['activityiconcolorinterfacesetting_desc'] = 'The activity icon color for "Interface"';
 
+// Settings: Course tab.
+$string['coursetab'] = 'Course';
+// ... Section: Course header.
+$string['courseheaderheading'] = 'Course Header';
+// ... ... Setting: Course header.
+$string['courseheaderimageenabled'] = 'Display the course image in the course header';
+$string['courseheaderimageenabled_desc'] = 'When enabled, the course image (which can be uploaded in a course\'s course settings) is displayed in the header of a course. The course images are shown there in addition to the \'My courses\' page where they are always shown.';
+$string['courseheaderimagefallback'] = 'Fallback course header image';
+$string['courseheaderimagefallback_desc'] = 'If you upload an image in this setting, it is used as fallback image and is displayed in the course header if no course image is uploaded in a particular course\'s course settings. If you do not upload an image here, a course header image is only shown in a particular course if a course image is uploaded in this particular course\'s course settings.';
+$string['courseheaderimageheight'] = 'Course header image height';
+$string['courseheaderimageheight_desc'] = 'With this setting, you control the height of the presented course header image.';
+$string['courseheaderimagelayout'] = 'Course header image layout';
+$string['courseheaderimagelayout_desc'] = 'With this setting, you control the layout of the course header image and the course title.';
+$string['courseheaderimagelayoutstackeddark'] = 'Course title stacked on course image (white font color for dark background images)';
+$string['courseheaderimagelayoutstackedlight'] = 'Course title stacked on course image (black font color for light background images)';
+$string['courseheaderimagelayoutheadingabove'] = 'Course title above of course image';
+$string['courseheaderimageposition'] = 'Course header image position';
+$string['courseheaderimageposition_desc'] = 'With this setting, you control the positioning of the course header image within the course header image container. The first value is the horizontal position, the second value is the vertical position.';
+
 // Settings: E-Mail branding tab.
 $string['emailbrandingtab'] = 'E-Mail branding';
 $string['templateemailhtmlprefix'] = '';

--- a/lib.php
+++ b/lib.php
@@ -50,6 +50,24 @@ define('THEME_BOOST_UNION_SETTING_FAVERSION_FA6FREE', 'fa6free');
 define('THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY', 'm');
 define('THEME_BOOST_UNION_SETTING_FAFILES_OPTIONAL', 'o');
 
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_100PX', '100px');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_150PX', '150px');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_200PX', '200px');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_250PX', '250px');
+
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_CENTER', 'center center');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_TOP', 'center top');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_BOTTOM', 'center bottom');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_TOP', 'left top');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_CENTER', 'left center');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_BOTTOM', 'left bottom');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_TOP', 'right top');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_CENTER', 'right center');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_BOTTOM', 'right bottom');
+
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_STACKEDDARK', 'stackeddark');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_STACKEDLIGHT', 'stackedlight');
+define('THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_HEADINGABOVE', 'headingabove');
 
 /**
  * Returns the main SCSS content.
@@ -251,7 +269,7 @@ function theme_boost_union_pluginfile($course, $cm, $context, $filearea, $args, 
     // Serve the files from the admin settings.
     if ($context->contextlevel == CONTEXT_SYSTEM && ($filearea === 'logo' || $filearea === 'backgroundimage' ||
         $filearea === 'loginbackgroundimage' || $filearea === 'favicon' || $filearea === 'additionalresources' ||
-                $filearea === 'customfonts' || $filearea === 'fontawesome')) {
+                $filearea === 'customfonts' || $filearea === 'fontawesome' || $filearea === 'courseheaderimagefallback')) {
         $theme = theme_config::load('boost_union');
         // By default, theme files must be cache-able by both browsers and proxies.
         if (!array_key_exists('cacheability', $options)) {

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -1,4 +1,24 @@
 /*=======================================
+ * Settings: Look -> Course
+ ======================================*/
+
+/*---------------------------------------
+ * Setting: Course header image.
+ --------------------------------------*/
+#courseheaderimage {
+    background-size: cover;
+    @include border-radius();
+}
+.courseheaderimage-dark {
+    color: white;
+    text-shadow: 0 0 5px black;
+}
+.courseheaderimage-light {
+    color: black;
+    text-shadow: 0 0 5px white;
+}
+
+/*=======================================
  * Settings: Look -> Resources
  ======================================*/
 

--- a/settings.php
+++ b/settings.php
@@ -371,6 +371,98 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $page->add($tab);
 
 
+        // Create course tab.
+        $tab = new admin_settingpage('theme_boost_union_look_course',
+                get_string('coursetab', 'theme_boost_union', null, true));
+
+        // Create course header heading.
+        $name = 'theme_boost_union/courseheaderheading';
+        $title = get_string('courseheaderheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Display the course image in the course header.
+        $name = 'theme_boost_union/courseheaderimageenabled';
+        $title = get_string('courseheaderimageenabled', 'theme_boost_union', null, true);
+        $description = get_string('courseheaderimageenabled_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Setting: Fallback course header image.
+        $name = 'theme_boost_union/courseheaderimagefallback';
+        $title = get_string('courseheaderimagefallback', 'theme_boost_union', null, true);
+        $description = get_string('courseheaderimagefallback_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configstoredfile($name, $title, $description, 'courseheaderimagefallback', 0,
+                array('maxfiles' => 1, 'accepted_types' => 'web_image'));
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/courseheaderimagefallback', 'theme_boost_union/courseheaderimageenabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+        // Setting: Course header image layout.
+        $name = 'theme_boost_union/courseheaderimagelayout';
+        $title = get_string('courseheaderimagelayout', 'theme_boost_union', null, true);
+        $description = get_string('courseheaderimagelayout_desc', 'theme_boost_union', null, true);
+        $courseheaderimagelayoutoptions = array(
+                THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_STACKEDDARK =>
+                        get_string('courseheaderimagelayoutstackeddark', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_STACKEDLIGHT =>
+                        get_string('courseheaderimagelayoutstackedlight', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_HEADINGABOVE =>
+                        get_string('courseheaderimagelayoutheadingabove', 'theme_boost_union'));
+        $setting = new admin_setting_configselect($name, $title, $description,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_HEADINGABOVE, $courseheaderimagelayoutoptions);
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/courseheaderimagelayout', 'theme_boost_union/courseheaderimageenabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+        // Setting: Course header image height.
+        $name = 'theme_boost_union/courseheaderimageheight';
+        $title = get_string('courseheaderimageheight', 'theme_boost_union', null, true);
+        $description = get_string('courseheaderimageheight_desc', 'theme_boost_union', null, true);
+        $courseheaderimageheightoptions = array(
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_100PX => THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_100PX,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_150PX => THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_150PX,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_200PX => THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_200PX,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_250PX => THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_250PX);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_COURSEIMAGEHEIGHT_150PX,
+                $courseheaderimageheightoptions);
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/courseheaderimageheight', 'theme_boost_union/courseheaderimageenabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+        // Setting: Course header image position.
+        $name = 'theme_boost_union/courseheaderimageposition';
+        $title = get_string('courseheaderimageposition', 'theme_boost_union', null, true);
+        $description = get_string('courseheaderimageposition_desc', 'theme_boost_union', null, true);
+        $courseheaderimagepositionoptions = array(
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_CENTER =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_CENTER,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_TOP =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_TOP,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_BOTTOM,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_TOP =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_TOP,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_CENTER =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_CENTER,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_LEFT_BOTTOM,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_TOP =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_TOP,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_CENTER =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_CENTER,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_RIGHT_BOTTOM);
+        $setting = new admin_setting_configselect($name, $title, $description,
+                THEME_BOOST_UNION_SETTING_COURSEIMAGEPOSITION_CENTER_CENTER, $courseheaderimagepositionoptions);
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/courseheaderimageposition', 'theme_boost_union/courseheaderimageenabled', 'neq',
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
         // Create E_Mail branding tab.
         $tab = new admin_settingpage('theme_boost_union_look_emailbranding',
                 get_string('emailbrandingtab', 'theme_boost_union', null, true));

--- a/templates/core/full_header.mustache
+++ b/templates/core/full_header.mustache
@@ -1,0 +1,132 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/full_header
+
+    This template renders the header.
+
+    Example context (json):
+    {
+        "contextheader": "context_header_html",
+        "settingsmenu": "settings_html",
+        "hasnavbar": false,
+        "navbar": "navbar_if_available",
+        "courseheader": "course_header_html",
+        "welcomemessage": "welcomemessage"
+        "courseheaderimageurl": "http://localhost/boostunionmoodle/pluginfile.php/14/course/overviewfiles/ex.png"
+    }
+}}
+{{!
+    This template overwrites the core/full_header template in the theme
+
+    Modifications compared to this template:
+    * Include a course header image
+      For the sake of readability and as the course header image feature has multiple layout options,
+      the HTML snippets for the course header have been duplicated in this template to cover each layout separately.
+      The selection algorithmn goes like this:
+      -> Do we have a welcome message?
+         -> Yes: Show the course header just like Moodle core does.
+         -> No: Do we have a course header image URL?
+            -> No: Show the course header just like Moodle core does.
+            -> Yes: Do we have to show the course heading above the course header image?
+               -> Yes: Show the course header like Moodle core does and add the #courseheaderimage element below it.
+               -> No: Wrap the course header of Moodle core in a #courseheaderimage element and add the configured
+                      stacked layout class to it.
+}}
+<header id="page-header" class="header-maxwidth d-print-none">
+    <div class="w-100">
+        <div class="d-flex flex-wrap">
+            {{#hasnavbar}}
+            <div id="page-navbar">
+                {{{navbar}}}
+            </div>
+            {{/hasnavbar}}
+            <div class="ml-auto d-flex">
+                {{{pageheadingbutton}}}
+            </div>
+            <div id="course-header">
+                {{{courseheader}}}
+            </div>
+        </div>
+        {{#welcomemessage}}
+            <div class="d-flex align-items-center">
+                {{> core/welcome }}
+                <div class="header-actions-container ml-auto" data-region="header-actions-container">
+                    {{#headeractions}}
+                        <div class="header-action ml-2">{{{.}}}</div>
+                    {{/headeractions}}
+                </div>
+            </div>
+        {{/welcomemessage}}
+        {{^welcomemessage}}
+            {{^courseheaderimageurl}}
+                <div class="d-flex align-items-center">
+                    {{#contextheader}}
+                        <div class="mr-auto">
+                            {{{contextheader}}}
+                        </div>
+                    {{/contextheader}}
+                    <div class="header-actions-container ml-auto" data-region="header-actions-container">
+                        {{#headeractions}}
+                            <div class="header-action ml-2">{{{.}}}</div>
+                        {{/headeractions}}
+                    </div>
+                </div>
+            {{/courseheaderimageurl}}
+            {{#courseheaderimageurl}}
+                {{#courseheaderimagelayoutheadingabove}}
+                    <div class="d-flex align-items-center">
+                        {{#contextheader}}
+                            <div class="mr-auto">
+                                {{{contextheader}}}
+                            </div>
+                        {{/contextheader}}
+                        <div class="header-actions-container ml-auto" data-region="header-actions-container">
+                            {{#headeractions}}
+                                <div class="header-action ml-2">{{{.}}}</div>
+                            {{/headeractions}}
+                        </div>
+                    </div>
+                    <div id="courseheaderimage" class="p-3 mb-3"
+                         style="background-image: url('{{{courseheaderimageurl}}}');
+                             {{#courseheaderimageheight}}min-height: {{{.}}};{{/courseheaderimageheight}}
+                             {{#courseheaderimageposition}}background-position: {{{.}}};{{/courseheaderimageposition}}">
+                    </div>
+                {{/courseheaderimagelayoutheadingabove}}
+                {{^courseheaderimagelayoutheadingabove}}
+                    <div id="courseheaderimage" class="p-3 mb-3 {{#courseheaderimagelayoutstackedclass}}courseheaderimage-{{{.}}}{{/courseheaderimagelayoutstackedclass}}"
+                            style="background-image: url('{{{courseheaderimageurl}}}');
+                                    {{#courseheaderimageheight}}min-height: {{{.}}};{{/courseheaderimageheight}}
+                                    {{#courseheaderimageposition}}background-position: {{{.}}};{{/courseheaderimageposition}}">
+                        <div class="d-flex align-items-center">
+                            {{#contextheader}}
+                                <div class="mr-auto">
+                                    {{{contextheader}}}
+                                </div>
+                            {{/contextheader}}
+                            <div class="header-actions-container ml-auto" data-region="header-actions-container">
+                                {{#headeractions}}
+                                    <div class="header-action ml-2">{{{.}}}</div>
+                                {{/headeractions}}
+                            </div>
+                        </div>
+                    </div>
+                {{/courseheaderimagelayoutheadingabove}}
+            {{/courseheaderimageurl}}
+        {{/welcomemessage}}
+    </div>
+</header>

--- a/templates/core/full_header.mustache.upstream
+++ b/templates/core/full_header.mustache.upstream
@@ -1,0 +1,63 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/full_header
+
+    This template renders the header.
+
+    Example context (json):
+    {
+        "contextheader": "context_header_html",
+        "settingsmenu": "settings_html",
+        "hasnavbar": false,
+        "navbar": "navbar_if_available",
+        "courseheader": "course_header_html",
+        "welcomemessage": "welcomemessage"
+    }
+}}
+<header id="page-header" class="header-maxwidth d-print-none">
+    <div class="w-100">
+        <div class="d-flex flex-wrap">
+            {{#hasnavbar}}
+            <div id="page-navbar">
+                {{{navbar}}}
+            </div>
+            {{/hasnavbar}}
+            <div class="ml-auto d-flex">
+                {{{pageheadingbutton}}}
+            </div>
+            <div id="course-header">
+                {{{courseheader}}}
+            </div>
+        </div>
+        <div class="d-flex align-items-center">
+            {{^welcomemessage}}
+                {{#contextheader}}
+                    <div class="mr-auto">
+                        {{{contextheader}}}
+                    </div>
+                {{/contextheader}}
+            {{/welcomemessage}}
+            {{> core/welcome }}
+            <div class="header-actions-container ml-auto" data-region="header-actions-container">
+                {{#headeractions}}
+                    <div class="header-action ml-2">{{{.}}}</div>
+                {{/headeractions}}
+            </div>
+        </div>
+    </div>
+</header>

--- a/tests/behat/theme_boost_union_looksettings_course.feature
+++ b/tests/behat/theme_boost_union_looksettings_course.feature
@@ -1,0 +1,247 @@
+@theme @theme_boost_union @theme_boost_union_looksettings @theme_boost_union_looksettings_course
+Feature: Configuring the theme_boost_union plugin for the "Course" tab on the "Look" page
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+  Background:
+    Given the following "users" exist:
+      | username |
+      | student1 |
+      | teacher1 |
+    And the following "courses" exist:
+      | fullname | shortname |
+      | Course 1 | C1        |
+      | Course 2 | C2        |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | teacher1 | C2     | editingteacher |
+      | student1 | C1     | student        |
+      | student1 | C2     | student        |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Display the course header image with the course image if course header images are enabled and an image is uploaded in the course.
+    Given the following config values are set as admin:
+      | config                   | value | plugin            |
+      | courseheaderimageenabled | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I click on "Settings" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Course image" filemanager
+    And I press "Save and display"
+    And I am on site homepage
+    And I log out
+    And I am on site homepage
+    And I follow "Log in"
+    And I log in as "<role>"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, '/course/overviewfiles/login_bg1.jpg')]" "xpath_element" should exist
+
+    Examples:
+      | role      |
+      | student1  |
+      | teacher1  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Do not display the course header image if course header images are enabled but an image is not uploaded in the course.
+    Given the following config values are set as admin:
+      | config                   | value | plugin            |
+      | courseheaderimageenabled | yes   | theme_boost_union |
+    When I log in as "<role>"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should not exist
+
+    Examples:
+      | role      |
+      | student1  |
+      | teacher1  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Do not display the course header image if course header images are disabled regardless if an image is uploaded in the course.
+    Given the following config values are set as admin:
+      | config                   | value | plugin            |
+      | courseheaderimageenabled | no    | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I click on "Settings" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Course image" filemanager
+    And I press "Save and display"
+    And I am on site homepage
+    And I log out
+    And I am on site homepage
+    And I follow "Log in"
+    And I log in as "<role>"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should not exist
+
+    Examples:
+      | role      |
+      | student1  |
+      | teacher1  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Display the course header image with the fallback image if course header images are enabled but an image is not uploaded in the course.
+    Given the following config values are set as admin:
+      | config                   | value | plugin            |
+      | courseheaderimageenabled | yes   | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Course" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I upload "theme/boost_union/tests/fixtures/login_bg2.jpg" file to "Fallback course header image" filemanager
+    And I press "Save changes"
+    And I am on site homepage
+    And I log out
+    And I am on site homepage
+    And I follow "Log in"
+    And I log in as "<role>"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, '1/theme_boost_union/courseheaderimagefallback/0/login_bg2.jpg')]" "xpath_element" should exist
+
+    Examples:
+      | role      |
+      | student1  |
+      | teacher1  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Display the course header image with the fallback image until a course image is uploaded.
+    Given the following config values are set as admin:
+      | config                   | value | plugin            |
+      | courseheaderimageenabled | yes   | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Course" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I upload "theme/boost_union/tests/fixtures/login_bg2.jpg" file to "Fallback course header image" filemanager
+    And I press "Save changes"
+    And I am on site homepage
+    And I log out
+    And I am on site homepage
+    And I follow "Log in"
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, '1/theme_boost_union/courseheaderimagefallback/0/login_bg2.jpg')]" "xpath_element" should exist
+    And I click on "Settings" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Course image" filemanager
+    And I press "Save and display"
+    And I am on site homepage
+    And I log out
+    And I am on site homepage
+    And I follow "Log in"
+    And I log in as "<role>"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, '1/theme_boost_union/courseheaderimagefallback/0/login_bg2.jpg')]" "xpath_element" should not exist
+    And "//div[@id='courseheaderimage' and contains(@style, '/course/overviewfiles/login_bg1.jpg')]" "xpath_element" should exist
+
+    Examples:
+      | role      |
+      | student1  |
+      | teacher1  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Display the course header image with the image of the current course.
+    Given the following config values are set as admin:
+      | config                   | value | plugin            |
+      | courseheaderimageenabled | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I click on "Settings" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Course image" filemanager
+    And I press "Save and display"
+    And I am on "Course 2" course homepage
+    And I click on "Settings" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg2.jpg" file to "Course image" filemanager
+    And I press "Save and display"
+    And I am on site homepage
+    And I log out
+    And I am on site homepage
+    And I follow "Log in"
+    And I log in as "<role>"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, '/course/overviewfiles/login_bg1.jpg')]" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, '/course/overviewfiles/login_bg2.jpg')]" "xpath_element" should not exist
+    And I am on "Course 2" course homepage
+    And "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, '/course/overviewfiles/login_bg1.jpg')]" "xpath_element" should not exist
+    And "//div[@id='courseheaderimage' and contains(@style, '/course/overviewfiles/login_bg2.jpg')]" "xpath_element" should exist
+
+    Examples:
+      | role      |
+      | student1  |
+      | teacher1  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Define the course header image (min-)height.
+    Given the following config values are set as admin:
+      | config                   | value    | plugin            |
+      | courseheaderimageenabled | yes      | theme_boost_union |
+      | courseheaderimageheight  | <height> | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I click on "Settings" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Course image" filemanager
+    And I press "Save and display"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, 'min-height: <height>')]" "xpath_element" should exist
+
+    Examples:
+      | height |
+      | 100px  |
+      | 150px  |
+      | 200px  |
+      | 250px  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Define the course header image position.
+    Given the following config values are set as admin:
+      | config                    | value      | plugin            |
+      | courseheaderimageenabled  | yes        | theme_boost_union |
+      | courseheaderimageposition | <position> | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I click on "Settings" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Course image" filemanager
+    And I press "Save and display"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "//div[@id='courseheaderimage' and contains(@style, 'background-position: <position>')]" "xpath_element" should exist
+
+    Examples:
+      | position      |
+      | center center |
+      | center top    |
+      | center bottom |
+      | left center   |
+      | left top      |
+      | left bottom   |
+      | right center  |
+      | right top     |
+      | right bottom  |
+
+  @javascript @_file_upload
+  Scenario Outline: Setting: Course header image - Define the course header image layout.
+    Given the following config values are set as admin:
+      | config                   | value    | plugin            |
+      | courseheaderimageenabled | yes      | theme_boost_union |
+      | courseheaderimagelayout  | <layout> | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I click on "Settings" "link"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Course image" filemanager
+    And I press "Save and display"
+    And I am on "Course 1" course homepage
+    Then "//div[@id='courseheaderimage']" "xpath_element" should exist
+    And "<elementshouldexist>" "css_element" should exist in the "#page-header" "css_element"
+    And "<elementshouldnotexist1>" "css_element" should not exist in the "#page-header" "css_element"
+    And "<elementshouldnotexist2>" "css_element" should not exist in the "#page-header" "css_element"
+
+    Examples:
+      | layout       | elementshouldexist                                 | elementshouldnotexist1                             | elementshouldnotexist2                     |
+      | stackeddark  | #courseheaderimage.courseheaderimage-dark          | div.d-flex.align-items-center + #courseheaderimage | #courseheaderimage.courseheaderimage-light |
+      | stackedlight | #courseheaderimage.courseheaderimage-light         | div.d-flex.align-items-center + #courseheaderimage | #courseheaderimage.courseheaderimage-dark  |
+      | headingabove | div.d-flex.align-items-center + #courseheaderimage | #courseheaderimage.courseheaderimage-dark          | #courseheaderimage.courseheaderimage-light |

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2022080916;
+$plugin->version = 2022080917;
 $plugin->release = 'v4.0-r8';
 $plugin->requires = 2022041900;
 $plugin->supported = [400, 400];


### PR DESCRIPTION
#77 and #138 discuss design changes for the course layout.
For this pull request, the following Features will be implemented:

- There is an admin setting which can enable or disable showing course images in the header of the course page
- There is an admin setting where a default course image can be uploaded, which is shown in case the course does not have an image.