### PR TITLE
Feature: Allow right-side blocks drawer of the home-page to be extended by default, closes #169

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,14 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2023-04-12 - Feature: Allow right-side blocks drawer of site home to be extended by default #169.
+
 ### v4.1-r6
 
 * 2023-03-22 - Feature: Allow admin to provide several additional block regions, solves #30.
-               Please note: This is a comparably large addition. If you encounter any issues with this feature, please report it on https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues.
+               Please note: This is a comparably large addition. If you encounter any issues with this feature, please report it on <https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues>.
 * 2023-03-20 - Improvement: Don't force child themes to reimplement various color settings (e.g. 'brandcolor'), solves #260.
 * 2023-03-17 - Improvement: Reduce code duplication when child theming by checking theme ancestry in theme_boost_union_before_standard_html_head, solves #245.
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,19 @@ With this setting, you can set the width of the 'Outside (bottom)' block region 
 ###### Outside regions horizontal placement
 
 With this setting, you can control if, on larger screens, the 'Outside (left)' and 'Outside (right)' block regions should be placed near the main content area or rather near the window edges.
+##### Site home right-hand block drawer
+
+###### Show right-hand block drawer of site home on visit
+
+With this setting, the right-hand block drawer of site home will be displayed in its expanded state by default. This only applies to users who are not logged in and does not overwrite the toggle state of each individual user.
+
+###### Show right-hand block drawer of site home on first login
+
+With this setting, the right-hand block drawer of site home will be displayed in its expanded state by default. This only applies to users who log in for the very first time and does not overwrite the toggle state of each individual user.
+
+###### Show right-hand block drawer of site home on guest login
+
+With this setting, the right-hand block drawer of site home will be displayed in its expanded state by default. This only applies to users who log in as a guest.
 
 #### Tab "Miscellaneous"
 

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -643,6 +643,18 @@ $string['tileordersetting_desc'] = 'With this setting, you define the order posi
 $string['tiletitlesetting'] = 'Advertisement tile {$a->no} title';
 $string['tiletitlesetting_desc'] = 'Here, you enter the title which should be displayed in the advertisement tile {$a->no}. This is an optional setting, the advertisement tile will be shown even if you do not set a title.';
 
+// ... Section: Site home right-hand block drawer behaviour.
+$string['sitehomerighthandblockdrawerbehaviour'] = 'Site home right-hand block drawer';
+// ... ... Setting: Show site home right-hand blocks drawer on visit setting.
+$string['showsitehomerighthandblockdraweronvisitsetting'] = 'Show right-hand block drawer of site home on visit';
+$string['showsitehomerighthandblockdraweronvisitsetting_desc'] = 'With this setting, the right-hand block drawer of site home will be displayed in its expanded state by default. This only applies to users who are not logged in and does not overwrite the toggle state of each individual user.';
+// ... ... Setting: Show site home right-hand block drawer on first login setting.
+$string['showsitehomerighthandblockdraweronfirstloginsetting'] = 'Show right-hand block drawer of site home on first login';
+$string['showsitehomerighthandblockdraweronfirstloginsetting_desc'] = 'With this setting, the right-hand block drawer of site home will be displayed in its expanded state by default. This only applies to users who log in for the very first time and does not overwrite the toggle state of each individual user.';
+// ... ... Setting: Show site home right-hand block drawer on guest login setting.
+$string['showsitehomerighthandblockdraweronguestloginsetting'] = 'Show right-hand block drawer of site home on guest login';
+$string['showsitehomerighthandblockdraweronguestloginsetting_desc'] = 'With this setting, the right-hand block drawer of site home will be displayed in its expanded state by default. This only applies to users who log in as a guest.';
+
 // Privacy API.
 $string['privacy:metadata'] = 'The Boost Union theme does not store any personal data about any user.';
 

--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -60,14 +60,38 @@ user_preference_allow_ajax_update('drawer-open-block', PARAM_BOOL);
 
 if (isloggedin()) {
     $courseindexopen = (get_user_preferences('drawer-open-index', true) == true);
-    $blockdraweropen = (get_user_preferences('drawer-open-block') == true);
+
+    if (isguestuser()) {
+        $sitehomerighthandblockdrawerserverconfig = get_config('theme_boost_union', 'showsitehomerighthandblockdraweronguestlogin');
+    } else {
+        $sitehomerighthandblockdrawerserverconfig = get_config('theme_boost_union', 'showsitehomerighthandblockdraweronfirstlogin');
+    }
+
+    $isadminsettingyes = ($sitehomerighthandblockdrawerserverconfig == THEME_BOOST_UNION_SETTING_SELECT_YES);
+    $blockdraweropen = (get_user_preferences('drawer-open-block', $isadminsettingyes)) == true;
 } else {
     $courseindexopen = false;
     $blockdraweropen = false;
+
+    if (get_config('theme_boost_union', 'showsitehomerighthandblockdraweronvisit') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+        $blockdraweropen = true;
+    }
 }
 
 if (defined('BEHAT_SITE_RUNNING')) {
-    $blockdraweropen = true;
+    try {
+        if (
+            get_config('theme_boost_union', 'showsitehomerighthandblockdraweronvisit') === false &&
+            get_config('theme_boost_union', 'showsitehomerighthandblockdraweronguestlogin') === false &&
+            get_config('theme_boost_union', 'showsitehomerighthandblockdraweronfirstlogin') === false
+        ) {
+            $blockdraweropen = true;
+        }
+    } catch (Exception $e) {
+        echo $e->getMessage();
+
+        $blockdraweropen = true;
+    }
 }
 
 $extraclasses = ['uses-drawers'];

--- a/settings.php
+++ b/settings.php
@@ -1170,6 +1170,31 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $description = get_string('outsideregionsplacement_desc', 'theme_boost_union', null, true);
         $setting = new admin_setting_configselect($name, $title, $description,
                 THEME_BOOST_UNION_SETTING_OUTSIDEREGIONSPLACEMENT_NEXTMAINCONTENT, $outsideregionsplacementoptions);
+        // Creat site home right-hand blocks drawer behaviour heading.
+        $name = 'theme_boost_union/sitehomerighthandblockdrawerbehaviour';
+        $title = get_string('sitehomerighthandblockdrawerbehaviour', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Show site home right-hand blocks drawer when logged out users visit.
+        $name = 'theme_boost_union/showsitehomerighthandblockdraweronvisit';
+        $title = get_string('showsitehomerighthandblockdraweronvisitsetting', 'theme_boost_union', null, true);
+        $description = get_string('showsitehomerighthandblockdraweronvisitsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Setting: Show site home right-hand blocks drawer when user logs in for the very first time.
+        $name = 'theme_boost_union/showsitehomerighthandblockdraweronfirstlogin';
+        $title = get_string('showsitehomerighthandblockdraweronfirstloginsetting', 'theme_boost_union', null, true);
+        $description = get_string('showsitehomerighthandblockdraweronfirstloginsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Setting: Show site home right-hand blocks drawer when user logs in as guest.
+        $name = 'theme_boost_union/showsitehomerighthandblockdraweronguestlogin';
+        $title = get_string('showsitehomerighthandblockdraweronguestloginsetting', 'theme_boost_union', null, true);
+        $description = get_string('showsitehomerighthandblockdraweronguestloginsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
 
         // Add tab to settings page.

--- a/tests/behat/theme_boost_union_feelsettings_blocks.feature
+++ b/tests/behat/theme_boost_union_feelsettings_blocks.feature
@@ -487,3 +487,109 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     And "#page-content" "css_element" should appear before "#theme-block-region-content-lower" "css_element"
     And "#theme-block-region-footer-left" "css_element" should appear before "#theme-block-region-footer-center" "css_element"
     And "#theme-block-region-footer-center" "css_element" should appear before "#theme-block-region-footer-right" "css_element"
+
+  Scenario: Test-Scenario 1.1: When the "showsitehomerighthandblockdraweronfirstlogin" setting is set to "yes" and I log in as a user for the first time I should see the drawer and the containing text block
+    Given the following config values are set as admin:
+      | config                               | value | plugin            |
+      | showsitehomerighthandblockdraweronfirstlogin | yes   | theme_boost_union |
+    And I log in as "admin"
+    And I am on site homepage
+    And I turn editing mode on
+    And I add the "Text" block
+    And I configure the "(new text block)" block
+    And I set the following fields to these values:
+      | Text block title | Text on all pages            |
+      | Content          | This is visible on all pages |
+    And I press "Save changes"
+    And I log out
+    When I log in as "student1"
+    And I am on site homepage
+    Then the "class" attribute of ".drawer-right" "css_element" should contain "show"
+
+  Scenario: Test-Scenario 1.2: When the "showsitehomerighthandblockdraweronfirstlogin" setting is set to "no" and I log in as a user for the first time I should not see the drawer and the containing text block
+    Given the following config values are set as admin:
+      | config                               | value | plugin            |
+      | showsitehomerighthandblockdraweronfirstlogin | no    | theme_boost_union |
+    And I log in as "admin"
+    And I am on site homepage
+    And I turn editing mode on
+    And I add the "Text" block
+    And I configure the "(new text block)" block
+    And I set the following fields to these values:
+      | Text block title | Text on all pages            |
+      | Content          | This is visible on all pages |
+    And I press "Save changes"
+    And I log out
+    When I log in as "student1"
+    And I am on site homepage
+    Then the "class" attribute of ".drawer-right" "css_element" should not contain "show"
+
+  Scenario: Test-Scenario 2.1: When the "showsitehomerighthandblockdraweronvisit" setting is set to "yes" and I visit the site I should see the drawer and the containing text block
+    Given the following config values are set as admin:
+      | config                          | value | plugin            |
+      | showsitehomerighthandblockdraweronvisit | yes   | theme_boost_union |
+    And I log in as "admin"
+    And I am on site homepage
+    And I turn editing mode on
+    And I add the "Text" block
+    And I configure the "(new text block)" block
+    And I set the following fields to these values:
+      | Text block title | Text on all pages            |
+      | Content          | This is visible on all pages |
+    And I press "Save changes"
+    And I log out
+    When I am on site homepage
+    Then the "class" attribute of ".drawer-right" "css_element" should contain "show"
+
+  Scenario: Test-Scenario 2.2: When the "showsitehomerighthandblockdraweronvisit" setting is set to "no" and I visit the site I should not see the drawer and the containing text block
+    Given the following config values are set as admin:
+      | config                          | value | plugin            |
+      | showsitehomerighthandblockdraweronvisit | no    | theme_boost_union |
+    And I log in as "admin"
+    And I am on site homepage
+    And I turn editing mode on
+    And I add the "Text" block
+    And I configure the "(new text block)" block
+    And I set the following fields to these values:
+      | Text block title | Text on all pages            |
+      | Content          | This is visible on all pages |
+    And I press "Save changes"
+    And I log out
+    When I am on site homepage
+    Then the "class" attribute of ".drawer-right" "css_element" should not contain "show"
+
+  Scenario: Test-Scenario 3.1: When the "showsitehomerighthandblockdraweronguestlogin" setting is set to "yes" and I log in as a guest I should see the drawer and the containing text block
+    Given the following config values are set as admin:
+      | config                               | value | plugin            |
+      | showsitehomerighthandblockdraweronguestlogin | yes   | theme_boost_union |
+    And I log in as "admin"
+    And I am on site homepage
+    And I turn editing mode on
+    And I add the "Text" block
+    And I configure the "(new text block)" block
+    And I set the following fields to these values:
+      | Text block title | Text on all pages            |
+      | Content          | This is visible on all pages |
+    And I press "Save changes"
+    And I log out
+    When I log in as "guest"
+    And I am on site homepage
+    Then the "class" attribute of ".drawer-right" "css_element" should contain "show"
+
+  Scenario: Test-Scenario 3.2: When the "showsitehomerighthandblockdraweronguestlogin" setting is set to "no" and I log in as a guest I should not see the drawer and the containing text block
+    Given the following config values are set as admin:
+      | config                               | value | plugin            |
+      | showsitehomerighthandblockdraweronguestlogin | no    | theme_boost_union |
+    And I log in as "admin"
+    And I am on site homepage
+    And I turn editing mode on
+    And I add the "Text" block
+    And I configure the "(new text block)" block
+    And I set the following fields to these values:
+      | Text block title | Text on all pages            |
+      | Content          | This is visible on all pages |
+    And I press "Save changes"
+    And I log out
+    When I log in as "guest"
+    And I am on site homepage
+    Then the "class" attribute of ".drawer-right" "css_element" should not contain "show"


### PR DESCRIPTION
This PR adds the following functionality to boost_union:
- Added section "Right-hand block drawer" to "Feel -> Blocks" admin settings
- Added functionality: configure right-hand block drawer to be shown on the frontpage without being logged in
- Added functionality: configure right-hand block drawer to be shown on a users first login
- Added functionality: configure right-hand block drawer to be shown for guest users

All changes to the right-hand block drawer behaviour do not impact the state management for users who have interacted with the open/closed state.