### PR TITLE
Bugfix: Improve card header and footer of advertisement tiles with background images, solves #232

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-03-05 - Bugfix: Improve card header and footer of advertisement tiles with background images, solves #232.
 * 2023-03-01 - Tests: Updated Moodle Plugin CI to use PHP 8.1 and Postgres 13 from Moodle 4.1 on.
 * 2023-02-12 - Feature: Allow admin to change the navbar color, solves #39, helps to resolve #110.
 

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -372,6 +372,7 @@ body.pagelayout-login:not(.loginbackgroundimage) #footnote {
     margin-bottom: 0;
 }
 
+
 /*=======================================
  * Settings: Content -> Advertisement tiles.
  ======================================*/
@@ -390,6 +391,22 @@ body.pagelayout-login:not(.loginbackgroundimage) #footnote {
     /* d-flex align-items-stretch align-self-stretch classes in mustache template require to set width to inherit
        (Otherwise width is flexible dependent on content). */
     width: inherit;
+}
+
+/* Improve the advertisement tile card if a background image is used. */
+.themeboostunionadvtilebg {
+    /* Remove the 1px border which is added around the card by default and which looks strange
+       with a background image. */
+    border: none;
+
+    /* Add a more solid background color so that the title remains readable. */
+    .card-header {
+        background-color: rgb(255, 255, 255, .8);
+    }
+    /* Remove the border-top from the footer. */
+    .card-footer {
+        border-top: none;
+    }
 }
 
 

--- a/templates/advertisementtiles.mustache
+++ b/templates/advertisementtiles.mustache
@@ -66,7 +66,7 @@
     <div class="row">
         {{#advtiles}}
         <div id="themeboostunionadvtile{{no}}" class="themeboostunionadvtile {{advtileslayoutclass}} d-flex align-items-stretch align-self-stretch py-3">
-            <div class="transparent-bg card"
+            <div class="transparent-bg card {{#backgroundimageurl}}themeboostunionadvtilebg{{/backgroundimageurl}}"
                 style="{{#backgroundimageurl}}background-image: url('{{{backgroundimageurl}}}');{{/backgroundimageurl}}
                         {{#backgroundimageposition}}background-position: {{{.}}};{{/backgroundimageposition}}
                         {{#tileheight}}min-height: {{{.}}};{{/tileheight}}">


### PR DESCRIPTION
This PR realizes the look which has been posted in #232 