### PR TITLE
#242 - removed editor_scss config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-03-15 - Bugfix: $THEME->editor_scss referenced a non-existing sheet. Setting it also ignored Boost's sheets. This solves #242.
 * 2023-03-18 - Bugfix: Fix wrong rgba color definition for advertisement tile backgrounds, solves #244.
 
 ### v4.1-r4

--- a/config.php
+++ b/config.php
@@ -27,7 +27,6 @@ defined('MOODLE_INTERNAL') || die();
 $THEME->name = 'boost_union';
 $THEME->sheets = [];
 $THEME->editor_sheets = [];
-$THEME->editor_scss = ['editor'];
 $THEME->usefallback = true;
 $THEME->scss = function($theme) {
     return theme_boost_union_get_main_scss_content($theme);


### PR DESCRIPTION
boost_union doesn't provide any editor.scss. By setting it, it unnecessarily blocks boost's own editor.scss inclusion.