### PR TITLE
#247 - reduce settings duplication for child theming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-03-17 - Improvement: Don't force child themes to reimplement settings 'loginformposition' and 'loginformtransparency', solves #247.
 * 2023-03-15 - Bugfix: $THEME->editor_scss referenced a non-existing sheet. Setting it also ignored Boost's sheets. This solves #242.
 * 2023-03-18 - Bugfix: Fix wrong rgba color definition for advertisement tile backgrounds, solves #244.
 

--- a/layout/login.php
+++ b/layout/login.php
@@ -42,9 +42,9 @@ $templatecontext = [
     'bodyattributes' => $bodyattributes,
     'loginbackgroundimagetext' => $loginbackgroundimagetext,
     'loginbackgroundimagetextcolor' => $loginbackgroundimagetextcolor,
-    'loginwrapperclass' => 'login-wrapper-'.$this->page->theme->settings->loginformposition,
+    'loginwrapperclass' => 'login-wrapper-'.get_config('theme_boost_union','loginformposition'),
     'logincontainerclass' =>
-            ($this->page->theme->settings->loginformtransparency == THEME_BOOST_UNION_SETTING_SELECT_YES) ?
+            (get_config('theme_boost_union','loginformtransparency') == THEME_BOOST_UNION_SETTING_SELECT_YES) ?
                     'login-container-80t' : ''
 ];
 


### PR DESCRIPTION
login.php explicitly used the current theme's settings to check for 'loginformposition' and 'loginformtransparency'. Using Boost Union's configuration doesn't require child themers to reimplement those settings.