### PR TITLE
#249 - draft: don't force settings duplication, but allow it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ moodle-theme_boost_union
 Changes
 -------
 
+* 2023-03-17 - Improvement: Do not force child themes to copy theme settings, but allow it.
+
 ### v4.1-r4
 
 * 2023-03-06 - Bugfix: Align the search bar with the dark navbar look, solves #234.

--- a/locallib.php
+++ b/locallib.php
@@ -1313,3 +1313,20 @@ function theme_boost_union_set_mobilecss_url() {
         set_config('mobilecssurl', '');
     }
 }
+
+/**
+ * Checks if the current theme (Boost Union or a child theme of it) has the requested setting.
+ * If it does, returns that setting's value.
+ * If it doesn't, returns the value of Boost Union's setting.
+ * @param string $setting - Name of the setting
+ * @return mixed
+ */
+function theme_boost_union_get_setting(string $setting) {
+    global $PAGE;
+    if ($PAGE->theme->settings->{$setting}) {
+        $value = $PAGE->theme->settings->{$setting};
+    } else {
+        $value = get_config('theme_boost_union', $setting);
+    }
+    return $value;
+}


### PR DESCRIPTION
Added a method that allows child themes to duplicate boost union settings, but doesn't force them to do so, in case child themes want to just reuse boost union's configuration