### PR TITLE
#262 - Use get_config in get_main_scss_content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2023-03-20 - Improvement: More consistency by using get_config in theme_boost_union_get_main_scss_content, solves #262.
+
 ### v4.1-r5
 
 * 2023-03-19 - Bugfix: Fully support multilang strings in advertisement tiles, solves #258.

--- a/lib.php
+++ b/lib.php
@@ -96,7 +96,8 @@ function theme_boost_union_get_main_scss_content($theme) {
     global $CFG;
 
     $scss = '';
-    $filename = !empty($theme->settings->preset) ? $theme->settings->preset : null;
+    $preset = get_config('theme_boost_union', 'preset');
+    $filename = !empty($preset) ? $preset : null;
     $fs = get_file_storage();
 
     $context = context_system::instance();


### PR DESCRIPTION
To be consistent across Boost Union, the final instances of $theme->settings are changed to get_config() calls.