### PR TITLE
Bugfix: CSS property name is meant, not a value, solves #271

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2023-04-04 - Bugfix: Take a css property name instead of its value, solves #271.
+
 ### v4.1-r6
 
 * 2023-03-22 - Feature: Allow admin to provide several additional block regions, solves #30.

--- a/lib.php
+++ b/lib.php
@@ -200,10 +200,10 @@ function theme_boost_union_get_pre_scss($theme) {
 
     // Set custom Boost Union SCSS variables.
     if (get_config('theme_boost_union', 'blockregionoutsideleftwidth')) {
-        $scss .= '$blockregionoutsideleftwidth: '.get_config('theme_boost_union', 'blockregionoutsideleftwidth').";\n";
+        $scss .= 'blockregionoutsideleftwidth: '.get_config('theme_boost_union', 'blockregionoutsideleftwidth').";\n";
     }
     if (get_config('theme_boost_union', 'blockregionoutsiderightwidth')) {
-        $scss .= '$blockregionoutsiderightwidth: '.get_config('theme_boost_union', 'blockregionoutsiderightwidth').
+        $scss .= 'blockregionoutsiderightwidth: '.get_config('theme_boost_union', 'blockregionoutsiderightwidth').
                 ";\n";
     }
 


### PR DESCRIPTION
That gave me a headache for some days when I was playing with a theme cloned from boost_union.