### PR TITLE
Improvement: Improve SCSS for dark navbar and primary color navbar, solves #273.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-05-17 - Improvement: Improve SCSS for dark navbar and primary color navbar, solves #273.
 * 2023-05-11 - Feature: Allow the admin to upload custom icons for activities and resources, solves #175.
 
 ### v4.1-r7

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -112,6 +112,20 @@
     .login a:hover {
         color: $white;
     }
+
+    /* Change the color of the notification action buttons to dark grey.
+       This has to use !important as Moodle core already uses !important for the icon colors. */
+    .popover-region-container a .icon {
+        color: #343a40 !important; /* stylelint-disable-line declaration-no-important */
+    }
+
+    /* Change the color of the language selector link in the navbar to a light grey and to white when hovered. */
+    .langmenu .dropdown .dropdown-toggle {
+        color: #c8c8c8;
+        &:hover {
+            color: $white;
+        }
+    }
 }
 
 /* Tweak the dark navbar with light font color a little bit more. */
@@ -132,6 +146,17 @@
     /* Change the background color of the search panel in the navbar. */
     #searchform-navbar {
         background-color: #343a40;
+    }
+
+    /* Change the color of the language selector drop down items when hovered, focused and active to dark grey
+       as this would be presented in the primary color otherwise. */
+    .langmenu {
+        .dropdown-item:active,
+        .dropdown-item:hover,
+        .dropdown-item:focus,
+        .dropdown-item:focus-within {
+            background-color: $dark;
+        }
     }
 }
 
@@ -154,14 +179,26 @@
     #searchform-navbar {
         background-color: $primary;
     }
+
+    /* Change the color of the active nav items's bottom border to white as this would be presented in the
+   primary color otherwise. */
+    .nav-link.active {
+        border-bottom-color: $white;
+    }
+
+    /* Change the color of the language selector icon to a light grey as well.
+        This has to use !important as Moodle core already uses !important for the icon colors. */
+    .langmenu .icon {
+        color: #c8c8c8 !important; /* stylelint-disable-line declaration-no-important */
+    }
 }
 
 /* Tweak the primary color navbar with dark font color. */
 .navbar.navbar-light.bg-primary {
-    /* Change the color of the active nav items's bottom border to white as this would be presented in the
+    /* Change the color of the active nav items's bottom border to dark grey as this would be presented in the
        primary color as well otherwise. */
     .nav-link.active {
-        border-bottom-color: $white;
+        border-bottom-color: rgba($black, .6);
     }
 
     /* Change the background color and colors of open custom menu parent navigation items in the navbar
@@ -193,6 +230,21 @@
     /* Change the background color of the search panel in the navbar. */
     #searchform-navbar {
         background-color: $primary;
+    }
+
+    /* Change the color of the login link in the navbar to dark grey and to darker grey when hovered. */
+    .login,
+    .login a {
+        color: rgba($black, .6);
+        &:hover {
+            color: rgba($black, .9);
+        }
+    }
+
+    /* Change the color of the divider to dark grey.
+       This has to use !important as Moodle core already uses !important for the border-left color.*/
+    .divider {
+        border-left: 1px solid rgba($black, .6) !important; /* stylelint-disable-line declaration-no-important */
     }
 }
 


### PR DESCRIPTION
This pull request solves issue #273.
Furthermore, it improves the look of the primary color navbar with the dark text, changes the color of the language menu for not logged-in users. 


For clarification, what this PR is about: 

Before
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/bbc8e857-8694-48d5-9e07-dc7ec5f15744)

After
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/b74cf91f-2bae-4910-8f0c-8539cf891d1e)

Before
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/340fd33b-c11b-4452-af62-6981e57e8ddd)

After
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/f03cb55d-afc7-4e5a-bcfd-cbc847f01a69)

Before
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/1251a653-4c33-42c2-8f73-9915efce58ab)

After
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/0b6d5e59-7f12-46fd-b590-955624603066)

Before
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/1265e70e-43a4-4680-b5a8-ef65138c7b99)

After
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/0617e122-3c78-4caa-bc16-78ee663d4efd)

Before
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/8d41e80f-7a62-4947-821d-cc31ee5d8d40)

After
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/d68459c5-2c68-4d0e-ab40-0dd2c9316ed9)

Before
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/8ceb997e-9530-4c9d-85ed-f9aaf3d2e6a6)

After
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/5868c06b-2c2b-41ab-a62d-d2a62e523431)

Before
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/ef7b5066-7544-4e96-906e-8ae556140f70)

After
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/488ad84e-903e-4ad0-97af-415062452390)
