### PR TITLE
Bugfix: Fix footer and footnote placement, solves #269.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-06-14 - Bugfix: Fix footer and footnote placement, solves #269.
 * 2023-06-13 - Feature: Add admin option to mark external links, solves #307.
 * 2023-06-13 - Feature: Allow the admin to overwrite the modules purpose, solves #288.
 * 2023-05-17 - Improvement: Improve SCSS for dark navbar and primary color navbar, solves #273.

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -364,6 +364,17 @@ body.hasstickyfooter #back-to-top {
  ======================================*/
 
 /*---------------------------------------
+ * Settings: Additional block regions - General.
+ --------------------------------------*/
+
+/* To support additional block regions around the main content area, Boost Union introduced
+   the main-inner-wrapper HTML element. Unfortunately, this breaks the Flexbox flow of Moodle core.
+   To make it work again, we have to set the Flexbox flex attribute in the main-inner-wrapper element as well. */
+.main-inner-wrapper {
+    flex: 1 0 auto;
+}
+
+/*---------------------------------------
  * Settings: Additional block regions - The offcanvas region.
  --------------------------------------*/
 


### PR DESCRIPTION
Adding the flex-grow-1 class to the new .main-inner-wrapper element fixes the problem.

Before
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/e113b051-3713-4f55-be95-396fefa62108)

After
![image](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/53710443/f9656fb3-0ebb-402c-a2ee-2329083c3866)

