### PR TITLE
Bugfix: Moodle 4.2 / FontAwesome 6 broken external link icon, solves #327

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2023-06-26 - Bugfix: Fixed broken FontAwesome 6 external link icon in Moodle 4.2+, solves #327.
+
 ### v4.1-r8
 
 * 2023-06-18 - Improvement: Split "Branding" tab into "Site branding" and "Activity branding", solves #315.

--- a/locallib.php
+++ b/locallib.php
@@ -1619,14 +1619,16 @@ function theme_boost_union_get_scss_to_mark_external_links($theme) {
         // SCSS to add external link icon after the link and respect LTR and RTL while doing this.
         $scss = 'body.dir-ltr a:not([href^="' . $CFG->wwwroot . '"])[href^="http://"]::after,
             body.dir-ltr a:not([href^="' . $CFG->wwwroot . '"])[href^="https://"]::after {
-            font-family: "FontAwesome";
-            content: "\f08e" !important;
+            font-family: "Font Awesome 6 Free", "FontAwesome";
+            font-weight: 900;
+            content: "#{$fa-var-external-link}" !important;
             padding-left: 0.25rem;
         }';
         $scss .= 'body.dir-rtl a:not([href^="' . $CFG->wwwroot . '"])[href^="http://"]::before,
             body.dir-rtl a:not([href^="' . $CFG->wwwroot . '"])[href^="https://"]::before {
-            font-family: "FontAwesome";
-            content: "\f08e" !important;
+            font-family: "Font Awesome 6 Free", "FontAwesome";
+            font-weight: 900;
+            content: "#{$fa-var-external-link}" !important;
             padding-right: 0.25rem;
         }';
 


### PR DESCRIPTION
I've implemented a bugfix for #327, which currently offers backwards-compatability but causes the external link icon to be a bit bolder (900 vs 400) in Moodle versions <= 4.1. This can be handled differently, e.g. by implementing a version check and still needs further discussion in #327.