### PR TITLE
Replaces get_config() calls with already loaded theme->settings

### DIFF
--- a/classes/boostnavbar.php
+++ b/classes/boostnavbar.php
@@ -56,7 +56,7 @@ class boostnavbar extends \theme_boost\boostnavbar {
             }
         }
         if ($this->page->context->contextlevel == CONTEXT_COURSE) {
-            if (get_config('theme_boost_union', 'categorybreadcrumbs') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            if ($PAGE->theme->settings->categorybreadcrumbs == THEME_BOOST_UNION_SETTING_SELECT_YES) {
                 // Add the categories breadcrumb navigation nodes.
                 foreach (array_reverse($this->get_categories()) as $category) {
                     $context = \context_coursecat::instance($category->id);
@@ -82,7 +82,7 @@ class boostnavbar extends \theme_boost\boostnavbar {
             $this->remove('mycourses');
             $this->remove('courses');
 
-            switch (get_config('theme_boost_union', 'categorybreadcrumbs')) {
+            switch ($PAGE->theme->settings->categorybreadcrumbs) {
                 case THEME_BOOST_UNION_SETTING_SELECT_NO:
                     foreach ($this->items as $key => $item) {
                         // Remove if it is a course category breadcrumb node.
@@ -156,7 +156,7 @@ class boostnavbar extends \theme_boost\boostnavbar {
 
         // Don't display the navbar if there is only one item. Apparently this is bad UX design.
         // Except, leave it in when in course context and categorybreadcrumbs are desired.
-        if (get_config('theme_boost_union', 'categorybreadcrumbs') != THEME_BOOST_UNION_SETTING_SELECT_YES &&
+        if ($PAGE->theme->settings->categorybreadcrumbs != THEME_BOOST_UNION_SETTING_SELECT_YES &&
                 $this->page->context->contextlevel == CONTEXT_COURSE) {
             if ($this->item_count() <= 1) {
                 $this->clear_items();
@@ -166,7 +166,7 @@ class boostnavbar extends \theme_boost\boostnavbar {
 
         // Make sure that the last item is not a link. Not sure if this is always a good idea.
         // Except, leave it when categorybreadcrumbs are desired.
-        if (get_config('theme_boost_union', 'categorybreadcrumbs') != THEME_BOOST_UNION_SETTING_SELECT_YES) {
+        if ($PAGE->theme->settings->categorybreadcrumbs != THEME_BOOST_UNION_SETTING_SELECT_YES) {
             $this->remove_last_item_action();
         }
     }

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -95,7 +95,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
         // Apparently, there isn't any flavour favicon set. Let's continue with the logic to serve the general favicon.
         $logo = null;
         if (!during_initial_install()) {
-            $logo = get_config('theme_boost_union', 'favicon');
+            $logo = $this->page->theme->settings->favicon;
         }
         if (empty($logo)) {
             return $this->image_url('favicon', 'theme');
@@ -164,7 +164,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
         }
 
         // Apparently, there isn't any flavour logo set. Let's continue to serve the general logo.
-        $logo = get_config('theme_boost_union', 'logo');
+        $logo = $this->page->theme->settings->logo;
         if (empty($logo)) {
             return false;
         }
@@ -250,7 +250,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
         }
 
         // Apparently, there isn't any flavour logo set. Let's continue to service the general compact logo.
-        $logo = get_config('theme_boost_union', 'logocompact');
+        $logo = $this->page->theme->settings->logocompact;
         if (empty($logo)) {
             return false;
         }
@@ -297,7 +297,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
 
         // If this isn't the login page and the page has a background image, add a class to the body attributes.
         if ($this->page->pagelayout != 'login') {
-            if (!empty(get_config('theme_boost_union', 'backgroundimage'))) {
+            if (!empty($this->page->theme->settings->backgroundimage)) {
                 $additionalclasses[] = 'backgroundimage';
             }
         }
@@ -366,17 +366,17 @@ class core_renderer extends \theme_boost\output\core_renderer {
         $header->headeractions = $this->page->get_header_actions();
 
         // Add the course header image for rendering.
-        if ($this->page->pagelayout == 'course' && (get_config('theme_boost_union', 'courseheaderimageenabled')
+        if ($this->page->pagelayout == 'course' && ($this->page->theme->settings->courseheaderimageenabled
                         == THEME_BOOST_UNION_SETTING_SELECT_YES)) {
             // If course header images are activated, we get the course header image url
             // (which might be the fallback image depending on the course settings and theme settings).
             $header->courseheaderimageurl = theme_boost_union_get_course_header_image_url();
             // Additionally, get the course header image height.
-            $header->courseheaderimageheight = get_config('theme_boost_union', 'courseheaderimageheight');
+            $header->courseheaderimageheight = $this->page->theme->settings->courseheaderimageheight;
             // Additionally, get the course header image position.
-            $header->courseheaderimageposition = get_config('theme_boost_union', 'courseheaderimageposition');
+            $header->courseheaderimageposition = $this->page->theme->settings->courseheaderimageposition;
             // Additionally, get the template context attributes for the course header image layout.
-            $courseheaderimagelayout = get_config('theme_boost_union', 'courseheaderimagelayout');
+            $courseheaderimagelayout = $this->page->theme->settings->courseheaderimagelayout;
             switch($courseheaderimagelayout) {
                 case THEME_BOOST_UNION_SETTING_COURSEIMAGELAYOUT_HEADINGABOVE:
                     $header->courseheaderimagelayoutheadingabove = true;

--- a/flavours/flavourslib.php
+++ b/flavours/flavourslib.php
@@ -38,7 +38,7 @@ function theme_boost_union_get_flavour_which_applies() {
     // This function is called from every Moodle page.
     // BUT: If the plugin is not properly installed or updated yet, we must not access any database table
     // as this would trigger a "Read from database" error.
-    if (get_config('theme_boost_union', 'version') < 2022080916) {
+    if ($PAGE->theme->settings->version < 2022080916) {
         return null;
     }
 

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -43,7 +43,7 @@ require_once($CFG->libdir . '/behat/lib.php');
 require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
 
 // Add activity navigation if the feature is enabled.
-$activitynavigation = get_config('theme_boost_union', 'activitynavigation');
+$activitynavigation = $PAGE->theme->settings->activitynavigation;
 if ($activitynavigation == THEME_BOOST_UNION_SETTING_SELECT_YES) {
     $PAGE->theme->usescourseindex = false;
 }

--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -47,7 +47,7 @@ require_once($CFG->dirroot . '/course/lib.php');
 require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
 
 // Add activity navigation if the feature is enabled.
-$activitynavigation = get_config('theme_boost_union', 'activitynavigation');
+$activitynavigation = $PAGE->theme->settings->activitynavigation;
 if ($activitynavigation == THEME_BOOST_UNION_SETTING_SELECT_YES) {
     $PAGE->theme->usescourseindex = false;
 }
@@ -62,9 +62,9 @@ if (isloggedin()) {
     $courseindexopen = (get_user_preferences('drawer-open-index', true) == true);
 
     if (isguestuser()) {
-        $sitehomerighthandblockdrawerserverconfig = get_config('theme_boost_union', 'showsitehomerighthandblockdraweronguestlogin');
+        $sitehomerighthandblockdrawerserverconfig = $PAGE->theme->settings->showsitehomerighthandblockdraweronguestlogin;
     } else {
-        $sitehomerighthandblockdrawerserverconfig = get_config('theme_boost_union', 'showsitehomerighthandblockdraweronfirstlogin');
+        $sitehomerighthandblockdrawerserverconfig = $PAGE->theme->settings->showsitehomerighthandblockdraweronfirstlogin;
     }
 
     $isadminsettingyes = ($sitehomerighthandblockdrawerserverconfig == THEME_BOOST_UNION_SETTING_SELECT_YES);
@@ -73,7 +73,7 @@ if (isloggedin()) {
     $courseindexopen = false;
     $blockdraweropen = false;
 
-    if (get_config('theme_boost_union', 'showsitehomerighthandblockdraweronvisit') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+    if ($PAGE->theme->settings->showsitehomerighthandblockdraweronvisit == THEME_BOOST_UNION_SETTING_SELECT_YES) {
         $blockdraweropen = true;
     }
 }

--- a/layout/includes/advertisementtiles.php
+++ b/layout/includes/advertisementtiles.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
 
 // Get theme config.
-$config = get_config('theme_boost_union');
+$config = $PAGE->theme->settings;
 
 // Initialize advertisement tiles data for templatecontext.
 $advertisementtiles = array();

--- a/layout/includes/backtotopbutton.php
+++ b/layout/includes/backtotopbutton.php
@@ -25,9 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$backtotopbutton = get_config('theme_boost_union', 'backtotopbutton');
-
 // Add back to top AMC module if the feature is enabled.
-if ($backtotopbutton == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+if ($PAGE->theme->settings->backtotopbutton == THEME_BOOST_UNION_SETTING_SELECT_YES) {
     $PAGE->requires->js_call_amd('theme_boost_union/backtotopbutton', 'init');
 }

--- a/layout/includes/blockregions.php
+++ b/layout/includes/blockregions.php
@@ -183,10 +183,10 @@ class additionalregions {
             'regions' => $regionsdata,
             'userisediting' => $PAGE->user_is_editing(),
             'maininnerwrapperclass' => $maininnerwrapperclass,
-            'outsideregionsplacement' => 'main-inner-outside-'.get_config('theme_boost_union', 'outsideregionsplacement'),
-            'outsidebottomwidth' => 'theme-block-region-outside-'.get_config('theme_boost_union', 'blockregionoutsidebottomwidth'),
-            'outsidetopwidth' => 'theme-block-region-outside-'.get_config('theme_boost_union', 'blockregionoutsidetopwidth'),
-            'footerwidth' => 'theme-block-region-footer-'.get_config('theme_boost_union', 'blockregionfooterwidth'),
+            'outsideregionsplacement' => 'main-inner-outside-'.$PAGE->theme->settings->outsideregionsplacement,
+            'outsidebottomwidth' => 'theme-block-region-outside-'.$PAGE->theme->settings->blockregionoutsidebottomwidth,
+            'outsidetopwidth' => 'theme-block-region-outside-'.$PAGE->theme->settings->blockregionoutsidetopwidth,
+            'footerwidth' => 'theme-block-region-footer-'.$PAGE->theme->settings->blockregionfooterwidth,
         ];
     }
 }

--- a/layout/includes/footnote.php
+++ b/layout/includes/footnote.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$footnotesetting = get_config('theme_boost_union', 'footnote');
+$footnotesetting = $PAGE->theme->settings->footnote;
 
 // Only proceed if text area does not only contains empty tags.
 if (!html_is_blank($footnotesetting)) {

--- a/layout/includes/infobanners.php
+++ b/layout/includes/infobanners.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 // Require the necessary libraries.
 require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
 
-$config = get_config('theme_boost_union');
+$config = $PAGE->theme->settings;
 
 // Initialize info banners data for templatecontext.
 $infobanners = array();

--- a/layout/includes/javascriptdisabledhint.php
+++ b/layout/includes/javascriptdisabledhint.php
@@ -25,10 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$hintsetting = get_config('theme_boost_union', 'javascriptdisabledhint');
-
 // If the feature is enabled.
-if ($hintsetting == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+if ($PAGE->theme->settings->javascriptdisabledhint == THEME_BOOST_UNION_SETTING_SELECT_YES) {
     // Add marker to show the hint to templatecontext.
     $templatecontext['showjavascriptdisabledhint'] = true;
 }

--- a/layout/includes/navbar.php
+++ b/layout/includes/navbar.php
@@ -24,10 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$navbarcolorsetting = get_config('theme_boost_union', 'navbarcolor');
-
 // Compose the navbar color classes based on the navbarcolor setting.
-switch($navbarcolorsetting) {
+switch($PAGE->theme->settings->navbarcolor) {
     case THEME_BOOST_UNION_SETTING_NAVBARCOLOR_DARK:
         $templatecontext['navbarcolorclasses'] = 'navbar-dark bg-dark';
         break;

--- a/layout/includes/scrollspy.php
+++ b/layout/includes/scrollspy.php
@@ -24,9 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$scrollspy = get_config('theme_boost_union', 'scrollspy');
-
 // Add scroll-spy AMD module if the feature is enabled.
-if ($scrollspy == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+if ($PAGE->theme->settings->scrollspy == THEME_BOOST_UNION_SETTING_SELECT_YES) {
     $PAGE->requires->js_call_amd('theme_boost_union/scrollspy', 'init');
 }

--- a/layout/includes/staticpages.php
+++ b/layout/includes/staticpages.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 // Require the necessary libraries.
 require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
 
-$config = get_config('theme_boost_union');
+$config = $PAGE->theme->settings;
 
 // The static pages to be supported.
 $staticpages = array('imprint', 'contact', 'help', 'maintenance');

--- a/layout/login.php
+++ b/layout/login.php
@@ -41,9 +41,9 @@ $templatecontext = [
     'bodyattributes' => $bodyattributes,
     'loginbackgroundimagetext' => $loginbackgroundimagetext,
     'loginbackgroundimagetextcolor' => $loginbackgroundimagetextcolor,
-    'loginwrapperclass' => 'login-wrapper-'.get_config('theme_boost_union', 'loginformposition'),
+    'loginwrapperclass' => 'login-wrapper-'.$PAGE->theme->settings->loginformposition,
     'logincontainerclass' =>
-            (get_config('theme_boost_union', 'loginformtransparency') == THEME_BOOST_UNION_SETTING_SELECT_YES) ?
+            ($PAGE->theme->settings->loginformtransparency == THEME_BOOST_UNION_SETTING_SELECT_YES) ?
                     'login-container-80t' : ''
 ];
 

--- a/lib.php
+++ b/lib.php
@@ -124,7 +124,7 @@ function theme_boost_union_get_main_scss_content($theme) {
  * Get SCSS to prepend.
  *
  * @param theme_config $theme The theme config object.
- * @return array
+ * @return string
  */
 function theme_boost_union_get_pre_scss($theme) {
     global $CFG;
@@ -149,8 +149,8 @@ function theme_boost_union_get_pre_scss($theme) {
 
     // Prepend variables first.
     foreach ($configurable as $configkey => $targets) {
-        $value = get_config('theme_boost_union', $configkey);
-        if (!($value)) {
+        $value = isset($theme->settings->{$configkey}) ? $theme->settings->{$configkey} : null;
+        if (empty($value)) {
             continue;
         }
         array_map(function($target) use (&$scss, $value) {
@@ -160,38 +160,38 @@ function theme_boost_union_get_pre_scss($theme) {
 
     // Overwrite Boost core SCSS variables which need units and thus couldn't be added to $configurable above.
     // Set variables which are influenced by the coursecontentmaxwidth setting.
-    if (get_config('theme_boost_union', 'coursecontentmaxwidth')) {
-        $scss .= '$course-content-maxwidth: '.get_config('theme_boost_union', 'coursecontentmaxwidth').";\n";
+    if (!empty($theme->settings->coursecontentmaxwidth)) {
+        $scss .= '$course-content-maxwidth: '.$theme->settings->coursecontentmaxwidth.";\n";
     }
     // Set variables which are influenced by the mediumcontentmaxwidth setting.
-    if (get_config('theme_boost_union', 'mediumcontentmaxwidth')) {
-        $scss .= '$medium-content-maxwidth: '.get_config('theme_boost_union', 'mediumcontentmaxwidth').";\n";
+    if (!empty($theme->settings->mediumcontentmaxwidth)) {
+        $scss .= '$medium-content-maxwidth: '.$theme->settings->mediumcontentmaxwidth.";\n";
     }
     // Set variables which are influenced by the h5pcontentmaxwidth setting.
-    if (get_config('theme_boost_union', 'h5pcontentmaxwidth')) {
-        $scss .= '$h5p-content-maxwidth: '.get_config('theme_boost_union', 'h5pcontentmaxwidth').";\n";
+    if (!empty($theme->settings->h5pcontentmaxwidth)) {
+        $scss .= '$h5p-content-maxwidth: '.$theme->settings->h5pcontentmaxwidth.";\n";
     }
 
     // Overwrite Boost core SCSS variables which are stored in a SCSS map and thus couldn't be added to $configurable above.
     // Set variables for the activity icon colors.
     $activityiconcolors = array();
-    if (get_config('theme_boost_union', 'activityiconcoloradministration')) {
-        $activityiconcolors[] = '"administration": '.get_config('theme_boost_union', 'activityiconcoloradministration');
+    if (!empty($theme->settings->activityiconcoloradministration)) {
+        $activityiconcolors[] = '"administration": '.$theme->settings->activityiconcoloradministration;
     }
-    if (get_config('theme_boost_union', 'activityiconcolorassessment')) {
-        $activityiconcolors[] = '"assessment": '.get_config('theme_boost_union', 'activityiconcolorassessment');
+    if (!empty($theme->settings->activityiconcolorassessment)) {
+        $activityiconcolors[] = '"assessment": '.$theme->settings->activityiconcolorassessment;
     }
-    if (get_config('theme_boost_union', 'activityiconcolorcollaboration')) {
-        $activityiconcolors[] = '"collaboration": '.get_config('theme_boost_union', 'activityiconcolorcollaboration');
+    if (!empty($theme->settings->activityiconcolorcollaboration)) {
+        $activityiconcolors[] = '"collaboration": '.$theme->settings->activityiconcolorcollaboration;
     }
-    if (get_config('theme_boost_union', 'activityiconcolorcommunication')) {
-        $activityiconcolors[] = '"communication": '.get_config('theme_boost_union', 'activityiconcolorcommunication');
+    if (!empty($theme->settings->activityiconcolorcommunication)) {
+        $activityiconcolors[] = '"communication": '.$theme->settings->activityiconcolorcommunication;
     }
-    if (get_config('theme_boost_union', 'activityiconcolorcontent')) {
-        $activityiconcolors[] = '"content": '.get_config('theme_boost_union', 'activityiconcolorcontent');
+    if (!empty($theme->settings->activityiconcolorcontent)) {
+        $activityiconcolors[] = '"content": '.$theme->settings->activityiconcolorcontent;
     }
-    if (get_config('theme_boost_union', 'activityiconcolorinterface')) {
-        $activityiconcolors[] = '"interface": '.get_config('theme_boost_union', 'activityiconcolorinterface');
+    if (!empty($theme->settings->activityiconcolorinterface)) {
+        $activityiconcolors[] = '"interface": '.$theme->settings->activityiconcolorinterface;
     }
     if (count($activityiconcolors) > 0) {
         $activityiconscss = '$activity-icon-colors: ('."\n";
@@ -201,26 +201,17 @@ function theme_boost_union_get_pre_scss($theme) {
     }
 
     // Set custom Boost Union SCSS variable: The block region outside left width.
-    $blockregionoutsideleftwidth = get_config('theme_boost_union', 'blockregionoutsideleftwidth');
-    // If the setting is not set.
-    if (!$blockregionoutsideleftwidth) {
-        // Set the variable to the default setting to make sure that the SCSS variable does not remain uninitialized.
-        $blockregionoutsideleftwidth = '300px';
-    }
+    $blockregionoutsideleftwidth = empty($theme->settings->blockregionoutsideleftwidth) ?
+        '300px' : $theme->settings->blockregionoutsideleftwidth;
     $scss .= '$blockregionoutsideleftwidth: '.$blockregionoutsideleftwidth.";\n";
 
     // Set custom Boost Union SCSS variable: The block region outside left width.
-    $blockregionoutsiderightwidth = get_config('theme_boost_union', 'blockregionoutsiderightwidth');
-    // If the setting is not set.
-    if (!$blockregionoutsiderightwidth) {
-        // Set the variable to the default setting to make sure that the SCSS variable does not remain uninitialized.
-        $blockregionoutsiderightwidth = '300px';
-    }
+    $blockregionoutsiderightwidth = empty($theme->settings->blockregionoutsiderightwidth) ?
+        '300px' : $theme->settings->blockregionoutsiderightwidth;
     $scss .= '$blockregionoutsiderightwidth: '.$blockregionoutsiderightwidth.";\n";
 
-    // Prepend pre-scss.
-    if (get_config('theme_boost_union', 'scsspre')) {
-        $scss .= get_config('theme_boost_union', 'scsspre');
+    if (!empty($theme->settings->scsspre)) {
+        $scss .= $theme->settings->scsspre;
     }
 
     return $scss;
@@ -254,8 +245,7 @@ function theme_boost_union_get_extra_scss($theme) {
 
     // In contrast to Boost core, Boost Union should add the login page background to the body element as well.
     // Thus, check if a login background image is set.
-    $loginbackgroundimagepresent = get_config('theme_boost_union', 'loginbackgroundimage');
-    if (!empty($loginbackgroundimagepresent)) {
+    if (!empty($theme->settings->loginbackgroundimage)) {
         // We first have to revert the background which is set to #page on the login page by Boost core already.
         // Doing this, we also have to make the background of the #page element transparent on the login page.
         $content .= 'body.pagelayout-login #page { ';
@@ -270,14 +260,13 @@ function theme_boost_union_get_extra_scss($theme) {
 
         // Finally, we add all possible background image urls which will be picked based on the (random) loginpageimage class.
         $content .= theme_boost_union_get_loginbackgroundimage_scss();
-    }
+    } else {
+        // Boost core has the behaviour that the normal background image is not shown on the login page,
+        // only the login background image is shown on the login page.
+        // This is fine, but it is done improperly as the normal background image is still there on the login page and just overlaid
+        // with a grey color in the #page element. This can result in flickering during the page load.
+        // We try to avoid this by removing the background image from the body tag if no login background image is set.
 
-    // Boost core has the behaviour that the normal background image is not shown on the login page, only the login background image
-    // is shown on the login page.
-    // This is fine, but it is done improperly as the normal background image is still there on the login page and just overlaid
-    // with a grey color in the #page element. This can result in flickering during the page load.
-    // We try to avoid this by removing the background image from the body tag if no login background image is set.
-    if (empty($loginbackgroundimagepresent)) {
         $content .= 'body.pagelayout-login { ';
         $content .= "background-image: none !important;";
         $content .= '}';

--- a/locallib.php
+++ b/locallib.php
@@ -42,7 +42,7 @@ function theme_boost_union_get_course_related_hints() {
 
     // If the setting showhintcoursehidden is set and the visibility of the course is hidden and
     // a hint for the visibility will be shown.
-    if (get_config('theme_boost_union', 'showhintcoursehidden') == THEME_BOOST_UNION_SETTING_SELECT_YES
+    if ($PAGE->theme->settings->showhintcoursehidden == THEME_BOOST_UNION_SETTING_SELECT_YES
             && has_capability('theme/boost_union:viewhintinhiddencourse', \context_course::instance($COURSE->id))
             && $PAGE->has_set_url()
             && $PAGE->url->compare(new moodle_url('/course/view.php'), URL_MATCH_BASE)
@@ -67,7 +67,7 @@ function theme_boost_union_get_course_related_hints() {
     // We also check that the user did not switch the role. This is a special case for roles that can fully access the course
     // without being enrolled. A role switch would show the guest access hint additionally in that case and this is not
     // intended.
-    if (get_config('theme_boost_union', 'showhintcourseguestaccess') == THEME_BOOST_UNION_SETTING_SELECT_YES
+    if ($PAGE->theme->settings->showhintcourseguestaccess == THEME_BOOST_UNION_SETTING_SELECT_YES
             && is_guest(\context_course::instance($COURSE->id), $USER->id)
             && $PAGE->has_set_url()
             && $PAGE->url->compare(new moodle_url('/course/view.php'), URL_MATCH_BASE)
@@ -107,7 +107,7 @@ function theme_boost_union_get_course_related_hints() {
     // If the setting showhintcourseselfenrol is set, a hint for users is shown that the course allows unrestricted self
     // enrolment. This hint is only shown if the course is visible, the self enrolment is visible and if the user has the
     // capability "theme/boost_union:viewhintcourseselfenrol".
-    if (get_config('theme_boost_union', 'showhintcourseselfenrol') == THEME_BOOST_UNION_SETTING_SELECT_YES
+    if ($PAGE->theme->settings->showhintcourseselfenrol == THEME_BOOST_UNION_SETTING_SELECT_YES
             && has_capability('theme/boost_union:viewhintcourseselfenrol', \context_course::instance($COURSE->id))
             && $PAGE->has_set_url()
             && $PAGE->url->compare(new moodle_url('/course/view.php'), URL_MATCH_BASE)
@@ -252,7 +252,7 @@ function theme_boost_union_get_course_related_hints() {
 
     // If the setting showswitchedroleincourse is set and the user has switched his role,
     // a hint for the role switch will be shown.
-    if (get_config('theme_boost_union', 'showswitchedroleincourse') === THEME_BOOST_UNION_SETTING_SELECT_YES
+    if ($PAGE->theme->settings->showswitchedroleincourse === THEME_BOOST_UNION_SETTING_SELECT_YES
             && is_role_switched($COURSE->id) ) {
 
         // Get the role name switched to.
@@ -299,8 +299,9 @@ function theme_boost_union_get_staticpage_link($page) {
  * @return string.
  */
 function theme_boost_union_get_staticpage_pagetitle($page) {
+    global $PAGE;
     // Get the configured page title.
-    $pagetitleconfig = format_string(get_config('theme_boost_union', $page.'pagetitle'), true,
+    $pagetitleconfig = format_string($PAGE->theme->settings->{$page.'pagetitle'}, true,
     ['context' => \context_system::instance()]);
 
     // If there is a string configured.
@@ -334,7 +335,7 @@ function theme_boost_union_infobanner_is_shown_on_page($bannerno) {
     global $PAGE;
 
     // Get theme config.
-    $config = get_config('theme_boost_union');
+    $config = $PAGE->theme->settings;
 
     // If the info banner is enabled.
     $enabledsettingname = 'infobanner'.$bannerno.'enabled';
@@ -554,17 +555,16 @@ function theme_boost_union_get_loginbackgroundimage_files() {
  * @return string|null
  */
 function theme_boost_union_get_urloftilebackgroundimage($tileno) {
+    global $PAGE;
+
     // If the tile number is apparently not valid, return.
     // Note: We just check the tile's number, we do not check if the tile is enabled or not.
     if ($tileno < 0 || $tileno > THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COUNT) {
         return null;
     }
 
-    // Get the background image config for this tile.
-    $bgconfig = get_config('theme_boost_union', 'tile'.$tileno.'backgroundimage');
-
     // If a background image is configured.
-    if (!empty($bgconfig)) {
+    if (!empty($PAGE->theme->settings->{'tile'.$tileno.'backgroundimage'})) {
         // Get the system context.
         $systemcontext = context_system::instance();
 
@@ -623,6 +623,8 @@ function theme_boost_union_get_loginbackgroundimage_scss() {
  * @throws dml_exception
  */
 function theme_boost_union_get_loginbackgroundimage_text() {
+    global $PAGE;
+
     // Get the random number.
     $number = theme_boost_union_get_random_loginbackgroundimage_number();
 
@@ -637,7 +639,7 @@ function theme_boost_union_get_loginbackgroundimage_text() {
         $filename = array_pop($file)->get_filename();
 
         // Get the config for loginbackgroundimagetext and make an array out of the lines.
-        $lines = explode("\n", get_config('theme_boost_union', 'loginbackgroundimagetext'));
+        $lines = explode("\n", $PAGE->theme->settings->loginbackgroundimagetext);
 
         // Process the lines.
         foreach ($lines as $line) {
@@ -916,6 +918,8 @@ function theme_boost_union_get_emailbrandingtextpreview() {
  * @return void
  */
 function theme_boost_union_fontawesome_checkin() {
+    global $PAGE;
+
     // Create cache for FontAwesome files.
     $cache = cache::make('theme_boost_union', 'fontawesome');
 
@@ -923,7 +927,7 @@ function theme_boost_union_fontawesome_checkin() {
     $cache->purge();
 
     // Get FontAwesome version config.
-    $faconfig = get_config('theme_boost_union', 'fontawesomeversion');
+    $faconfig = $PAGE->theme->settings->fontawesomeversion;
 
     // If a FontAwesome version is enabled.
     if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null) {
@@ -1026,6 +1030,8 @@ function theme_boost_union_get_fontawesome_filestructure($version) {
  * @throws dml_exception
  */
 function theme_boost_union_get_fontawesome_templatecontext() {
+    global $PAGE;
+
     // Create cache for FontAwesome files.
     $cache = cache::make('theme_boost_union', 'fontawesome');
 
@@ -1035,7 +1041,7 @@ function theme_boost_union_get_fontawesome_templatecontext() {
     }
 
     // Get FontAwesome version config.
-    $faconfig = get_config('theme_boost_union', 'fontawesomeversion');
+    $faconfig = $PAGE->theme->settings->fontawesomeversion;
 
     // If a FontAwesome version is enabled.
     if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null) {
@@ -1099,10 +1105,10 @@ function theme_boost_union_get_fontawesome_templatecontext() {
  * @return array|null The array of checks or null if an invalid FontAwesome version is configured.
  */
 function theme_boost_union_get_fontawesome_checks_templatecontext() {
-    global $CFG;
+    global $CFG, $PAGE;
 
     // Get FontAwesome version config.
-    $version = get_config('theme_boost_union', 'fontawesomeversion');
+    $version = $PAGE->theme->settings->fontawesomeversion;
 
     // Pick the checks for the selected FA version.
     switch ($version) {
@@ -1191,7 +1197,7 @@ function theme_boost_union_add_fontawesome_to_page() {
     }
 
     // Get FontAwesome version config.
-    $faconfig = get_config('theme_boost_union', 'fontawesomeversion');
+    $faconfig = $PAGE->theme->settings->fontawesomeversion;
 
     // If a FontAwesome version is enabled.
     if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null) {
@@ -1237,7 +1243,7 @@ function theme_boost_union_add_flavourcss_to_page() {
                 array('id' => $flavour->id, 'rev' => theme_get_revision()));
 
         // Add the CSS file to the page.
-        $PAGE->requires->css($flavourcssurl);
+        $PAGE->theme->requires->css($flavourcssurl);
     }
 }
 
@@ -1266,7 +1272,7 @@ function theme_boost_union_get_course_header_image_url() {
         return $courseimage;
 
         // Otherwise, if a fallback image is configured.
-    } else if (get_config('theme_boost_union', 'courseheaderimagefallback')) {
+    } else if ($PAGE->theme->settings->courseheaderimagefallback) {
         // Get the system context.
         $systemcontext = \context_system::instance();
 

--- a/settings.php
+++ b/settings.php
@@ -28,6 +28,7 @@ use \theme_boost_union\admin_setting_configstoredfilealwayscallback;
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig || has_capability('theme/boost_union:configure', context_system::instance())) {
+    global $PAGE;
 
     // How this file works:
     // This theme's settings are divided into multiple settings pages.
@@ -495,9 +496,8 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         // Information: Custom icons files list.
         // If there is at least one file uploaded and if custom icons are enabled (unfortunately, hide_if does not
         // work for admin_setting_description up to now, that's why we have to use this workaround).
-        $modiconsenableconfig = get_config('theme_boost_union', 'modiconsenable');
-        if ($modiconsenableconfig == THEME_BOOST_UNION_SETTING_SELECT_YES &&
-                !empty(get_config('theme_boost_union', 'modiconsfiles'))) {
+        if ($PAGE->theme->settings->modiconsenable == THEME_BOOST_UNION_SETTING_SELECT_YES &&
+                !empty($PAGE->theme->settings->modiconsenablemodiconsfiles)) {
             // Prepare the widget.
             $name = 'theme_boost_union/modiconlist';
             $title = get_string('modiconlistsetting', 'theme_boost_union', null, true);
@@ -805,7 +805,7 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
 
         // Information: Additional resources list.
         // If there is at least one file uploaded.
-        if (!empty(get_config('theme_boost_union', 'additionalresources'))) {
+        if (!empty($PAGE->theme->settings->additionalresources)) {
             // Prepare the widget.
             $name = 'theme_boost_union/additionalresourceslist';
             $title = get_string('additionalresourceslistsetting', 'theme_boost_union', null, true);
@@ -849,7 +849,7 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
 
         // Information: Custom fonts list.
         // If there is at least one file uploaded.
-        if (!empty(get_config('theme_boost_union', 'customfonts'))) {
+        if (!empty($PAGE->theme->settings->customfonts)) {
             // Prepare the widget.
             $name = 'theme_boost_union/customfontslist';
             $title = get_string('customfontslistsetting', 'theme_boost_union', null, true);
@@ -909,11 +909,11 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
                 THEME_BOOST_UNION_SETTING_FAVERSION_NONE);
 
         // Information: FontAwesome list.
-        $faconfig = get_config('theme_boost_union', 'fontawesomeversion');
+        $faconfig = $PAGE->theme->settings->fontawesomeversion;
         // If there is at least one file uploaded and if a FontAwesome version is enabled (unfortunately, hide_if does not
         // work for admin_setting_description up to now, that's why we have to use this workaround).
         if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null &&
-                !empty(get_config('theme_boost_union', 'fontawesomefiles'))) {
+                !empty($PAGE->theme->settings->fontawesomefiles)) {
             // Prepare the widget.
             $name = 'theme_boost_union/fontawesomelist';
             $title = get_string('fontawesomelistsetting', 'theme_boost_union', null, true);
@@ -933,7 +933,7 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         // If there is at least one file uploaded and if a FontAwesome version is enabled (unfortunately, hide_if does not
         // work for admin_setting_description up to now, that's why we have to use this workaround).
         if ($faconfig != THEME_BOOST_UNION_SETTING_FAVERSION_NONE && $faconfig != null &&
-                !empty(get_config('theme_boost_union', 'fontawesomefiles'))) {
+                !empty($PAGE->theme->settings->fontawesomefiles)) {
             // Prepare the widget.
             $name = 'theme_boost_union/fontawesomechecks';
             $title = get_string('fontawesomecheckssetting', 'theme_boost_union', null, true);
@@ -1617,7 +1617,7 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
             $title = get_string('infobannerdismissiblesetting', 'theme_boost_union', array('no' => $i), true);
             $description = get_string('infobannerdismissiblesetting_desc', 'theme_boost_union', array('no' => $i), true);
             // Add Reset button if the info banner is already configured to be dismissible.
-            if (get_config('theme_boost_union', 'infobanner'.$i.'dismissible') == true) {
+            if ($PAGE->theme->settings->{'infobanner'.$i.'dismissible'} == true) {
                 $reseturl = new moodle_url('/theme/boost_union/settings_infobanner_resetdismissed.php',
                         array('sesskey' => sesskey(), 'no' => $i));
                 $description .= html_writer::empty_tag('br');


### PR DESCRIPTION
This replaces some of the get_config() calls with already loaded settings in the theme instance.
I only changed the get_config_call() calls where settings a fully loaded or the global $PAGE is available. 