### PR TITLE
Add js and css to use local_och5p with mod_hvp

### DIFF
--- a/renderers.php
+++ b/renderers.php
@@ -79,6 +79,7 @@ if (file_exists($CFG->dirroot.'/mod/hvp/renderer.php')) {
              * @param string $embedtype How the H5P is displayed.
              */
             public function hvp_alter_styles(&$styles, $libraries, $embedtype) {
+                global $CFG;
                 // Build the H5P CSS file URL.
                 $h5pcssurl = new moodle_url('/theme/boost_union/h5p/styles.php');
 
@@ -87,6 +88,52 @@ if (file_exists($CFG->dirroot.'/mod/hvp/renderer.php')) {
                         'path' => $h5pcssurl->out(),
                         'version' => '?ver='.theme_get_revision(),
                 );
+
+                if (file_exists($CFG->dirroot.'/local/och5p/version.php')) {
+                    if (
+                        isset($libraries['H5P.InteractiveVideo']) &&
+                        $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
+                    ) {
+                        $h5peditoravurl = new moodle_url('/local/och5p/lib/style/H5PEditor.AV.css');
+                        $styles[] = (object)array(
+                            'path' => $h5peditoravurl->out(),
+                            'version' => '?ver=0.0.1',
+                        );
+                        $ocfontsurl = new moodle_url('/local/och5p/lib/style/oc-fonts.css');
+                        $styles[] = (object)array(
+                            'path' => $ocfontsurl->out(),
+                            'version' => '?ver=0.0.1',
+                        );
+                    }
+                }
+            }
+            /**
+             * Add scripts when an H5P is displayed.
+             *
+             * @param object $scripts Scripts that will be applied.
+             * @param array $libraries Libraries that will be displayed.
+             * @param string $embedType How the H5P is displayed.
+             */
+            public function hvp_alter_scripts(&$scripts, $libraries, $embedtype) {
+                global $CFG;
+                // Check if plugin local_och5p is installed.
+                if (file_exists($CFG->dirroot.'/local/och5p/version.php')) {
+                    if (
+                        isset($libraries['H5P.InteractiveVideo']) &&
+                        $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
+                    ) {
+                        $h5prunltiurl = new moodle_url('/local/och5p/lib/js/H5PRunLTI.js');
+                        $scripts[] = (object)array(
+                            'path' => $h5prunltiurl->out(),
+                            'version' => '?ver=0.0.1',
+                        );
+                        $h5peditoravurl = new moodle_url('/local/och5p/lib/js/H5PEditor.AV.js');
+                        $scripts[] = (object)array(
+                            'path' => $h5peditoravurl->out(),
+                            'version' => '?ver=0.0.1',
+                        );
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
local_och5p offers a button to select opencast videos for H5P.InteractiveVideo. 

The plugin local_och5p creates a renderes.php with needed css and js in the theme directory. But as theme_boost_union  already integrates a renderers.php with similar functions since version v4.1-r2 it does not work properly.

This pull request adds the css and js if mod_hvp and local_och5p as well as H5P.InteractiveVideo is installed.

I would like to see this in version 401 as well. Should I create a pull request for that branch, too?