### PR TITLE
Fix for och5p plugins compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-08-18 - Improvement: Add CSS and Scripts for local_och5p local_och5pcore to the theme renderer.
 * 2023-08-13 - Improvement: Make the fonts in the dark navbar variants always fully white (not only when hovered) to improve the contrast.
 * 2023-08-13 - Feature: Smart menus, solves #137
 

--- a/renderers.php
+++ b/renderers.php
@@ -44,6 +44,7 @@ class theme_boost_union_core_h5p_renderer extends \core_h5p\output\renderer {
      */
     public function h5p_alter_styles(&$styles, $libraries, $embedtype) {
         global $CFG;
+
         // Build the H5P CSS file URL.
         $h5pcssurl = new moodle_url('/theme/boost_union/h5p/styles.php');
 
@@ -53,24 +54,22 @@ class theme_boost_union_core_h5p_renderer extends \core_h5p\output\renderer {
                 'version' => '?ver='.theme_get_revision(),
         );
 
-        // Adding local_och5pcore styles.
+        // If the local_och5pcore plugin is installed, add some more styles.
         if (file_exists($CFG->dirroot.'/local/och5pcore/version.php')) {
-            if (
-                isset($libraries['H5P.InteractiveVideo']) &&
-                $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
-            ) {
+            // If H5P interactive videos are installed.
+            if (isset($libraries['H5P.InteractiveVideo']) && $libraries['H5P.InteractiveVideo']['majorVersion'] == '1') {
                 // Adding H5PEditor css file.
                 $h5peditoravurl = new moodle_url('/local/och5pcore/lib/style/H5PEditor.AV.css');
                 $styles[] = (object) array(
                     'path' => $h5peditoravurl->out(),
-                    'version' => '?ver=0.0.1',
+                    'version' => '?ver='.theme_get_revision(),
                 );
 
                 // Adding opencast font css file.
                 $ocfontsurl = new moodle_url('/local/och5pcore/lib/style/oc-fonts.css');
                 $styles[] = (object) array(
                     'path' => $ocfontsurl->out(),
-                    'version' => '?ver=0.0.1',
+                    'version' => '?ver='.theme_get_revision(),
                 );
             }
         }
@@ -81,29 +80,27 @@ class theme_boost_union_core_h5p_renderer extends \core_h5p\output\renderer {
      *
      * @param array $scripts Scripts that will be applied.
      * @param array $libraries Libraries that will be displayed.
-     * @param string $embedType How the H5P is displayed.
+     * @param string $embedtype How the H5P is displayed.
      */
-    public function h5p_alter_scripts(&$scripts, $libraries, $embedType) {
+    public function h5p_alter_scripts(&$scripts, $libraries, $embedtype) {
         global $CFG;
-        // Adding local_och5pcore scripts.
-        if (file_exists($CFG->dirroot.'/local/och5pcore/version.php')) {
 
-            if (
-                isset($libraries['H5P.InteractiveVideo']) &&
-                $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
-            ) {
+        // If the local_och5pcore plugin is installed, add some more scripts.
+        if (file_exists($CFG->dirroot.'/local/och5pcore/version.php')) {
+            // If H5P interactive videos are installed.
+            if (isset($libraries['H5P.InteractiveVideo']) && $libraries['H5P.InteractiveVideo']['majorVersion'] == '1') {
                 // Adding LTI related script into scripts array.
                 $h5prunltiurl = new moodle_url('/local/och5pcore/lib/js/H5PRunLTI.js');
                 $scripts[] = (object) array(
                     'path' => $h5prunltiurl->out(),
-                    'version' => '?ver=0.0.1',
+                    'version' => '?ver='.theme_get_revision(),
                 );
 
                 // Adding editor script to scripts array.
                 $h5peditoravurl = new moodle_url('/local/och5pcore/lib/js/H5PEditor.AV.js');
                 $scripts[] = (object) array(
                     'path' => $h5peditoravurl->out(),
-                    'version' => '?ver=0.0.1',
+                    'version' => '?ver='.theme_get_revision(),
                 );
             }
         }
@@ -136,6 +133,7 @@ if (file_exists($CFG->dirroot.'/mod/hvp/renderer.php')) {
              */
             public function hvp_alter_styles(&$styles, $libraries, $embedtype) {
                 global $CFG;
+
                 // Build the H5P CSS file URL.
                 $h5pcssurl = new moodle_url('/theme/boost_union/h5p/styles.php');
 
@@ -145,24 +143,22 @@ if (file_exists($CFG->dirroot.'/mod/hvp/renderer.php')) {
                         'version' => '?ver='.theme_get_revision(),
                 );
 
-                // Adding local_och5p styles.
+                // If the local_och5p plugin is installed, add some more styles.
                 if (file_exists($CFG->dirroot.'/local/och5p/version.php')) {
-                    if (
-                        isset($libraries['H5P.InteractiveVideo']) &&
-                        $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
-                    ) {
+                    // If H5P interactive videos are installed.
+                    if (isset($libraries['H5P.InteractiveVideo']) && $libraries['H5P.InteractiveVideo']['majorVersion'] == '1') {
                         // Adding H5PEditor css file.
                         $h5peditoravurl = new moodle_url('/local/och5p/lib/style/H5PEditor.AV.css');
                         $styles[] = (object) array(
                             'path' => $h5peditoravurl->out(),
-                            'version' => '?ver=0.0.1',
+                            'version' => '?ver='.theme_get_revision(),
                         );
 
                         // Adding opencast font css file.
                         $ocfontsurl = new moodle_url('/local/och5p/lib/style/oc-fonts.css');
                         $styles[] = (object) array(
                             'path' => $ocfontsurl->out(),
-                            'version' => '?ver=0.0.1',
+                            'version' => '?ver='.theme_get_revision(),
                         );
                     }
                 }
@@ -173,29 +169,27 @@ if (file_exists($CFG->dirroot.'/mod/hvp/renderer.php')) {
              *
              * @param array $scripts Scripts that will be applied.
              * @param array $libraries Libraries that will be displayed.
-             * @param string $embedType How the H5P is displayed.
+             * @param string $embedtype How the H5P is displayed.
              */
-            public function hvp_alter_scripts(&$scripts, $libraries, $embedType) {
+            public function hvp_alter_scripts(&$scripts, $libraries, $embedtype) {
                 global $CFG;
 
-                // Adding local_och5p scripts.
+                // If the local_och5p plugin is installed, add some more scripts.
                 if (file_exists($CFG->dirroot.'/local/och5p/version.php')) {
-                    if (
-                        isset($libraries['H5P.InteractiveVideo']) &&
-                        $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
-                    ) {
+                    // If H5P interactive videos are installed.
+                    if (isset($libraries['H5P.InteractiveVideo']) && $libraries['H5P.InteractiveVideo']['majorVersion'] == '1') {
                         // Adding LTI related script into scripts array.
                         $h5prunltiurl = new moodle_url('/local/och5p/lib/js/H5PRunLTI.js');
                         $scripts[] = (object) array(
                             'path' => $h5prunltiurl->out(),
-                            'version' => '?ver=0.0.1',
+                            'version' => '?ver='.theme_get_revision(),
                         );
 
                         // Adding editor script to scripts array.
                         $h5peditoravurl = new moodle_url('/local/och5p/lib/js/H5PEditor.AV.js');
                         $scripts[] = (object) array(
                             'path' => $h5peditoravurl->out(),
-                            'version' => '?ver=0.0.1',
+                            'version' => '?ver='.theme_get_revision(),
                         );
                     }
                 }

--- a/renderers.php
+++ b/renderers.php
@@ -43,6 +43,7 @@ class theme_boost_union_core_h5p_renderer extends \core_h5p\output\renderer {
      * @param string $embedtype How the H5P is displayed.
      */
     public function h5p_alter_styles(&$styles, $libraries, $embedtype) {
+        global $CFG;
         // Build the H5P CSS file URL.
         $h5pcssurl = new moodle_url('/theme/boost_union/h5p/styles.php');
 
@@ -51,6 +52,61 @@ class theme_boost_union_core_h5p_renderer extends \core_h5p\output\renderer {
                 'path' => $h5pcssurl->out(),
                 'version' => '?ver='.theme_get_revision(),
         );
+
+        // Adding local_och5pcore styles.
+        if (file_exists($CFG->dirroot.'/local/och5pcore/version.php')) {
+            if (
+                isset($libraries['H5P.InteractiveVideo']) &&
+                $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
+            ) {
+                // Adding H5PEditor css file.
+                $h5peditoravurl = new moodle_url('/local/och5pcore/lib/style/H5PEditor.AV.css');
+                $styles[] = (object) array(
+                    'path' => $h5peditoravurl->out(),
+                    'version' => '?ver=0.0.1',
+                );
+
+                // Adding opencast font css file.
+                $ocfontsurl = new moodle_url('/local/och5pcore/lib/style/oc-fonts.css');
+                $styles[] = (object) array(
+                    'path' => $ocfontsurl->out(),
+                    'version' => '?ver=0.0.1',
+                );
+            }
+        }
+    }
+
+    /**
+     * Add scripts when an H5P is displayed.
+     *
+     * @param array $scripts Scripts that will be applied.
+     * @param array $libraries Libraries that will be displayed.
+     * @param string $embedType How the H5P is displayed.
+     */
+    public function h5p_alter_scripts(&$scripts, $libraries, $embedType) {
+        global $CFG;
+        // Adding local_och5pcore scripts.
+        if (file_exists($CFG->dirroot.'/local/och5pcore/version.php')) {
+
+            if (
+                isset($libraries['H5P.InteractiveVideo']) &&
+                $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
+            ) {
+                // Adding LTI related script into scripts array.
+                $h5prunltiurl = new moodle_url('/local/och5pcore/lib/js/H5PRunLTI.js');
+                $scripts[] = (object) array(
+                    'path' => $h5prunltiurl->out(),
+                    'version' => '?ver=0.0.1',
+                );
+
+                // Adding editor script to scripts array.
+                $h5peditoravurl = new moodle_url('/local/och5pcore/lib/js/H5PEditor.AV.js');
+                $scripts[] = (object) array(
+                    'path' => $h5peditoravurl->out(),
+                    'version' => '?ver=0.0.1',
+                );
+            }
+        }
     }
 }
 
@@ -79,6 +135,7 @@ if (file_exists($CFG->dirroot.'/mod/hvp/renderer.php')) {
              * @param string $embedtype How the H5P is displayed.
              */
             public function hvp_alter_styles(&$styles, $libraries, $embedtype) {
+                global $CFG;
                 // Build the H5P CSS file URL.
                 $h5pcssurl = new moodle_url('/theme/boost_union/h5p/styles.php');
 
@@ -87,6 +144,61 @@ if (file_exists($CFG->dirroot.'/mod/hvp/renderer.php')) {
                         'path' => $h5pcssurl->out(),
                         'version' => '?ver='.theme_get_revision(),
                 );
+
+                // Adding local_och5p styles.
+                if (file_exists($CFG->dirroot.'/local/och5p/version.php')) {
+                    if (
+                        isset($libraries['H5P.InteractiveVideo']) &&
+                        $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
+                    ) {
+                        // Adding H5PEditor css file.
+                        $h5peditoravurl = new moodle_url('/local/och5p/lib/style/H5PEditor.AV.css');
+                        $styles[] = (object) array(
+                            'path' => $h5peditoravurl->out(),
+                            'version' => '?ver=0.0.1',
+                        );
+
+                        // Adding opencast font css file.
+                        $ocfontsurl = new moodle_url('/local/och5p/lib/style/oc-fonts.css');
+                        $styles[] = (object) array(
+                            'path' => $ocfontsurl->out(),
+                            'version' => '?ver=0.0.1',
+                        );
+                    }
+                }
+            }
+
+            /**
+             * Add scripts when an H5P is displayed.
+             *
+             * @param array $scripts Scripts that will be applied.
+             * @param array $libraries Libraries that will be displayed.
+             * @param string $embedType How the H5P is displayed.
+             */
+            public function hvp_alter_scripts(&$scripts, $libraries, $embedType) {
+                global $CFG;
+
+                // Adding local_och5p scripts.
+                if (file_exists($CFG->dirroot.'/local/och5p/version.php')) {
+                    if (
+                        isset($libraries['H5P.InteractiveVideo']) &&
+                        $libraries['H5P.InteractiveVideo']['majorVersion'] == '1'
+                    ) {
+                        // Adding LTI related script into scripts array.
+                        $h5prunltiurl = new moodle_url('/local/och5p/lib/js/H5PRunLTI.js');
+                        $scripts[] = (object) array(
+                            'path' => $h5prunltiurl->out(),
+                            'version' => '?ver=0.0.1',
+                        );
+
+                        // Adding editor script to scripts array.
+                        $h5peditoravurl = new moodle_url('/local/och5p/lib/js/H5PEditor.AV.js');
+                        $scripts[] = (object) array(
+                            'path' => $h5peditoravurl->out(),
+                            'version' => '?ver=0.0.1',
+                        );
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds related styles and scripts of both `och5p` plugins (`local_och5p` and `local_och5pcore`).
It fixes the related issue for both plugins in:
* https://github.com/Opencast-Moodle/moodle-local_och5p/issues/8
* https://github.com/elan-ev/moodle-local_och5pcore/issues/4

It completed #354