### PR TITLE
Feature: Add frontpage slider functionality, solves #162

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ Changes
 * 2023-09-22 - Make codechecker happier
 * 2023-09-24 - Test: Behat scenario 'Show hint for self enrolment without an enrolment key' was broken, solves #398.
 * 2023-09-22 - Improvement: Reuse Moodle core function remove_dir(), solves #369.
+* 2023-09-19 - Feature: Add slider which can be displayed on site home, solves #162.
 
 ### v4.2-r2
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,10 @@ In this tab, you can enable and configure multiple information banners to be sho
 
 In this tab, you can enable and configure multiple advertisement tiles to be shown on site home.
 
+#### Tab "Slider"
+
+In this tab, you can enable and configure multiple slides to be shown on site home.
+
 ### Settings page "Functionality"
 
 #### Tab "Courses"

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -652,7 +652,8 @@ $string['infobannermodesetting_desc'] = 'With this setting, you can define if in
 $string['infobannerdismissiblesetting'] = 'Info banner {$a->no} dismissible';
 $string['infobannerdismissiblesetting_desc'] = 'With this setting, you can make info banner {$a->no} dismissible. If the user clicks on the x-button in the info banner, the banner will be hidden for this user permanently. The visibility is not reset anyhow automatically, even if you change the content of the info banner. If you want to reset the visibility of the info banner, click the \'Reset visibility\' button below.';
 $string['infobannerstartsetting'] = 'Info banner {$a->no} start time';
-$string['infobannerstartsetting_desc'] = 'With this setting, you can define from when on info banner {$a->no} should be displayed. The configured time is interpreted as server time, not as user time.';$string['infobannerendsetting'] = 'Info banner {$a->no} end time';
+$string['infobannerstartsetting_desc'] = 'With this setting, you can define from when on info banner {$a->no} should be displayed. The configured time is interpreted as server time, not as user time.';
+$string['infobannerendsetting'] = 'Info banner {$a->no} end time';
 $string['infobannerendsetting_desc'] = 'With this setting, you can define until when info banner {$a->no} should be displayed. The configured time is interpreted as server time, not as user time.';
 // Settings: Advertisement tiles tab.
 $string['tilestab'] = 'Advertisement tiles';
@@ -776,6 +777,49 @@ $string['flavourspreviewflavour'] = 'Preview flavour';
 $string['flavourspreviewblindtext'] = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Felis imperdiet proin fermentum leo vel orci porta. Sed nisi lacus sed viverra tellus in hac habitasse. Vivamus arcu felis bibendum ut. Nisi porta lorem mollis aliquam ut porttitor. Odio euismod lacinia at quis risus sed vulputate odio. Sed felis eget velit aliquet sagittis id consectetur purus. Nec ullamcorper sit amet risus nullam eget. Pellentesque sit amet porttitor eget dolor. Cursus mattis molestie a iaculis at erat pellentesque.';
 $string['flavourstitle'] = 'Title';
 $string['flavourstitle_help'] = 'The flavour\'s title is just used internally to allow you to document a particular flavour in the list of flavours.';
+
+// Settings: Slider.
+$string['slidertab'] = 'Slider';
+// ... Section: Slider general.
+$string['slidergeneralheading'] = 'Slider general';
+$string['slideractivatedsetting'] = 'Activate Slider';
+$string['slideractivatedsetting_desc'] = 'With this setting, you activate the slider to be shown on site home.';
+$string['sliderpositiononfrontpage'] = 'Position the slider';
+$string['sliderpositiononfrontpage_desc'] = 'The slider is shown on site home only. With this setting, you control if the slider is displayed before the site home content or after the site home content. If you want to show only the slider on site home and nothing else, all other site home content can be removed by changing the <a href="{$a->url}">site home settings</a>.';
+$string['sliderfrontpagepositionsetting_before'] = 'Before the site home content';
+$string['sliderfrontpagepositionsetting_after'] = 'After the site home content';
+$string['sliderarrownavsetting'] = 'Enable arrow navigation';
+$string['sliderarrownavsetting_desc'] = 'With this setting, you can add navigation arrows on both sides of the slider.';
+$string['sliderindicatornavsetting'] = 'Enable slider indicator navigation';
+$string['sliderindicatornavsetting_desc'] = 'With this setting, you can add navigation indicators on the bottom of the slider.';
+$string['slideranimationsetting'] = 'Animation type';
+$string['slideranimationsetting_desc'] = 'With this setting, you control the slider animation. \'Slide\' applies a sliding animation, \'fade\' applies a fading animation and \'none\' removes all animations.';
+$string['sliderintervalsetting'] = 'Interval speed';
+$string['sliderintervalsetting_desc'] = 'With this setting, you control how long a slide is displayed in milliseconds. The minimum value is 1000 (one second) and the maximum value is 10000 (10 seconds).';
+$string['sliderridesetting'] = 'Cycle through slides';
+$string['sliderridesetting_desc'] = 'With this setting, you control the cycling behaviour of the slider. \'On page load\' begins cycling through slides after the page has finished loading, \'after interaction\' will start cycling after a user has interacted with the slider. \'Never\' disables the automatic cycling of slides altogether, requiring user input to cycle through slides.';
+$string['sliderkeybaordsetting'] = 'Allow keyboard interaction';
+$string['sliderkeybaordsetting_desc'] = 'With this setting, you enable keyboard inputs (arrow keys) to control the slider. Please note that disabling this lowers accessibility.';
+$string['sliderpausesetting'] = 'Pause slider on mouseover';
+$string['sliderpausesetting_desc'] = 'With this setting, you prevent the slider from cycling through the slides when a user hovers over a slide. Please note that disabling this lowers accessibility.';
+$string['sliderwrapsetting'] = 'Continuously cycle through slides';
+$string['sliderwrapsetting_desc'] = 'With this setting, you make the slider cycling through all slides. If you disable this, the slider will stop cycling at the last slide.';
+// ... Section: Slides.
+$string['oneslidetab'] = 'Slide {$a->no}';
+$string['oneslideenabled'] = 'Enable slide {$a->no}';
+$string['oneslideenabled_desc'] = 'With this setting, you can enable slide {$a->no}.';
+$string['oneslidepickimage'] = 'Slide {$a->no} image';
+$string['oneslidepickimage_desc'] = 'Here, you can upload an image file which will be shown as background image behind the content of slide {$a->no}. Please make sure or check that the content is still readable on the background image. Please note that it is required to set an image for the slide to appear.';
+$string['oneslideimagetitle'] = 'Slide {$a->no} image title';
+$string['oneslideimagetitle_desc'] = 'Here, you can set a title for the image of slide {$a->no}. This is an optional setting, the slide will be shown even if you do not set an image title. Please note that not providing an image title lowers accessibility.';
+$string['oneslidelink'] = 'Slide {$a->no} link URL';
+$string['oneslidelink_desc'] = 'Here, you can set a (Moodle-internal or external) URL which the slide content of slide {$a->no} will link to. The link will be opened in a new browser tab. This is an optional setting, the slide will be shown even if you do not set a link URL.';
+$string['oneslidelinktitle'] = 'Slide {$a->no} link title';
+$string['oneslidelinktitle_desc'] = 'Here, you can set a title for the URL of slide {$a->no}. This is an optional setting, the slide will be shown even if you do not set a link title. Please note that not providing a link title lowers accessibility.';
+$string['oneslidecaption'] = 'Slide {$a->no} caption';
+$string['oneslidecaption_desc'] = 'Here, you enter the caption which should be displayed in slide {$a->no}. The caption is displayed at the bottom center of the slide. This is an optional setting, the slide will be shown even if you do not set a caption.';
+$string['oneslidecontent'] = 'Slide {$a->no} content';
+$string['oneslidecontent_desc'] = 'Here, you enter the content which should be displayed in slide {$a->no}. The content is displayed at the bottom center of the slide. If a caption is set, the content is displayed below the caption. This is an optional setting, the slide will be shown even if you do not set any content.';
 
 // Settings: Smart menus page.
 $string['smartmenus'] = 'Smart menus';

--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -196,6 +196,11 @@ if ($PAGE->pagelayout == 'frontpage') {
     require_once(__DIR__ . '/includes/advertisementtiles.php');
 }
 
+// Include the template content for the slider, but only if we are on the frontpage.
+if ($PAGE->pagelayout == 'frontpage') {
+    require_once(__DIR__ . '/includes/slider.php');
+}
+
 // Include the template content for the smart menus.
 require_once(__DIR__ . '/includes/smartmenus.php');
 

--- a/layout/includes/slider.php
+++ b/layout/includes/slider.php
@@ -1,0 +1,120 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - scrollspy include.
+ *
+ * @package   theme_boost_union
+ * @copyright 2023 Annika Lambert <annika.lambert@itc.ruhr-uni-bochum.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+// Require the necessary libraries.
+require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
+
+// Get theme config.
+$config = get_config('theme_boost_union');
+
+$generalsettings = new stdClass();
+$generalsettings->show = $config->{'slideractivatedsetting'};
+
+// Getting and setting the Slider position on the frontpage.
+switch ($config->{'sliderpositiononfrontpage'}) {
+    case THEME_BOOST_UNION_SETTING_SLIDER_FRONTPAGEPOSITION_BEFORE:
+        $templatecontext['sliderpositionbefore'] = true;
+        $templatecontext['sliderpositionafter'] = false;
+        break;
+    case THEME_BOOST_UNION_SETTING_SLIDER_FRONTPAGEPOSITION_AFTER:
+        $templatecontext['sliderpositionbefore'] = false;
+        $templatecontext['sliderpositionafter'] = true;
+}
+
+if ($generalsettings->show) {
+
+    $generalsettings->showarrownav = $config->{'sliderarrownavsetting'};
+    $generalsettings->showindicatornav = $config->{'sliderindicatornavsetting'};
+
+    switch ($config->{'slideranimationsetting'}) {
+        case 0:
+            $generalsettings->animation = "slide";
+            break;
+        case 1:
+            $generalsettings->animation = "slide carousel-fade";
+            break;
+        case 2:
+            $generalsettings->animation = "";
+    }
+    if ($config->{'sliderintervalsetting'} < 1000) {
+        $generalsettings->interval = 1000;
+    } else if ($config->{'sliderintervalsetting'} > 10000) {
+        $generalsettings->interval = 10000;
+    } else {
+        $generalsettings->interval = $config->{'sliderintervalsetting'};
+    }
+
+    // Bootstrap mixed-value logic.
+    switch ($config->{'sliderridesetting'}) {
+        case 0:
+            $templatecontext['ride'] = "carousel";
+            break;
+        case 1:
+            $templatecontext['ride'] = "true";
+            break;
+        case 2:
+            $templatecontext['ride'] = "false";
+    }
+
+    $generalsettings->ride = $templatecontext['ride'];
+
+    /**
+     * Maps boolean values (true/false) to corresponding string values ("true"/"false")
+     *
+     * PHP translates booleans to 1/0 instead of true/false. Bootstrap needs string boolean values.
+     */
+    function boolean_to_string ($var) {
+        if ($var == 1) {
+            return "true";
+        } else {
+            return "false";
+        }
+    }
+    $generalsettings->keyboard = boolean_to_string($config->{'sliderkeyboardsetting'});
+    $generalsettings->pause = boolean_to_string($config->{'sliderpausesetting'});
+    $generalsettings->wrap = boolean_to_string($config->{'sliderwrapsetting'});
+
+
+    $templatecontext['slidergeneralsettings'] = $generalsettings;
+
+
+    $slides = [];
+    for ($i = 1; $i <= THEME_BOOST_UNION_SETTING_SLIDES_COUNT; $i++) {
+        $sliderimage = theme_boost_union_get_urlofsliderimage($i);
+        if ($sliderimage && $config->{'slide' . $i . 'enabled'} == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            $slidercontent = new stdClass();
+            $slidercontent->count = count($slides);
+            $slidercontent->image = $sliderimage;
+            $slidercontent->imagetitle = $config->{'oneslideimagetitle' . $i};
+            $slidercontent->link = $config->{'oneslidelink' . $i};
+            $slidercontent->linktitle = $config->{'oneslidelinktitle' . $i};
+            $slidercontent->caption = $config->{'oneslidecaption' . $i};
+            $slidercontent->content = $config->{'oneslidecontent' . $i};
+            array_push($slides, $slidercontent);
+        }
+    }
+    $templatecontext['slidecontent'] = $slides;
+}

--- a/lib.php
+++ b/lib.php
@@ -50,6 +50,10 @@ define('THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_COLUMN_COUNT', 4);
 define('THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_BEFORE', 1);
 define('THEME_BOOST_UNION_SETTING_ADVERTISEMENTTILES_FRONTPAGEPOSITION_AFTER', 2);
 
+define('THEME_BOOST_UNION_SETTING_SLIDES_COUNT', 6);
+define('THEME_BOOST_UNION_SETTING_SLIDER_FRONTPAGEPOSITION_BEFORE', 1);
+define('THEME_BOOST_UNION_SETTING_SLIDER_FRONTPAGEPOSITION_AFTER', 2);
+
 define('THEME_BOOST_UNION_SETTING_FAVERSION_NONE', 'none');
 define('THEME_BOOST_UNION_SETTING_FAVERSION_FA6FREE', 'fa6free');
 define('THEME_BOOST_UNION_SETTING_FAFILES_MANDATORY', 'm');
@@ -289,6 +293,11 @@ function theme_boost_union_get_extra_scss($theme) {
     // Setting: Mark external links.
     $content .= theme_boost_union_get_scss_to_mark_external_links($theme);
 
+    // Load slider css if slider setting is enabled.
+    if (get_config("theme_boost_union", "slideractivatedsetting")) {
+        $content .= theme_boost_union_get_slider_scss();
+    }
+
     return $content;
 }
 
@@ -384,8 +393,9 @@ function theme_boost_union_pluginfile($course, $cm, $context, $filearea, $args, 
         // This code is copied and modified from theme_boost_pluginfile() in theme/boost/lib.php.
     } else if ($context->contextlevel == CONTEXT_SYSTEM && ($filearea === 'backgroundimage' ||
         $filearea === 'loginbackgroundimage' || $filearea === 'additionalresources' ||
-                $filearea === 'customfonts' || $filearea === 'courseheaderimagefallback' ||
-                preg_match("/tilebackgroundimage[2-9]|1[0-2]?/", $filearea))) {
+                $filearea === 'customfonts' || $filearea === 'fontawesome' || $filearea === 'courseheaderimagefallback' ||
+                preg_match("/tilebackgroundimage[2-9]|1[0-2]?/", $filearea) ||
+                preg_match("/sliderbackgroundimage[2-9]|1[0-2]?/", $filearea))) {
         $theme = theme_config::load('boost_union');
         // By default, theme files must be cache-able by both browsers and proxies.
         if (!array_key_exists('cacheability', $options)) {

--- a/locallib.php
+++ b/locallib.php
@@ -588,6 +588,44 @@ function theme_boost_union_get_urloftilebackgroundimage($tileno) {
 }
 
 /**
+ *
+ * Get the slider image URL from the filearea 'oneslideimage'.tileno.
+ *
+ * @param int $slideno The slide number.
+ * @return string|null
+ */
+function theme_boost_union_get_urlofsliderimage($slideno) {
+    // Only continue if slide number is valid.
+    if ($slideno < 0 || $slideno > THEME_BOOST_UNION_SETTING_SLIDES_COUNT) {
+        return null;
+    }
+    // Get the image config for this slide.
+    $bgconfig = get_config('theme_boost_union', 'oneslidepickimage'.$slideno);
+
+    if (!empty($bgconfig)) {
+        // Get the system context.
+        $systemcontext = context_system::instance();
+
+        // Get filearea.
+        $fs = get_file_storage();
+
+        // Get all files from filearea.
+        $files = $fs->get_area_files($systemcontext->id, 'theme_boost_union', 'sliderbackgroundimage'.$slideno,
+                false, 'itemid', false);
+
+        // Just pick the first file - we are sure that there is just one file.
+        $file = reset($files);
+
+        // Build and return the image URL.
+        return moodle_url::make_pluginfile_url($file->get_contextid(), $file->get_component(), $file->get_filearea(),
+                $file->get_itemid(), $file->get_filepath(), $file->get_filename());
+    }
+
+    // No file was found.
+    return null;
+}
+
+/**
  * Add background images from setting 'loginbackgroundimage' to SCSS.
  *
  * @return string
@@ -1393,4 +1431,17 @@ function theme_boost_union_get_scss_to_mark_external_links($theme) {
         }';
     }
     return $scss;
+}
+
+/**
+ * Get the css settings for the slider feature.
+ */
+function theme_boost_union_get_slider_scss() {
+    $layout = ".carousel-caption { text-shadow: 0px 0px 2px black; }";
+    $layout .= ".carousel-control-prev, .carousel-control-next { filter: drop-shadow( 0px 0px 2px rgb(0, 0, 0)); }";
+    $layout .= ".carousel-indicators { filter: drop-shadow( 0px 0px 1px rgb(0, 0, 0)); }";
+    $layout .= ".carousel-inner { border-radius: 0.5rem; }";
+    $layout .= ".boost-union-frontpage-slider { padding: 15px; }";
+
+    return $layout;
 }

--- a/settings.php
+++ b/settings.php
@@ -1796,8 +1796,169 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $page->add($tab);
 
 
+        // Create Slider tab.
+        $tab = new admin_settingpage('theme_boost_union_slider',
+                get_string('slidertab', 'theme_boost_union', null, true));
+
+        // Create Slider general heading.
+        $name = 'theme_boost_union/slidergeneralheading';
+        $title = get_string('slidergeneralheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Toggle whether Slider is shown.
+        $title = get_string('slideractivatedsetting', 'theme_boost_union', null, true);
+        $description = get_string('slideractivatedsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcheckbox("theme_boost_union/slideractivatedsetting", $title, $description, 0);
+        $tab->add($setting);
+
+        // Setting: Pick where Slider is shown.
+        $choices = [
+                THEME_BOOST_UNION_SETTING_SLIDER_FRONTPAGEPOSITION_BEFORE =>
+                        get_string('sliderfrontpagepositionsetting_before', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_SLIDER_FRONTPAGEPOSITION_AFTER =>
+                        get_string('sliderfrontpagepositionsetting_after', 'theme_boost_union'),
+        ];
+        $name = 'theme_boost_union/sliderpositiononfrontpage';
+        $title = get_string('sliderpositiononfrontpage', 'theme_boost_union', null, true);
+        $url = new moodle_url('/admin/settings.php', ['section' => 'frontpagesettings']);
+        $description = get_string('sliderpositiononfrontpage_desc', 'theme_boost_union', ['url' => $url], true);
+        $setting = new admin_setting_configselect($name, $title, $description,
+                THEME_BOOST_UNION_SETTING_SLIDER_FRONTPAGEPOSITION_BEFORE, $choices);
+        $tab->add($setting);
+
+        // Setting: Toggle whether Slider Arrow Controls are shown.
+        $title = get_string('sliderarrownavsetting', 'theme_boost_union', null, true);
+        $description = get_string('sliderarrownavsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcheckbox("theme_boost_union/sliderarrownavsetting", $title, $description, 0);
+        $tab->add($setting);
+
+        // Setting: Toggle whether Slider Indicator Controls are shown.
+        $title = get_string('sliderindicatornavsetting', 'theme_boost_union', null, true);
+        $description = get_string('sliderindicatornavsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcheckbox("theme_boost_union/sliderindicatornavsetting", $title, $description, 0);
+        $tab->add($setting);
+
+        // Setting: Select a slide-animation.
+        $title = get_string('slideranimationsetting', 'theme_boost_union', null, true);
+        $description = get_string('slideranimationsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect("theme_boost_union/slideranimationsetting", $title, $description, 0,
+                [0 => 'slide', 1 => 'fade', 2 => 'none']);
+        $tab->add($setting);
+
+        // Setting: Set interval speed.
+        $title = get_string('sliderintervalsetting', 'theme_boost_union', null, true);
+        $description = get_string('sliderintervalsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configtext("theme_boost_union/sliderintervalsetting",
+                $title, $description, 5000, PARAM_INT, 6);
+        $tab->add($setting);
+
+        // Setting: Toggle keyboard interaction.
+        $title = get_string('sliderkeybaordsetting', 'theme_boost_union', null, true);
+        $description = get_string('sliderkeybaordsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcheckbox("theme_boost_union/sliderkeyboardsetting", $title, $description, 1);
+        $tab->add($setting);
+
+        // Setting: Set pause behaviour.
+        $title = get_string('sliderpausesetting', 'theme_boost_union', null, true);
+        $description = get_string('sliderpausesetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcheckbox("theme_boost_union/sliderpausesetting", $title, $description, 1);
+        $tab->add($setting);
+
+        // Setting: Set ride behaviour.
+        $title = get_string('sliderridesetting', 'theme_boost_union', null, true);
+        $description = get_string('sliderridesetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect("theme_boost_union/sliderridesetting", $title, $description, 0,
+        [0 => 'on page load', 1 => 'after interaction', 2 => 'never']);
+        $tab->add($setting);
+
+        // Setting: Toggle wrapping.
+        $title = get_string('sliderwrapsetting', 'theme_boost_union', null, true);
+        $description = get_string('sliderwrapsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcheckbox("theme_boost_union/sliderwrapsetting", $title, $description, 1);
+        $tab->add($setting);
+
+        // Create a hardcoded amount of slides.
+        for ($i = 1; $i <= THEME_BOOST_UNION_SETTING_SLIDES_COUNT; $i++) {
+
+            // Create Slide heading.
+            $name = 'theme_boost_union/oneslidetab'.$i;
+            $title = get_string('oneslidetab', 'theme_boost_union', ['no' => $i], true);
+            $setting = new admin_setting_heading($name, $title, null);
+            $tab->add($setting);
+
+            // Setting: Slide enabled.
+            $name = 'theme_boost_union/slide'.$i.'enabled';
+            $title = get_string('oneslideenabled', 'theme_boost_union', ['no' => $i], true);
+            $description = get_string('oneslideenabled_desc', 'theme_boost_union', ['no' => $i], true);
+            $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO,
+                    $yesnooption);
+            $tab->add($setting);
+
+            // Setting: Select picture.
+            $name = 'theme_boost_union/oneslidepickimage'.$i;
+            $title = get_string('oneslidepickimage', 'theme_boost_union', ['no' => $i], true);
+            $description = get_string('oneslidepickimage_desc', 'theme_boost_union', ['no' => $i], true);
+            $setting = new admin_setting_configstoredfile($name, $title, $description, "sliderbackgroundimage".$i, 0,
+                    ['maxfiles' => 1, 'accepted_types' => 'web_image']);
+            $setting->set_updatedcallback('theme_reset_all_caches');
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/oneslidepickimage'.$i, 'theme_boost_union/slide'.$i.'enabled', 'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Set title for picture.
+            $name = 'theme_boost_union/oneslideimagetitle'.$i;
+            $title = get_string('oneslideimagetitle', 'theme_boost_union', ['no' => $i], true);
+            $description = get_string('oneslideimagetitle_desc', 'theme_boost_union', ['no' => $i], true);
+            $setting = new admin_setting_configtext($name, $title, $description, "");
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/oneslideimagetitle'.$i, 'theme_boost_union/slide'.$i.'enabled', 'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Set link for slide.
+            $name = 'theme_boost_union/oneslidelink'.$i;
+            $title = get_string('oneslidelink', 'theme_boost_union', ['no' => $i], true);
+            $description = get_string('oneslidelink_desc', 'theme_boost_union', ['no' => $i], true);
+            $setting = new admin_setting_configtext($name, $title, $description, "");
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/oneslidelink'.$i, 'theme_boost_union/slide'.$i.'enabled', 'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Set title for link.
+            $name = 'theme_boost_union/oneslidelinktitle'.$i;
+            $title = get_string('oneslidelinktitle', 'theme_boost_union', ['no' => $i], true);
+            $description = get_string('oneslidelinktitle_desc', 'theme_boost_union', ['no' => $i], true);
+            $setting = new admin_setting_configtext($name, $title, $description, "");
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/oneslidelinktitle'.$i, 'theme_boost_union/slide'.$i.'enabled', 'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Set Caption text.
+            $name = 'theme_boost_union/oneslidecaption'.$i;
+            $title = get_string('oneslidecaption', 'theme_boost_union', ['no' => $i], true);
+            $description = get_string('oneslidecaption_desc', 'theme_boost_union', ['no' => $i], true);
+            $setting = new admin_setting_configtext($name, $title, $description, "");
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/oneslidecaption'.$i, 'theme_boost_union/slide'.$i.'enabled', 'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES);
+
+            // Setting: Set Content text.
+            $name = 'theme_boost_union/oneslidecontent'.$i;
+            $title = get_string('oneslidecontent', 'theme_boost_union', ['no' => $i], true);
+            $description = get_string('oneslidecontent_desc', 'theme_boost_union', ['no' => $i], true);
+            $setting = new admin_setting_confightmleditor($name, $title, $description, "");
+            $tab->add($setting);
+            $page->hide_if('theme_boost_union/oneslidecontent'.$i, 'theme_boost_union/slide'.$i.'enabled', 'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES);
+        }
+
+        // Add tab to settings page.
+        $page->add($tab);
+
         // Add settings page to the admin settings category.
         $ADMIN->add('theme_boost_union', $page);
+
+
 
         // Create Functionality settings page with tabs
         // (and allow users with the theme/boost_union:configure capability to access it).

--- a/templates/slider.mustache
+++ b/templates/slider.mustache
@@ -1,0 +1,101 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template plugintype_pluginname/template_name
+
+    Template purpose and description.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * none
+
+    Example context (json):
+    {
+    }
+}}
+
+{{#slidergeneralsettings.show}}
+<div class="boost-union-frontpage-slider">
+  <div id="slider" class="carousel {{slidergeneralsettings.animation}}" data-interval="{{slidergeneralsettings.interval}}"
+    data-keyboard="{{slidergeneralsettings.keyboard}}" data-pause="{{slidergeneralsettings.pause}}"
+    data-ride="{{slidergeneralsettings.ride}}" data-wrap="{{slidergeneralsettings.wrap}}"
+  >
+
+    {{#slidergeneralsettings.showindicatornav}}
+    <ol class="carousel-indicators">
+       {{#slidecontent}}
+      <li data-target="#slider" data-slide-to="{{count}}"></li>
+      {{/slidecontent}}
+    </ol>
+    {{/slidergeneralsettings.showindicatornav}}
+
+    <div class="carousel-inner">
+    
+      {{#slidecontent}}
+        <div class="carousel-item">
+        
+          {{#link}}<a href="{{link}}" title="{{linktitle}}" target="_blank">{{/link}}
+            {{#image}}<img class="d-block w-100" src="{{image}}" alt="{{imagetitle}}">{{/image}}
+          {{#link}}</a>{{/link}}
+
+          <div class="carousel-caption">
+            <h5>{{caption}}</h5>
+            {{{content}}}
+          </div>
+        </div>
+      {{/slidecontent}}
+    </div>
+
+    {{#slidergeneralsettings.showarrownav}}
+    <a class="carousel-control-prev" href="#slider" role="button" data-slide="prev">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="sr-only">prev</span>
+    </a>
+    <a class="carousel-control-next" href="#slider" role="button" data-slide="next">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="sr-only">next</span>
+    </a>
+    {{/slidergeneralsettings.showarrownav}}
+      
+  </div>
+</div>
+{{/slidergeneralsettings.show}}
+
+
+{{#js}}
+require(['jquery', 'theme_boost/bootstrap/carousel'], function($) {
+  if (document.getElementById("slider")) {
+    let carouselitems = document.getElementById("slider").getElementsByClassName('carousel-item');
+    if (carouselitems && carouselitems[0]){
+      carouselitems[0].className += ' active';
+    }
+    
+    let carouselindicators = document.getElementById("slider").getElementsByTagName('li');
+    if (carouselindicators && carouselindicators[0]) {
+      carouselindicators[0].className += ' active';
+    }
+    
+    $('#slider').carousel();
+  }
+});
+
+{{/js}}

--- a/templates/theme_boost/drawers.mustache
+++ b/templates/theme_boost/drawers.mustache
@@ -207,6 +207,10 @@
             {{/regions.contentupper.hasblocks}}
             <div id="page-content" class="pb-3 d-print-block">
                 <div id="region-main-box">
+                    {{#sliderpositionbefore}}
+                        {{> theme_boost_union/slider }}
+                    {{/sliderpositionbefore}}
+
                     {{#advtilespositionbefore}}
                         {{> theme_boost_union/advertisementtiles }}
                     {{/advtilespositionbefore}}
@@ -231,6 +235,7 @@
                                 </div>
                             </div>
                         {{/overflow}}
+
                         {{{courserelatedhints}}}
                         {{{ output.main_content }}}
                         {{{ output.activity_navigation }}}
@@ -240,6 +245,10 @@
                     {{#advtilespositionafter}}
                         {{> theme_boost_union/advertisementtiles }}
                     {{/advtilespositionafter}}
+                    {{#sliderpositionafter}}
+                        {{> theme_boost_union/slider }}
+                    {{/sliderpositionafter}}
+
                 </div>
             </div>
             {{#regions.contentlower.hasblocks}}

--- a/tests/behat/theme_boost_union_contentsettings_slider.feature
+++ b/tests/behat/theme_boost_union_contentsettings_slider.feature
@@ -1,0 +1,188 @@
+@theme @theme_boost_union @theme_boost_union_contentsettings @theme_boost_union_contentsettings_slider @javascript @_file_upload
+Feature: Configuring the theme_boost_union plugin for the "Slider" tab on the "Content" page
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+  Background:
+    Given the following config values are set as admin:
+      | debug          | 0 |
+      | debugdisplay   | 0 |
+    And the following config values are set as admin:
+      | config                 | value          | plugin            |
+      | slideractivatedsetting | 1              | theme_boost_union |
+      | slidercaptionsetting   | 1              | theme_boost_union |
+      | slidercontentsetting   | 1              | theme_boost_union |
+      | slide1enabled          | yes            | theme_boost_union |
+    And I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Content" in site administration
+    And I click on "Slider" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.jpg" file to "Slide 1 image" filemanager
+    And I press "Save changes"
+
+  Scenario Outline: Setting: Slider - Display Slider on Frontpage When activated
+    Given the following config values are set as admin:
+     | config                 | value                    | plugin            |
+     | slideractivatedsetting | <setting>                | theme_boost_union |
+    When I am on site homepage
+    Then ".boost-union-frontpage-slider" "css_element" <shouldnotexist>
+
+    Examples:
+      | setting  | shouldnotexist    |
+      | 0        | should not exist  |
+      | 1        | should exist      |
+
+  Scenario: Slider does not appear on any other page than frontpage - e.g. Dashboard
+    When I follow "Dashboard"
+    Then ".boost-union-frontpage-slider" "css_element" should not exist
+
+  Scenario: Slider does not appear on any other page than frontpage - e.g. Course
+    Given the following "courses" exist:
+     | shortname | fullname |
+     | C1        | Course 1 |
+    And I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then ".boost-union-frontpage-slider" "css_element" should not exist
+
+  Scenario Outline: Setting: Slider position - Display Slider before or after main content of site home
+    Given the following config values are set as admin:
+      | config                    | value              | plugin            |
+      | sliderpositiononfrontpage | <position>         | theme_boost_union |
+    When I am on site homepage
+    Then ".boost-union-frontpage-slider" "css_element" should appear <beforeafter> "#region-main" "css_element"
+
+    Examples:
+      | position | beforeafter |
+      | 1        | before      |
+      | 2        | after       |
+
+  Scenario Outline: Setting: Enable/Disable Indicator & Arrow navigation
+    Given the following config values are set as admin:
+      | config                      | value           | plugin            |
+      | sliderarrownavsetting       | <setting>       | theme_boost_union |
+      | sliderindicatornavsetting   | <setting>       | theme_boost_union |
+    When I am on site homepage
+    Then ".boost-union-frontpage-slider #slider .carousel-control-next" "css_element" <shouldnotexist>
+    And ".boost-union-frontpage-slider #slider .carousel-indicators" "css_element" <shouldnotexist>
+
+    Examples:
+      | setting | shouldnotexist   |
+      | 1       | should exist     |
+      | 0       | should not exist |
+
+  Scenario Outline: Setting: Pick Slide Animation
+    Given the following config values are set as admin:
+      | config                      | value           | plugin            |
+      | slideranimationsetting      | <setting>       | theme_boost_union |
+    When I am on site homepage
+    Then ".boost-union-frontpage-slider <animation>" "css_element" <shouldnotexist>
+
+    Examples:
+      | setting | animation             | shouldnotexist    |
+      | 0       | .slide                | should exist      |
+      | 1       | .carousel-fade        | should exist      |
+      | 2       | .slide                | should not exist  |
+      | 2       | .carousel-fade        | should not exist  |
+
+  Scenario Outline: Setting: Slideshow interval speed
+    Given the following config values are set as admin:
+      | config                    | value           | plugin            |
+      | sliderintervalsetting     | <setting>       | theme_boost_union |
+    When I am on site homepage
+    Then the "data-interval" attribute of "#slider" "css_element" should contain "<speed>"
+
+    Examples:
+      | setting | speed     |
+      | 500     | 1000      |
+      | 4321    | 4321      |
+      | 10001   | 10000     |
+
+  Scenario Outline: Setting: Ride
+    Given the following config values are set as admin:
+      | config                      | value           | plugin            |
+      | sliderridesetting           | <setting>       | theme_boost_union |
+    When I am on site homepage
+    Then the "data-ride" attribute of "#slider" "css_element" should contain "<ride>"
+
+    Examples:
+      | setting | ride      |
+      | 0       | carousel  |
+      | 1       | true      |
+      | 2       | false     |
+
+  Scenario Outline: Setting: Keyboard
+    Given the following config values are set as admin:
+      | config                      | value           | plugin            |
+      | sliderkeyboardsetting       | <setting>       | theme_boost_union |
+    When I am on site homepage
+    Then the "data-keyboard" attribute of "#slider" "css_element" should contain "<keyboard>"
+
+    Examples:
+      | setting | keyboard  |
+      | 1       | true      |
+      | 0       | false     |
+
+  Scenario Outline: Setting: Pause on mouseover
+    Given the following config values are set as admin:
+      | config                    | value           | plugin            |
+      | sliderpausesetting        | <setting>       | theme_boost_union |
+    When I am on site homepage
+    Then the "data-pause" attribute of "#slider" "css_element" should contain "<pause>"
+
+    Examples:
+      | setting | pause     |
+      | 1       | true      |
+      | 0       | false     |
+
+  Scenario Outline: Setting: Cycle/ Wrap
+    Given the following config values are set as admin:
+      | config                    | value           | plugin            |
+      | sliderwrapsetting         | <setting>       | theme_boost_union |
+    When I am on site homepage
+    Then the "data-wrap" attribute of "#slider" "css_element" should contain "<wrap>"
+
+    Examples:
+      | setting | wrap      |
+      | 1       | true      |
+      | 0       | false     |
+
+  Scenario: No picture no slide
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Content" in site administration
+    And I click on "Slider" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I delete "login_bg1.jpg" from "Slide 1 image" filemanager
+    And I press "Save changes"
+    And I am on site homepage
+    Then ".boost-union-frontpage-slider .carousel-item" "css_element" should not exist
+
+  Scenario: Disable Slide
+    Given the following config values are set as admin:
+      | config                 | value          | plugin            |
+      | slide1enabled          | no             | theme_boost_union |
+    When I am on site homepage
+    Then ".boost-union-frontpage-slider .carousel-item" "css_element" should not exist
+
+  Scenario: Image Title
+    Given the following config values are set as admin:
+      | config                 | value                           | plugin            |
+      | oneslideimagetitle1    | This is an image description    | theme_boost_union |
+    When I am on site homepage
+    Then the "alt" attribute of ".boost-union-frontpage-slider .carousel-item img" "css_element" should contain "This is an image description"
+
+  Scenario: Link & Link title
+    Given the following config values are set as admin:
+      | config              | value                                 | plugin            |
+      | oneslidelink1       | https://moodlenrw.de/                 | theme_boost_union |
+      | oneslidelinktitle1  | Visit the Moodle.NRW Knowledge Base!  | theme_boost_union |
+    When I am on site homepage
+    Then the "href" attribute of ".boost-union-frontpage-slider .carousel-item a" "css_element" should contain "https://moodlenrw.de/"
+    And the "title" attribute of ".boost-union-frontpage-slider .carousel-item a" "css_element" should contain "Visit the Moodle.NRW Knowledge Base!"
+
+  Scenario: Caption & Content Texts
+    Given the following config values are set as admin:
+      | config                 | value          | plugin            |
+      | oneslidecaption1       | Caption Text   | theme_boost_union |
+      | oneslidecontent1       | Content Text   | theme_boost_union |
+    When I am on site homepage
+    Then I should see "Caption Text" in the ".boost-union-frontpage-slider .carousel-item .carousel-caption h5" "css_element"
+    And I should see "Content Text" in the ".boost-union-frontpage-slider .carousel-item .carousel-caption" "css_element"


### PR DESCRIPTION
This PR adds a slider functionality implemented with the bootstrap [carousel class](https://getbootstrap.com/docs/4.0/components/carousel/).

* Added tab "Slider" to "Content" admin settings
* Added setting to activate the slider feature
* Added setting to have up to 6 slides, each slide consisting of a ...
  * background image
  * link for clicking on that image (optional)
  * caption text being displayed on top of the image (optional)
  * content text being displayed under the caption (optional)
  * title for the image and title for the link to improve accessibility (optional)
* Added setting for where to place the slider on the frontpage
* Added settings corresponding to the bootstrap carousel [options](https://getbootstrap.com/docs/4.0/components/carousel/#options)