### PR TITLE
Bugfix: Styles of styled e-mail previews leaked into the rest of the admin UI, solves #413.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-11-09 - Bugfix: Styles of styled e-mail previews leaked into the rest of the admin UI, solves #413.
 * 2023-11-04 - Bugfix: Pass footnote content without text_to_html div generation, solves #442.
 * 2023-10-09 - Improvement: Add a direct 'view course' icon on the course management pages, solves #129.
 * 2023-10-05 - Improvement: Allow the admin to set the background-position of the background and login background images, solves #111.

--- a/locallib.php
+++ b/locallib.php
@@ -869,7 +869,7 @@ function theme_boost_union_get_emailbrandinghtmlpreview() {
     $mail = $OUTPUT->render_from_template('core/email_html', $mailtemplatecontext);
 
     // And compose mail preview.
-    $previewtemplatecontext = ['mail' => $mail];
+    $previewtemplatecontext = ['mail' => $mail, 'type' => 'html', 'monospace' => false];
     $preview = $OUTPUT->render_from_template('theme_boost_union/emailpreview', $previewtemplatecontext);
 
     return $preview;
@@ -898,10 +898,9 @@ function theme_boost_union_get_emailbrandingtextpreview() {
     // Otherwise, compose mail text.
     $mailtemplatecontext = ['body' => get_string('emailbrandingtextdemobody', 'theme_boost_union')];
     $mail = nl2br($OUTPUT->render_from_template('core/email_text', $mailtemplatecontext));
-    $mail = '<div class="text-monospace">'.$mail.'</div>';
 
     // And compose mail preview.
-    $previewtemplatecontext = ['mail' => $mail];
+    $previewtemplatecontext = ['mail' => $mail, 'type' => 'text', 'monospace' => true];
     $preview = $OUTPUT->render_from_template('theme_boost_union/emailpreview', $previewtemplatecontext);
 
     return $preview;

--- a/templates/emailpreview.mustache
+++ b/templates/emailpreview.mustache
@@ -24,7 +24,34 @@
 
     Example context (json):
     {
-        "mail": "Lorem ipsum"
+        "mail": "Lorem ipsum",
+        "type": "html",
+        "monospace": false
     }
 }}
-<div class="shadow p-3 my-5 bg-white rounded">{{{mail}}}</div>
+{{!
+    This template uses Shadow DOM to avoid that any CSS styles which are added to the mail with a styles tag
+    do not bleed into the admin page.
+    See https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM.
+}}
+<template id="theme_boost_union-email{{type}}preview-shadow">{{{mail}}}</template>
+<div class="shadow p-3 my-5 bg-white rounded {{#monospace}}text-monospace{{/monospace}}" id="theme_boost_union-email{{type}}preview-host"></div>
+{{#js}}
+    // Get the host element.
+    const theme_boost_union_email{{type}}preview_host = document.querySelector('#theme_boost_union-email{{type}}preview-host');
+
+    // Only if the host element exists on this page.
+    if (typeof(theme_boost_union_email{{type}}preview_host) != 'undefined' && theme_boost_union_email{{type}}preview_host != null) {
+        // If the browser supports Shadow DOM.
+        if (document.body.attachShadow) {
+            // Add the email content within a Shadow DOM.
+            const theme_boost_union_email{{type}}preview_shadow = theme_boost_union_email{{type}}preview_host.attachShadow({ mode: "open" });
+            const theme_boost_union_email{{type}}preview_template = document.getElementById('theme_boost_union-email{{type}}preview-shadow');
+            theme_boost_union_email{{type}}preview_shadow.appendChild(theme_boost_union_email{{type}}preview_template.content);
+        } else {
+            // Add the email content without Shadow DOM (which will result in style bleeding anyway).
+            const theme_boost_union_email{{type}}preview_template = document.getElementById('theme_boost_union-email{{type}}preview-shadow');
+            theme_boost_union_email{{type}}preview_host.appendChild(theme_boost_union_email{{type}}preview_template.content);
+        }
+    }
+{{/js}}


### PR DESCRIPTION
I have tested this fix on recent Firefox and Chrome browsers and it worked. However, as it uses the Shadow DOM feature, testing on other / older browsers might be good.

Testing instructions can be found here: https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues/413#issuecomment-1757843468