### PR TITLE
Bugfix: Hide back to top button on small screens as soon as the right hand drawer is opened, solves #379.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-11-09 - Bugfix: Hide back to top button on small screens as soon as the right hand drawer is opened, solves #379.
 * 2023-11-09 - Bugfix: Styles of styled e-mail previews leaked into the rest of the admin UI, solves #413.
 * 2023-11-04 - Bugfix: Pass footnote content without text_to_html div generation, solves #442.
 * 2023-10-09 - Improvement: Add a direct 'view course' icon on the course management pages, solves #129.

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -334,9 +334,20 @@
     /* Move the caret icon slightly up for a nicer look. */
     vertical-align: 0.3rem;
 }
+/* If the right-hand drawer is opened. */
 #page.drawers.show-drawer-right #back-to-top {
-    /* Move the back to top button when right drawer is shown. */
-    right: calc(#{$drawer-right-width} + 2rem);
+    /* On larger screens, the drawer opens near the main content.
+       The back to top button can be moved nicely to the left. */
+    @include media-breakpoint-up(lg) {
+        /* Move the back to top button when right drawer is shown. */
+        right: calc(#{$drawer-right-width} + 2rem);
+    }
+    /* On smaller screens, the drawer opens as an overlay over the main content.
+       The back to top button looks misplaced then. */
+    @include media-breakpoint-down(lg) {
+        /* Hide the back to top button when right drawer is shown. */
+        display: none;
+    }
 }
 /* If the communications button is shown, the back to top button has to be moved more upwards.
    To realize this, our back-to-top JS has added a class to the body tag. */


### PR DESCRIPTION
On Moodle 4.3, the page is scrolled up automatically on smaller screens as soon as the right hand drawer is opened. Thus, this bug does not really affect Moodle 4.3.

However, I have also tested this patch on 4.2 and 4.1 (to which it will be backported, of course, during the next release) and it solves the bug there nicely.