### PR TITLE
Bugfix: Bulk actions widget overlaid course header image, solves #469.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-11-11 - Bugfix: Bulk actions widget overlaid course header image, solves #469.
 * 2023-11-09 - Bugfix: Hide back to top button on small screens as soon as the right hand drawer is opened, solves #379.
 * 2023-11-09 - Bugfix: Styles of styled e-mail previews leaked into the rest of the admin UI, solves #413.
 * 2023-11-04 - Bugfix: Pass footnote content without text_to_html div generation, solves #442.

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -287,6 +287,13 @@
     color: black;
     text-shadow: 0 0 5px white;
 }
+/* If the header actions are placed _within_ the course header image element, i.e. the title is stacked on the image.*/
+#courseheaderimage .header-action {
+    /* Add a background color of white to the header actions to make sure that they can be read properly. */
+    background-color: white;
+    @include border-radius();
+}
+
 
 /*=======================================
  * Settings: Look -> Resources


### PR DESCRIPTION
Before:
<img width="820" alt="grafik" src="https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/1092118/98100975-1a93-42a7-b313-3057dc806778">

After:
<img width="806" alt="grafik" src="https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/1092118/b53d0bc0-75d1-443b-8cbb-c119c37e4d9e">

This was a quick fix in CSS, but it should be sufficient from my point of view.

While the "bulk actions" widget on Moodle 4.3 is the first widget where I realized this header actions area myself, the header actions area has been there before on Moodle 4 already and might be filled by course formats or plugins. Thus, it should be safe to backport this patch to pre-4.3 versions of Boost Union as well.