### PR TITLE
Bugfix: Correct order for in-course breadcrumb when sections exist in…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2023-11-23 - Bugfix: Correct order for in-course breadcrumb when sections exist in it (First categories then sections), solves #317.
+
 ### v4.3-r2
 
 * 2023-11-11 - Bugfix: Bulk actions widget overlaid course header image, solves #469.

--- a/classes/boostnavbar.php
+++ b/classes/boostnavbar.php
@@ -57,7 +57,8 @@ class boostnavbar extends \theme_boost\boostnavbar {
         }
         if ($this->page->context->contextlevel == CONTEXT_COURSE) {
             if (get_config('theme_boost_union', 'categorybreadcrumbs') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
-                // Add the categories breadcrumb navigation nodes.
+                // Create the categories breadcrumb navigation nodes.
+                $categorynodes = [];
                 foreach (array_reverse($this->get_categories()) as $category) {
                     $context = \context_coursecat::instance($category->id);
                     if (!\core_course_category::can_view_category($category)) {
@@ -68,12 +69,24 @@ class boostnavbar extends \theme_boost\boostnavbar {
                     $url = new moodle_url('/course/index.php', ['categoryid' => $category->id]);
                     $name = format_string($category->name, true, ['context' => $displaycontext]);
                     $categorynode = \breadcrumb_navigation_node::create($name, $url, \breadcrumb_navigation_node::TYPE_CATEGORY,
-                            null, $category->id);
+                        null, $category->id);
                     if (!$category->visible) {
                         $categorynode->hidden = true;
                     }
-                    $this->items[] = $categorynode;
+                    $categorynodes[] = $categorynode;
                 }
+                $itemswithcategories = [];
+                if (!$this->items) {
+                    $itemswithcategories = $categorynodes;
+                } else {
+                    foreach ($this->items as $item) {
+                        if ($item->type == \breadcrumb_navigation_node::TYPE_COURSE) {
+                            $itemswithcategories = array_merge($itemswithcategories, $categorynodes);
+                        }
+                        $itemswithcategories[] = $item;
+                    }
+                }
+                $this->items = $itemswithcategories;
             }
 
             // Remove any duplicate navbar nodes.

--- a/tests/behat/behat_theme_boost_union_behat_navigation.php
+++ b/tests/behat/behat_theme_boost_union_behat_navigation.php
@@ -41,4 +41,22 @@ use Behat\Mink\Exception\ExpectationException as ExpectationException;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_theme_boost_union_behat_navigation extends behat_theme_boost_behat_navigation {
+    /**
+     * Opens the second section of the course.
+     *
+     * @Given /^I am in the second section of "(?P<coursefullname_string>(?:[^"]|\\")*)" course$/
+     * @throws coding_exception
+     * @param string $coursefullname The full name of the course.
+     * @return void
+     */
+    public function i_am_in_the_second_section_of_course(string $coursefullname) {
+        $courseid = $this->get_course_id($coursefullname);
+        $urlparams = [
+            'id' => $courseid,
+            'section' => 1,
+        ];
+        $url = new moodle_url('/course/view.php', $urlparams);
+        $this->execute('behat_general::i_visit', [$url]);
+    }
+
 }

--- a/tests/behat/theme_boost_union_feelsettings_navigation.feature
+++ b/tests/behat/theme_boost_union_feelsettings_navigation.feature
@@ -97,6 +97,32 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
       | yes     | should      |
       | no      | should not  |
 
+  Scenario: Setting: Course category breadcrumbs and course sections
+    Given the following "categories" exist:
+      | name           | category | idnumber | category |
+      | Category E     | 0        | CE       | 0        |
+      | Category ED    | 1        | CED      | CE       |
+    And the following "courses" exist:
+      | fullname  | shortname | category |
+      | Course C1 | CC1       | CE       |
+      | Course C2 | CC2       | CED      |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | CC2    | editingteacher |
+    And the following config values are set as admin:
+      | config              | value     | plugin            |
+      | categorybreadcrumbs | yes       | theme_boost_union |
+    When I log in as "teacher1"
+    And I am in the second section of "Course C1" course
+    Then "Category E" "link" should exist in the ".breadcrumb" "css_element"
+    And "Topic 1" "link" should not exist in the ".breadcrumb" "css_element"
+    And I am in the second section of "Course C2" course
+    And "Category E" "link" should exist in the ".breadcrumb" "css_element"
+    And "Category ED" "link" should exist in the ".breadcrumb" "css_element"
+    And "Topic 1" "link" should exist in the ".breadcrumb" "css_element"
+    And "Topic 1" "link" should appear after "Category E" "link"
+    And "Topic 1" "link" should appear after "Category ED" "link"
+
   @javascript
   Scenario: Setting: back to top button - Enable "Back to top button"
     Given the following config values are set as admin:


### PR DESCRIPTION
… it (First categories then sections), solves #317