### PR TITLE
Bugfix: Correct order for in-course breadcrumb when sections exist in it (First categories then sections)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-04-20 - Bugfix: Correct order for in-course breadcrumb when sections exist in it (First categories then sections), solves #317.
 * 2024-04-20 - Cleanup: Add proper JS promise error handling, resolves #435.
 
 ### v4.3-r11

--- a/classes/boostnavbar.php
+++ b/classes/boostnavbar.php
@@ -57,7 +57,8 @@ class boostnavbar extends \theme_boost\boostnavbar {
         }
         if ($this->page->context->contextlevel == CONTEXT_COURSE) {
             if (get_config('theme_boost_union', 'categorybreadcrumbs') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
-                // Add the categories breadcrumb navigation nodes.
+                // Create the categories breadcrumb navigation nodes.
+                $categorynodes = [];
                 foreach (array_reverse($this->get_categories()) as $category) {
                     $context = \context_coursecat::instance($category->id);
                     if (!\core_course_category::can_view_category($category)) {
@@ -72,8 +73,20 @@ class boostnavbar extends \theme_boost\boostnavbar {
                     if (!$category->visible) {
                         $categorynode->hidden = true;
                     }
-                    $this->items[] = $categorynode;
+                    $categorynodes[] = $categorynode;
                 }
+                $itemswithcategories = [];
+                if (!$this->items) {
+                    $itemswithcategories = $categorynodes;
+                } else {
+                    foreach ($this->items as $item) {
+                        if ($item->type == \breadcrumb_navigation_node::TYPE_COURSE) {
+                            $itemswithcategories = array_merge($itemswithcategories, $categorynodes);
+                        }
+                        $itemswithcategories[] = $item;
+                    }
+                }
+                $this->items = $itemswithcategories;
             }
 
             // Remove any duplicate navbar nodes.

--- a/tests/behat/behat_theme_boost_union_behat_navigation.php
+++ b/tests/behat/behat_theme_boost_union_behat_navigation.php
@@ -41,4 +41,40 @@ use Behat\Mink\Exception\ExpectationException as ExpectationException;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_theme_boost_union_behat_navigation extends behat_theme_boost_behat_navigation {
+
+    /**
+     * Changes the course format options.
+     *
+     * @Given /^"(?P<coursefullname_string>(?:[^"]|\\")*)" has been set to one page per section$/
+     * @throws coding_exception
+     * @param string $coursefullname The full name of the course.
+     * @return void
+     */
+    public function has_been_set_to_one_page_per_section(string $coursefullname) {
+        $courseid = $this->get_course_id($coursefullname);
+        /** @var \format_topics $format */
+        $format = course_get_format($courseid);
+        $sectionsperpage = new stdClass();
+        $sectionsperpage->coursedisplay = COURSE_DISPLAY_MULTIPAGE;
+        $format->update_course_format_options($sectionsperpage);
+    }
+
+    /**
+     * Opens the second section of the course.
+     *
+     * @When /^I am in the second section of "(?P<coursefullname_string>(?:[^"]|\\")*)" course$/
+     * @throws coding_exception
+     * @param string $coursefullname The full name of the course.
+     * @return void
+     */
+    public function i_am_in_the_second_section_of_course(string $coursefullname) {
+        $courseid = $this->get_course_id($coursefullname);
+        $urlparams = [
+            'id' => $courseid,
+            'section' => 1,
+        ];
+        $url = new moodle_url('/course/view.php', $urlparams);
+        $this->execute('behat_general::i_visit', [$url]);
+    }
+
 }

--- a/tests/behat/behat_theme_boost_union_behat_navigation.php
+++ b/tests/behat/behat_theme_boost_union_behat_navigation.php
@@ -43,16 +43,14 @@ use Behat\Mink\Exception\ExpectationException as ExpectationException;
 class behat_theme_boost_union_behat_navigation extends behat_theme_boost_behat_navigation {
 
     /**
-     * Changes the course format options.
+     * Set the course format options to one page per section.
      *
      * @Given /^"(?P<coursefullname_string>(?:[^"]|\\")*)" has been set to one page per section$/
-     * @throws coding_exception
      * @param string $coursefullname The full name of the course.
      * @return void
      */
     public function has_been_set_to_one_page_per_section(string $coursefullname) {
         $courseid = $this->get_course_id($coursefullname);
-        /** @var \format_topics $format */
         $format = course_get_format($courseid);
         $sectionsperpage = new stdClass();
         $sectionsperpage->coursedisplay = COURSE_DISPLAY_MULTIPAGE;
@@ -60,21 +58,20 @@ class behat_theme_boost_union_behat_navigation extends behat_theme_boost_behat_n
     }
 
     /**
-     * Opens the second section of the course.
+     * Opens the nth section of the course.
      *
-     * @When /^I am in the second section of "(?P<coursefullname_string>(?:[^"]|\\")*)" course$/
-     * @throws coding_exception
+     * @When /^I am on section "(?P<section_int>(?:[^"]|\\")*)" page of "(?P<coursefullname_string>(?:[^"]|\\")*)" course$/
+     * @param int $section The ID of the section.
      * @param string $coursefullname The full name of the course.
      * @return void
      */
-    public function i_am_in_the_second_section_of_course(string $coursefullname) {
+    public function i_am_on_the_nth_section_page_of_course(int $section, string $coursefullname) {
         $courseid = $this->get_course_id($coursefullname);
         $urlparams = [
             'id' => $courseid,
-            'section' => 1,
+            'section' => $section,
         ];
         $url = new moodle_url('/course/view.php', $urlparams);
         $this->execute('behat_general::i_visit', [$url]);
     }
-
 }

--- a/tests/behat/theme_boost_union_feelsettings_navigation.feature
+++ b/tests/behat/theme_boost_union_feelsettings_navigation.feature
@@ -206,6 +206,34 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
       | yes     | should      |
       | no      | should not  |
 
+  Scenario: Setting: Course category breadcrumbs and course sections
+    Given the following "categories" exist:
+      | name           | category | idnumber | category |
+      | Category E     | 0        | CE       | 0        |
+      | Category ED    | 1        | CED      | CE       |
+    And the following "courses" exist:
+      | fullname  | shortname | category |
+      | Course C1 | CC1       | CE       |
+      | Course C2 | CC2       | CED      |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | CC2    | editingteacher |
+    And the following config values are set as admin:
+      | config              | value     | plugin            |
+      | categorybreadcrumbs | yes       | theme_boost_union |
+    And "Course C1" has been set to one page per section
+    And "Course C2" has been set to one page per section
+    When I log in as "teacher1"
+    And I am in the second section of "Course C1" course
+    Then "Category E" "link" should exist in the ".breadcrumb" "css_element"
+    And "Topic 1" "link" should not exist in the ".breadcrumb" "css_element"
+    And I am in the second section of "Course C2" course
+    And "Category E" "link" should exist in the ".breadcrumb" "css_element"
+    And "Category ED" "link" should exist in the ".breadcrumb" "css_element"
+    And "Topic 1" "link" should exist in the ".breadcrumb" "css_element"
+    And "Topic 1" "link" should appear after "Category E" "link"
+    And "Topic 1" "link" should appear after "Category ED" "link"
+
   @javascript
   Scenario: Setting: back to top button - Enable "Back to top button"
     Given the following config values are set as admin:

--- a/tests/behat/theme_boost_union_feelsettings_navigation.feature
+++ b/tests/behat/theme_boost_union_feelsettings_navigation.feature
@@ -206,7 +206,7 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
       | yes     | should      |
       | no      | should not  |
 
-  Scenario: Setting: Course category breadcrumbs and course sections
+  Scenario: Setting: Course category breadcrumbs (verify that course sections are properly displayed _after_ the categories)
     Given the following "categories" exist:
       | name           | category | idnumber | category |
       | Category E     | 0        | CE       | 0        |
@@ -224,15 +224,17 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
     And "Course C1" has been set to one page per section
     And "Course C2" has been set to one page per section
     When I log in as "teacher1"
-    And I am in the second section of "Course C1" course
+    And I am on section "1" page of "Course C1" course
     Then "Category E" "link" should exist in the ".breadcrumb" "css_element"
+    And "Enrolment options" "text" should exist in the ".breadcrumb" "css_element"
+    And "Enrolment options" "text" should appear after "Category E" "link" in the ".breadcrumb" "css_element"
     And "Topic 1" "link" should not exist in the ".breadcrumb" "css_element"
-    And I am in the second section of "Course C2" course
+    And I am on section "1" page of "Course C2" course
     And "Category E" "link" should exist in the ".breadcrumb" "css_element"
     And "Category ED" "link" should exist in the ".breadcrumb" "css_element"
     And "Topic 1" "link" should exist in the ".breadcrumb" "css_element"
-    And "Topic 1" "link" should appear after "Category E" "link"
-    And "Topic 1" "link" should appear after "Category ED" "link"
+    And "Category ED" "link" should appear after "Category E" "link" in the ".breadcrumb" "css_element"
+    And "Topic 1" "link" should appear after "Category ED" "link" in the ".breadcrumb" "css_element"
 
   @javascript
   Scenario: Setting: back to top button - Enable "Back to top button"


### PR DESCRIPTION
Solves #317