### PR TITLE
Feature: Allow the admin to hide the manual login form, solves #490.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2023-12-10 - Feature: Allow the admin to hide the manual login form and the IDP login intro, solves #490.
 * 2023-12-10 - Improvement: Allow the admin to change the look of the course overview block, solves #204
 
 ### v4.3-r3

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ With this setting, you can optimize the login form to fit to a greater variety o
 
 With this setting, you can make the login form slightly transparent to let the background image shine through even more.
 
+#### Login providers
+
+##### Local login
+
+With this setting, you control if the local login form is shown on the login page or not. By default, the local login form is shown and users an login into the site as normal. If you disable this setting, the local login form is hidden. This allows you to just provide login buttons for external identity providers like OAuth2 or OIDC.
+
+##### IDP login intro
+
+With this setting, you control if the 'Log in using your account on' intro is shown above the IDP login buttons or not. By default, the intro is shown and users will be quickly informed what the IDP buttons are about. If you disable this setting, the IDP intro is hidden. This allows you to provide a clean user login interface if you just use external identity providers like OAuth2 or OIDC.
+
 #### Tab "Dashboard / My courses"
 
 ##### Course overview block

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -23,6 +23,7 @@
  */
 
 namespace theme_boost_union\output;
+use context_course;
 use context_system;
 use moodle_url;
 
@@ -483,5 +484,46 @@ class core_renderer extends \theme_boost\output\core_renderer {
         }
 
         return $this->render_from_template('core/block', $context);
+    }
+
+    /**
+     * Renders the login form.
+     *
+     * This renderer function is copied and modified from /lib/outputrenderers.php
+     *
+     * @param \core_auth\output\login $form The renderable.
+     * @return string
+     */
+    public function render_login(\core_auth\output\login $form) {
+        global $CFG, $SITE;
+
+        $context = $form->export_for_template($this);
+
+        $context->errorformatted = $this->error_text($context->error);
+        $url = $this->get_logo_url();
+        if ($url) {
+            $url = $url->out(false);
+        }
+        $context->logourl = $url;
+        $context->sitename = format_string($SITE->fullname, true,
+            ['context' => context_course::instance(SITEID), "escape" => false]);
+
+        // Check if the local login form is enabled.
+        $loginlocalloginsetting = get_config('theme_boost_union', 'loginlocalloginenable');
+        $showlocallogin = isset($loginlocalloginsetting) ? $loginlocalloginsetting : THEME_BOOST_UNION_SETTING_SELECT_YES;
+        if ($showlocallogin == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            // Add marker to show the local login form to template context.
+            $context->showlocallogin = true;
+        }
+
+        // Check if the IDP login intro is enabled.
+        $loginidpshowintrosetting = get_config('theme_boost_union', 'loginidpshowintro');
+        $showidploginintro = isset($loginidpshowintrosetting) ? $loginidpshowintrosetting : THEME_BOOST_UNION_SETTING_SELECT_YES;
+        if ($showidploginintro == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            // Add marker to show the IDP login intro to template context.
+            $context->showidploginintro = true;
+        }
+
+        return $this->render_from_template('core/loginform', $context);
     }
 }

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -193,6 +193,14 @@ $string['loginformpositionsetting_right'] = 'Right-aligned';
 // ... ... Setting: login form transparency.
 $string['loginformtransparencysetting'] = 'Login form transparency';
 $string['loginformtransparencysetting_desc'] = 'With this setting, you can make the login form slightly transparent to let the background image shine through even more.';
+// ... Section: Login providers.
+$string['loginprovidersheading'] = 'Login providers';
+// ... ... Setting: Local login form.
+$string['loginlocalloginenablesetting'] = 'Local login';
+$string['loginlocalloginenablesetting_desc'] = 'With this setting, you control if the local login form is shown on the login page or not. By default, the local login form is shown and users an login into the site as normal. If you disable this setting, the local login form is hidden. This allows you to just provide login buttons for external identity providers like OAuth2 or OIDC.';
+// ... ... Setting: IDP login intro.
+$string['loginidpshowintrosetting'] = 'IDP login intro';
+$string['loginidpshowintrosetting_desc'] = 'With this setting, you control if the <em>\'{$a}\'</em> intro is shown above the IDP login buttons or not. By default, the intro is shown and users will be quickly informed what the IDP buttons are about. If you disable this setting, the IDP intro is hidden. This allows you to provide a clean user login interface if you just use external identity providers like OAuth2 or OIDC.';
 
 // Settings: Dashboard / My courses tab.
 $string['dashboardtab'] = 'Dashboard / My courses';

--- a/settings.php
+++ b/settings.php
@@ -632,6 +632,26 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
 
+        // Create login providers heading.
+        $name = 'theme_boost_union/loginprovidersheading';
+        $title = get_string('loginprovidersheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Local login.
+        $name = 'theme_boost_union/loginlocalloginenable';
+        $title = get_string('loginlocalloginenablesetting', 'theme_boost_union', null, true);
+        $description = get_string('loginlocalloginenablesetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_YES, $yesnooption);
+        $tab->add($setting);
+
+        // Setting: IDP login intro.
+        $name = 'theme_boost_union/loginidpshowintro';
+        $title = get_string('loginidpshowintrosetting', 'theme_boost_union', null, true);
+        $description = get_string('loginidpshowintrosetting_desc', 'theme_boost_union', get_string('potentialidps', 'auth'), true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_YES, $yesnooption);
+        $tab->add($setting);
+
         // Add tab to settings page.
         $page->add($tab);
 

--- a/templates/core/loginform.mustache
+++ b/templates/core/loginform.mustache
@@ -40,6 +40,8 @@
     * sitename - Name of site.,
     * logintoken - Random token to protect login request.,
     * maintenance - Maintenance message
+    * showlocallogin - Should the local login form be shown?
+    * showidploginintro - Should the IDP login intro be shown?
 
     Example context (json):
     {
@@ -91,7 +93,9 @@
         "sitename": "Beer & Chips",
         "logintoken": "randomstring",
         "maintenance": "For full access to this site, you need to login in as an admin.",
-        "languagemenu": "Choose language"
+        "languagemenu": "Choose language",
+        "showlocallogin": true,
+        "showidploginintro": true
     }
 }}
 {{!
@@ -99,6 +103,8 @@
 
     Modifications compared to the original template:
     * Add btn-secondary class to identityprovider login buttons.
+    * Added the possibility to hide the local login form.
+    * Added the possibility to hide the IDP login intro.
 }}
 
 <div class="loginform">
@@ -127,6 +133,7 @@
     {{#cansignup}}
         <a href="{{signupurl}}" class="sr-only">{{#str}} tocreatenewaccount {{/str}}</a>
     {{/cansignup}}
+    {{#showlocallogin}}
     <form class="login-form" action="{{loginurl}}" method="post" id="login">
         <input id="anchor" type="hidden" name="anchor" value="">
         <script>document.getElementById('anchor').value = location.hash;</script>
@@ -166,10 +173,13 @@
             <a href="{{forgotpasswordurl}}">{{#str}}forgotaccount{{/str}}</a>
         </div>
     </form>
+    {{/showlocallogin}}
     {{#hasidentityproviders}}
         <div class="login-divider"></div>
         <div class="login-identityproviders">
+            {{#showidploginintro}}
             <h2 class="login-heading">{{#str}} potentialidps, auth {{/str}}</h2>
+            {{/showidploginintro}}
             {{#identityproviders}}
                 <a class="btn login-identityprovider-btn btn-block btn-secondary" href="{{url}}">
                     {{#iconurl}}

--- a/tests/behat/theme_boost_union_looksettings_loginpage.feature
+++ b/tests/behat/theme_boost_union_looksettings_loginpage.feature
@@ -137,3 +137,42 @@ Feature: Configuring the theme_boost_union plugin for the "Login page" tab on th
       | setting | shouldcontain      |
       | yes     | should contain     |
       | no      | should not contain |
+
+  Scenario Outline: Setting: Local login
+    Given the following config values are set as admin:
+      | config                | value     | plugin            |
+      | loginlocalloginenable | <setting> | theme_boost_union |
+    When I am on site homepage
+    And I click on "Log in" "link" in the ".logininfo" "css_element"
+    Then "form#login" "css_element" <shouldornot> exist
+
+    Examples:
+      | setting | shouldornot |
+      | yes     | should      |
+      | no      | should not  |
+
+  Scenario Outline: Setting: IDP login intro
+    Given the following config values are set as admin:
+      | config            | value     | plugin            |
+      | loginidpshowintro | <setting> | theme_boost_union |
+    And the following config values are set as admin:
+        | config | value         |
+        | auth   | manual,oauth2 |
+    When I log in as "admin"
+    And I navigate to "Server > OAuth 2 services" in site administration
+    And I press "Google"
+    And I should see "Create new service: Google"
+    And I set the following fields to these values:
+      | Name                       | Testing service                           |
+      | Client ID                  | thisistheclientid                         |
+      | Client secret              | supersecret                               |
+    And I press "Save changes"
+    And I log out
+    And I am on site homepage
+    And I click on "Log in" "link" in the ".logininfo" "css_element"
+    Then ".login-identityproviders .login-heading" "css_element" <shouldornot> exist
+
+    Examples:
+      | setting | shouldornot |
+      | yes     | should      |
+      | no      | should not  |

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2023102006;
+$plugin->version = 2023102007;
 $plugin->release = 'v4.3-r3';
 $plugin->requires = 2023100900;
 $plugin->supported = [403, 403];


### PR DESCRIPTION
This PR introduces two new settings to hide the local login form and the IDP login intro on the login page

Before:
<img width="1047" alt="grafik" src="https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/1092118/da19572a-ccac-4db4-b770-fd9f6762f1b0">

After:
<img width="1046" alt="grafik" src="https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/1092118/c9c23972-ab56-45d1-864b-46b0aaec5f4c">

