### PR TITLE
Upgrade: Migrate the before_standard_html_head() function to the new hook callback on Moodle 4.4, resolves #604.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2024-03-22 - Upgrade: Migrate the before_standard_html_head() function to the new hook callback on Moodle 4.4, resolves #604.
+
 ### v4.3-r10
 
 * 2024-03-18 - Improvement: Add prefixes to the sessionStorage keys in the scrollspy implementation, resolves #598.

--- a/classes/local/hook/output/before_standard_head_html_generation.php
+++ b/classes/local/hook/output/before_standard_head_html_generation.php
@@ -14,20 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace theme_boost_union\local\hook\output;
+
 /**
- * Theme Boost Union - Version file
+ * Theme Boost Union - Hook: Allows plugins to add any elements to the page <head> html tag.
  *
  * @package    theme_boost_union
- * @copyright  2022 Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
+ * @copyright  2024 Alexander Bias <bias@alexanderbias.de>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+class before_standard_head_html_generation {
+    /**
+     * Callback to add head elements.
+     *
+     * @param \core\hook\output\before_standard_head_html_generation $hook
+     */
+    public static function callback(\core\hook\output\before_standard_head_html_generation $hook): void {
+        global $CFG;
 
-defined('MOODLE_INTERNAL') || die();
+        // Require local library.
+        require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
 
-$plugin->component = 'theme_boost_union';
-$plugin->version = 2023102032;
-$plugin->release = 'v4.3-r10';
-$plugin->requires = 2023100900;
-$plugin->supported = [403, 403];
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = ['theme_boost' => 2023100900];
+        // Call callback implementation.
+        theme_boost_union_callbackimpl_before_standard_html($hook);
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -15,19 +15,19 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Theme Boost Union - Version file
+ * Theme Boost Union - Hook callbacks.
  *
  * @package    theme_boost_union
- * @copyright  2022 Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
+ * @copyright  2024 Alexander Bias <bias@alexanderbias.de>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'theme_boost_union';
-$plugin->version = 2023102032;
-$plugin->release = 'v4.3-r10';
-$plugin->requires = 2023100900;
-$plugin->supported = [403, 403];
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = ['theme_boost' => 2023100900];
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_standard_head_html_generation::class,
+        'callback' => 'theme_boost_union\local\hook\output\before_standard_head_html_generation::callback',
+        'priority' => 0,
+    ],
+];

--- a/lib.php
+++ b/lib.php
@@ -499,35 +499,14 @@ function theme_boost_union_pluginfile($course, $cm, $context, $filearea, $args, 
 }
 
 /**
- * Callback to add head elements.
- *
- * We use this callback to inject the flavour's CSS code to the page.
+ * Callback to add head elements (for releases up to Moodle 4.3).
  *
  * @return string
  */
 function theme_boost_union_before_standard_html_head() {
-    global $CFG, $PAGE;
 
-    // Initialize HTML.
-    $html = '';
-
-    // If a theme other than Boost Union or a child theme of it is active, return directly.
-    // This is necessary as the before_standard_html_head() callback is called regardless of the active theme.
-    if ($PAGE->theme->name != 'boost_union' && !in_array('boost_union', $PAGE->theme->parents)) {
-        return $html;
-    }
-
-    // Require local library.
-    require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
-
-    // Add the flavour CSS to the page.
-    theme_boost_union_add_flavourcss_to_page();
-
-    // Add the touch icons to the page.
-    $html .= theme_boost_union_get_touchicons_html_for_page();
-
-    // Return the HTML code.
-    return $html;
+    // Call and return callback implementation.
+    return theme_boost_union_callbackimpl_before_standard_html();
 }
 
 /**

--- a/locallib.php
+++ b/locallib.php
@@ -1961,3 +1961,55 @@ function theme_boost_union_get_navbar_starredcoursespopover() {
 
     return $html;
 }
+
+/**
+ * Callback to add head elements.
+ * This function is implemented here and used from two locations:
+ * -> function theme_boost_union_before_standard_html_head in lib.php (for releases up to Moodle 4.3)
+ * -> class theme_boost_union\local\hook\output\before_standard_head_html_generation (for releases from Moodle 4.4 on).
+ *
+ * We use this callback
+ * -> to inject the flavour's CSS code to the page
+ * -> to add the touch icons to the page
+ *
+ * @param \core\hook\output\before_standard_head_html_generation $hook If the hook is passed, the hook implementation will
+ *                                                                     be used. If not, the legacy implementation will
+ *                                                                     be used.
+ * @return string|void The legacy implementation will return a string, the hook implementation will return nothing.
+ */
+function theme_boost_union_callbackimpl_before_standard_html(&$hook = null) {
+    global $CFG, $PAGE;
+
+    // Require local library.
+    require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
+
+    // Initialize HTML.
+    $html = '';
+
+    // If a theme other than Boost Union or a child theme of it is active, return directly.
+    // This is necessary as the callback is called regardless of the active theme.
+    if ($PAGE->theme->name != 'boost_union' && !in_array('boost_union', $PAGE->theme->parents)) {
+        if ($hook != null) {
+            return;
+        } else {
+            return $html;
+        }
+    }
+
+    // Require local library.
+    require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
+
+    // Add the flavour CSS to the page.
+    theme_boost_union_add_flavourcss_to_page();
+
+    // Add the touch icons to the page.
+    $html .= theme_boost_union_get_touchicons_html_for_page();
+
+    if ($hook != null) {
+        // Add the HTML code to the hook.
+        $hook->add_html($html);
+    } else {
+        // Return the HTML code.
+        return $html;
+    }
+}


### PR DESCRIPTION
This patch is mainly targeted towards the upcoming Moodle 4.4 release, but it is implemented in a backwards-compatible way. 

It has been tested by me manually in 4.4dev. As soon as the tests of the PR (on 4.3) are green, it can be merged.