### PR TITLE
Upgrade: Boost Union settings were moved to an admin settings category of its own to support the new theme chooser on Moodle 4.4, resolves #482.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Changes
 
 ### Unreleased
 
+* 2024-03-25 - Upgrade: Boost Union settings were moved to an admin settings category of its own to support the new theme chooser on Moodle 4.4, resolves #482.
+               Please note: This change is backported to Moodle 4.3 to 4.1.
 * 2024-03-22 - Upgrade: Migrate the before_standard_html_head() function to the new hook callback on Moodle 4.4, resolves #604.
 
 ### v4.3-r10

--- a/settings.php
+++ b/settings.php
@@ -37,16 +37,18 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
     // stupid "Too much data passed as arguments to js_call_amd..." debugging message if we would
     // pack all settings onto just one settings page.
     // To achieve this goal, we create a custom admin settings category and fill it with several settings pages.
-    // However, there is still the $settings variable which is expected by Moodle coreto be filled with the theme
-    // settings and which is automatically added to the admin settings tree in one settings page.
-    // To avoid that there appears an empty "Boost Union" settings page near our own custom settings category,
-    // we set $settings to null.
 
-    // Avoid that the theme settings page is auto-created.
-    $settings = null;
+    // However, there is still the $settings variable which is expected by Moodle core to be filled with the theme
+    // settings and which is automatically linked from the theme selector page.
+    // To avoid that there appears a broken "Boost Union" settings page, we redirect the user to the settings
+    // category if he opens this page.
+    $mainsettingspageurl = new moodle_url('/admin/settings.php', ['section' => 'themesettingboost_union']);
+    if ($ADMIN->fulltree && $PAGE->has_set_url() && $PAGE->url->compare($mainsettingspageurl)) {
+        redirect(new moodle_url('/admin/category.php', ['category' => 'theme_boost_union']));
+    }
 
     // Create custom admin settings category.
-    $ADMIN->add('themes', new admin_category('theme_boost_union',
+    $ADMIN->add('appearance', new admin_category('theme_boost_union',
             get_string('pluginname', 'theme_boost_union', null, true)));
 
     // Create empty settings page structure to make the site administration work on non-admin pages.

--- a/tests/behat/behat_theme_boost_union_base_smartmenus.php
+++ b/tests/behat/behat_theme_boost_union_base_smartmenus.php
@@ -42,7 +42,7 @@ class behat_theme_boost_union_base_smartmenus extends behat_base {
      */
     public function i_navigate_to_smartmenus() {
         $this->execute('behat_navigation::i_navigate_to_in_site_administration',
-            ['Appearance > Themes > Boost Union > Smart menus']);
+            ['Appearance > Boost Union > Smart menus']);
     }
 
     /**
@@ -53,7 +53,7 @@ class behat_theme_boost_union_base_smartmenus extends behat_base {
      */
     public function i_navigate_to_smartmenu_item($menu) {
         $this->execute('behat_navigation::i_navigate_to_in_site_administration',
-            ['Appearance > Themes > Boost Union > Smart menus']);
+            ['Appearance > Boost Union > Smart menus']);
         $this->execute('behat_general::i_click_on_in_the', ['.action-list-items', 'css_element', $menu, 'table_row']);
     }
 
@@ -66,7 +66,7 @@ class behat_theme_boost_union_base_smartmenus extends behat_base {
      */
     public function i_create_smartmenu_with_the_following_fields_to_these_values(TableNode $data) {
         $this->execute('behat_navigation::i_navigate_to_in_site_administration',
-            ['Appearance > Themes > Boost Union > Smart menus']);
+            ['Appearance > Boost Union > Smart menus']);
         $this->execute('behat_general::i_click_on', ['Create menu', 'button']);
         $this->execute('behat_forms::i_set_the_following_fields_to_these_values', [$data]);
         $this->execute('behat_general::i_click_on', ['Save and return', 'button']);
@@ -82,7 +82,7 @@ class behat_theme_boost_union_base_smartmenus extends behat_base {
      */
     public function i_create_smartmenus_with_the_following_fields_to_these_values($menu, TableNode $data) {
         $this->execute('behat_navigation::i_navigate_to_in_site_administration',
-            ['Appearance > Themes > Boost Union > Smart menus']);
+            ['Appearance > Boost Union > Smart menus']);
         $this->execute('behat_general::i_click_on_in_the', ['.action-list-items', 'css_element', $menu, 'table_row']);
         $this->execute('behat_general::i_click_on', ['Add menu item', 'button']);
         $this->execute('behat_forms::i_set_the_following_fields_to_these_values', [$data]);

--- a/tests/behat/theme_boost_union_flavourssettings_application.feature
+++ b/tests/behat/theme_boost_union_flavourssettings_application.feature
@@ -36,7 +36,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
 
   Scenario: Flavours: Application - Flavour ID is added as body class attribute
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -48,7 +48,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript
   Scenario: Flavours: Application - Apply a flavour to a particular category without subcategories (and show this fact in the overview table and make sure that other categories are not affected)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -87,7 +87,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript
   Scenario: Flavours: Application - Apply a flavour to a particular category with subcategories (and show this fact in the overview table and make sure that other categories are not affected)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -126,7 +126,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript
   Scenario: Flavours: Application - Do not apply a flavour to categories anymore
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -162,7 +162,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript
   Scenario: Flavours: Application - Apply a flavour to a particular cohort (and show this fact in the overview table and make sure that other cohorts are not affected)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -192,7 +192,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript
   Scenario: Flavours: Application - Do not apply a flavour to cohorts anymore
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -224,7 +224,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript
   Scenario: Flavours: Application - Stop after the first matching flavour
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets

--- a/tests/behat/theme_boost_union_flavourssettings_caching.feature
+++ b/tests/behat/theme_boost_union_flavourssettings_caching.feature
@@ -16,7 +16,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
   @javascript
   Scenario: Flavours: Caching - After creating an additional flavour (and thereby changing the flavour which applies to a particular user), the flavour which applies now should take direct effect (i.e. the flavours cache is properly purged)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -26,7 +26,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I should not see "Course categories" in the "Non-effective flavour" "table_row"
     And I am on "Course 1" course homepage
     And I should see "Course 1" in the "#page-header .page-header-headings" "css_element"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -51,7 +51,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
   @javascript
   Scenario: Flavours: Caching - After editing a flavour (and thereby changing the flavour which applies to a particular user), the flavour which applies now should take direct effect (i.e. the flavours cache is properly purged)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -70,7 +70,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I click on "Save changes" "button"
     And I should see "Flavours" in the "#region-main h2" "css_element"
     And I should see "Course categories" in the "Effective flavour" "table_row"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -91,7 +91,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I should see "Course categories" in the "Non-effective flavour" "table_row"
     And I am on "Course 1" course homepage
     And I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on ".action-edit" "css_element" in the "Effective flavour" "table_row"
     And I click on "span.badge" "css_element" in the "#fitem_id_applytocategories_ids .form-autocomplete-selection" "css_element"
     And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
@@ -106,7 +106,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
   @javascript
   Scenario: Flavours: Caching - After deleting a flavour (and thereby changing the flavour which applies to a particular user), the flavour which applies now should take direct effect (i.e. the flavours cache is properly purged)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -125,7 +125,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I click on "Save changes" "button"
     And I should see "Flavours" in the "#region-main h2" "css_element"
     And I should see "Course categories" in the "Effective flavour" "table_row"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -146,7 +146,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I should see "Course categories" in the "Non-effective flavour" "table_row"
     And I am on "Course 1" course homepage
     And I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on ".action-delete" "css_element" in the "Effective flavour" "table_row"
     And I click on "Delete" "button"
     And I am on "Course 1" course homepage
@@ -155,7 +155,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
   @javascript
   Scenario Outline: Flavours: Caching - After sorting a flavour (and thereby changing the flavour which applies to a particular user), the flavour which applies now should take direct effect (i.e. the flavours cache is properly purged)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -173,7 +173,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I set the field "Include subcategories" to "0"
     And I click on "Save changes" "button"
     And I should see "Flavours" in the "#region-main h2" "css_element"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -193,7 +193,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I should see "Flavours" in the "#region-main h2" "css_element"
     And I am on "Course 1" course homepage
     And I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on ".sort-flavour-<action>-action" "css_element" in the "<flavourtosort> flavour" "table_row"
     And I am on "Course 1" course homepage
     Then I should see "Course 1" in the "#page-header .page-header-headings" "css_element"
@@ -214,7 +214,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
       | admin | CH1    |
       | admin | CH2    |
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -232,7 +232,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I click on "Save changes" "button"
     And I should see "Flavours" in the "#region-main h2" "css_element"
     And I should see "Cohorts" in the "Effective flavour" "table_row"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -269,7 +269,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
       | user  | cohort |
       | admin | CH2    |
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -287,7 +287,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I click on "Save changes" "button"
     And I should see "Flavours" in the "#region-main h2" "css_element"
     And I should see "Cohorts" in the "Effective flavour" "table_row"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -327,7 +327,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
       | admin | CH1    |
       | admin | CH2    |
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets
@@ -345,7 +345,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, cachin
     And I click on "Save changes" "button"
     And I should see "Flavours" in the "#region-main h2" "css_element"
     And I should see "Cohorts" in the "Effective flavour" "table_row"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I expand all fieldsets

--- a/tests/behat/theme_boost_union_flavourssettings_look.feature
+++ b/tests/behat/theme_boost_union_flavourssettings_look.feature
@@ -16,7 +16,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript @_file_upload
   Scenario: Flavours: Compact logo - Upload a compact logo (with a global compact logo not having been uploaded before)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -30,11 +30,11 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript @_file_upload
   Scenario: Flavours: Compact logo - Upload a compact logo (with a global compact logo being overridden)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Site branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I upload "theme/boost_union/tests/fixtures/moodlelogo.png" file to "Compact logo" filemanager
     And I click on "Save changes" "button"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -48,11 +48,11 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript @_file_upload
   Scenario: Flavours: Compact logo - Do not upload a compact logo (with a global compact logo being served properly)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Site branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I upload "theme/boost_union/tests/fixtures/moodlelogo.png" file to "Compact logo" filemanager
     And I click on "Save changes" "button"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -65,7 +65,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript @_file_upload
   Scenario: Flavours: Favicon - Upload a favicon (with a global favicon not having been uploaded before)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -83,7 +83,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
     And I click on "Site branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I upload "theme/boost_union/tests/fixtures/favicon.ico" file to "Favicon" filemanager
     And I press "Save changes"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -101,7 +101,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
     And I click on "Site branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I upload "theme/boost_union/tests/fixtures/favicon.ico" file to "Favicon" filemanager
     And I click on "Save changes" "button"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -123,7 +123,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   @javascript
   Scenario: Flavours: Custom SCSS - Add custom SCSS to the page
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"

--- a/tests/behat/theme_boost_union_flavourssettings_management.feature
+++ b/tests/behat/theme_boost_union_flavourssettings_management.feature
@@ -6,7 +6,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - When the theme is installed, no flavours exist
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     Then I should see "Flavours" in the "#region-main h2" "css_element"
     And I should see "There aren't any flavours created yet. Please create your first flavour to get things going."
     And "table" "css_element" should not exist in the "#region-main" "css_element"
@@ -17,7 +17,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - Add a flavour (and set its metadata)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -35,7 +35,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - Preview existing flavours
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -50,7 +50,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - Edit (the metadata of) an existing flavour
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -68,7 +68,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - Delete existing flavours (until none is left anymore)
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -98,7 +98,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - Cancel the creation of a new flavour
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I click on "Cancel" "button"
@@ -112,7 +112,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - Cancel the editing of an existing flavour
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -130,7 +130,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - Cancel the deletion of an existing flavour
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"
@@ -151,7 +151,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, managi
 
   Scenario: Flavours: Management - Move existing flavours up and down
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
     And I should see "Create flavour" in the "#page-header h1" "css_element"
     And I set the field "Title" to "My shiny new flavour"

--- a/tests/behat/theme_boost_union_general.feature
+++ b/tests/behat/theme_boost_union_general.feature
@@ -1,14 +1,23 @@
 @theme @theme_boost_union @theme_boost_union_general @theme_boost_union_general_admin
 Feature: Configuring the theme_boost_union plugin as admin
   In order to use the features
-  As manager
+  As admin
   I need to be able to configure the theme Boost Union plugin
+
+#  @javascript
+#  Scenario: Redirect the user from the theme selector page to the Boost Union settings category page
+#    When I log in as "admin"
+#    And I follow "Site administration"
+#    And I navigate to "Appearance > Themes" in site administration
+#    And I click on "#theme-settings-boost_union" "css_element" in the "#theme-card-boost_union" "css_element"
+#    And I should see "Category: Boost Union"
+#    And I should see "Boost Union" in the ".breadcrumb" "css_element"
 
   @javascript
   Scenario: Switch to the active Boost Union admin sub-tab after saving a setting and the following page reload
     When I log in as "admin"
     And I follow "Site administration"
-    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Page" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "Course content max width" to "600px"
     And I click on "Save changes" "button"

--- a/tests/behat/theme_boost_union_goodiesfordesigners.feature
+++ b/tests/behat/theme_boost_union_goodiesfordesigners.feature
@@ -27,7 +27,7 @@ Feature: Using the goodies for designers in the theme_boost_union plugin
   @javascript
   Scenario: Feature: Themerev as SCSS variable
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a small CSS snippet to the page which adds the themrev to the Dashboard header.
     # This is just to make it easy to detect that this SCSS variable is set.

--- a/tests/behat/theme_boost_union_looksettings_h5p.feature
+++ b/tests/behat/theme_boost_union_looksettings_h5p.feature
@@ -20,7 +20,7 @@ Feature: Configuring the theme_boost_union plugin for the "H5P" tab on the "Look
   @javascript
   Scenario: Setting: Raw CSS for H5P - Add custom SCSS to a mod_h5p content type
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "H5P" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a small CSS snippet to the page which makes the H5P content red.
     # This is just to make it easy to detect the effect of this custom CSS code.

--- a/tests/behat/theme_boost_union_looksettings_scss.feature
+++ b/tests/behat/theme_boost_union_looksettings_scss.feature
@@ -12,7 +12,7 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
   @javascript
   Scenario: Setting: Raw initial SCSS - Add custom SCSS to the theme
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a small CSS snippet to the page which hides the heading in the page header.
     # This is just to make it easy to detect the effect of this custom SCSS code.
@@ -27,7 +27,7 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
   @javascript
   Scenario: Setting: Raw SCSS - Add custom SCSS to the theme
     When I log in as "admin"
-    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a small CSS snippet to the page which hides the heading in the page header.
     # This is just to make it easy to detect the effect of this custom SCSS code.

--- a/tests/behat/theme_boost_union_managers.feature
+++ b/tests/behat/theme_boost_union_managers.feature
@@ -20,12 +20,12 @@ Feature: Configuring the theme_boost_union plugin as manager
     And I follow "Site administration"
     Then ".secondary-navigation li[data-key='appearance']" "css_element" should exist
     # We just need to test the 'look' page as a representative of all theme admin pages.
-    And I navigate to "Appearance > Themes > Boost Union > Look" in site administration
+    And I navigate to "Appearance > Boost Union > Look" in site administration
     And "body#page-admin-setting-theme_boost_union_look" "css_element" should exist
     And I should see "Look" in the "#region-main" "css_element"
     And I should see "General settings" in the "#region-main" "css_element"
     # However, we have to test the 'flavours' page as well as this is an external admin page.
-    And I navigate to "Appearance > Themes > Boost Union > Flavours" in site administration
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And "body#page-admin-theme-boost_union-flavours-overview" "css_element" should exist
     And I should see "Flavours" in the "#region-main" "css_element"
     And I should see "Create flavour" in the "#region-main" "css_element"


### PR DESCRIPTION
This PR ships with a commended Behat test in tests/behat/theme_boost_union_general.feature which cannot be uncommented before Moodle 4.4

I will create a follow-up issue to uncomment it on 4.4.