### PR TITLE
Upgrade: Boost Union settings were moved to an admin settings category of its own to support the new theme chooser on Moodle 4.4, refines #482

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@ Changes
 * 2024-04-01 - Improvement: Enhance the activitynavigation setting description to cover section navigation as well, resolves #536.
 * 2024-03-30 - Bugfix: Smart menu divider did not work for user menu submenus, resolves #537.
 * 2024-03-25 - Upgrade: Boost Union settings were moved to an admin settings category of its own to support the new theme chooser on Moodle 4.4, resolves #482.
-               Please note: This change is backported to Moodle 4.3 to 4.1.
+               Please note: This change is backported to Moodle 4.3 to 4.1 as well.
+               Child theme support: If you are running a Boost Union Child theme, please make sure to adapt your child theme to our latest boilerplate.
 * 2024-03-22 - Upgrade: Migrate the before_standard_html_head() function to the new hook callback on Moodle 4.4, resolves #604.
 
 ### v4.3-r10

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Usage & Settings
 After installing the theme, it does not do anything to Moodle yet.
 
 To configure the theme and its behaviour, please visit:
-Site administration -> Appearance -> Themes -> Boost Union.
+Site administration -> Appearance -> Boost Union.
 
 There, you find multiple setting pages:
 

--- a/flavours/edit.php
+++ b/flavours/edit.php
@@ -47,7 +47,6 @@ require_capability('theme/boost_union:configure', $context);
 $PAGE->set_context($context);
 $PAGE->set_url(new moodle_url('/theme/boost_union/flavours/edit.php', ['action' => $action]));
 $PAGE->set_cacheable(false);
-$PAGE->navbar->add(get_string('themes', 'core'), new moodle_url('/admin/category.php', ['category' => 'themes']));
 $PAGE->navbar->add(get_string('pluginname', 'theme_boost_union'), new moodle_url('/admin/category.php',
         ['category' => 'theme_boost_union']));
 $PAGE->navbar->add(get_string('flavoursflavours', 'theme_boost_union'), new moodle_url('/theme/boost_union/flavours/overview.php'));

--- a/flavours/preview.php
+++ b/flavours/preview.php
@@ -44,7 +44,6 @@ require_capability('theme/boost_union:configure', $context);
 $PAGE->set_context($context);
 $PAGE->set_url(new moodle_url('/theme/boost_union/flavours/preview.php', ['id' => $flavourid]));
 $PAGE->set_cacheable(false);
-$PAGE->navbar->add(get_string('themes', 'core'), new moodle_url('/admin/category.php', ['category' => 'themes']));
 $PAGE->navbar->add(get_string('pluginname', 'theme_boost_union'), new moodle_url('/admin/category.php',
         ['category' => 'theme_boost_union']));
 $PAGE->navbar->add(get_string('flavoursflavours', 'theme_boost_union'), new moodle_url('/theme/boost_union/flavours/overview.php'));

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -33,6 +33,18 @@ $string['githubissueslink'] = '<a href="https://github.com/moodle-an-hochschulen
 // Settings: General strings.
 $string['dontchange'] = 'Do not change anything';
 
+// Settings: Overview page.
+$string['settingsoverview'] = 'Settings overview';
+$string['settingsoverview_title'] = 'Boost Union settings overview';
+$string['settingsoverview_look_desc'] = 'Settings for branding your Moodle site are located here: Colors, icons, images, sizing and, of course, custom SCSS.';
+$string['settingsoverview_feel_desc'] = 'Settings for the overall behaviour of your Moodle site are located here: Navigation items, navigation helpers, blocks and links.';
+$string['settingsoverview_content_desc'] = 'Settings for the global content of your Moodle site are located here: Footer, static pages, info banners, advertisement tiles and sliders.';
+$string['settingsoverview_functionality_desc'] = 'Settings for additional useful global or course-related functionality on your Moodle site are located here.';
+$string['settingsoverview_flavours_desc'] = 'With flavours, you can diversify the look of your Moodle site between cohorts and / or course categories.';
+$string['settingsoverview_smartmenus_desc'] = 'With smart menus, you can extend the navigation items of your Moodle site in the main menu and the user menus well as introduce a bottom menu or a top menu.';
+$string['settingsoverview_all'] = 'All settings on one page';
+$string['settingsoverview_all_desc'] = 'Here, you can open the standard Moodle category settings page for Boost Union that shows all settings on one page. But beware, it is really packed.';
+
 // Settings: Look page.
 $string['configtitlelook'] = 'Look';
 

--- a/settings.php
+++ b/settings.php
@@ -40,11 +40,11 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
 
     // However, there is still the $settings variable which is expected by Moodle core to be filled with the theme
     // settings and which is automatically linked from the theme selector page.
-    // To avoid that there appears a broken "Boost Union" settings page, we redirect the user to the settings
-    // category if he opens this page.
+    // To avoid that there appears a broken "Boost Union" settings page, we redirect the user to a settings
+    // overview page if he opens this page.
     $mainsettingspageurl = new moodle_url('/admin/settings.php', ['section' => 'themesettingboost_union']);
     if ($ADMIN->fulltree && $PAGE->has_set_url() && $PAGE->url->compare($mainsettingspageurl)) {
-        redirect(new moodle_url('/admin/category.php', ['category' => 'theme_boost_union']));
+        redirect(new moodle_url('/theme/boost_union/settings_overview.php'));
     }
 
     // Create custom admin settings category.
@@ -53,6 +53,14 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
 
     // Create empty settings page structure to make the site administration work on non-admin pages.
     if (!$ADMIN->fulltree) {
+        // Create Overview page
+        // (and allow users with the theme/boost_union:configure capability to access it).
+        $overviewpage = new admin_externalpage('theme_boost_union_overview',
+                get_string('settingsoverview', 'theme_boost_union', null, true),
+                new moodle_url('/theme/boost_union/settings_overview.php'),
+                'theme/boost_union:configure');
+        $ADMIN->add('theme_boost_union', $overviewpage);
+
         // Create Look settings page
         // (and allow users with the theme/boost_union:configure capability to access it).
         $tab = new admin_settingpage('theme_boost_union_look',
@@ -115,7 +123,6 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         // Prepare regular expression for checking if the value is a percent number (from 0% to 100%) or a pixel number
         // (with 3 or 4 digits) or a viewport width number (from 0 to 100).
         $widthregex = '/^((\d{1,2}|100)%)|((\d{1,2}|100)vw)|(\d{3,4}px)$/';
-
 
         // Create Look settings page with tabs
         // (and allow users with the theme/boost_union:configure capability to access it).

--- a/settings_overview.php
+++ b/settings_overview.php
@@ -1,0 +1,117 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - Settings overview file (which is just used as broker page).
+ *
+ * @package    theme_boost_union
+ * @copyright  2024 Alexander Bias <bias@alexanderbias.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__.'/../../config.php');
+
+// Require login.
+require_login();
+
+// Get system context.
+$context = context_system::instance();
+
+// Require the necessary capability to configure the theme (or an admin account which has this capability automatically).
+require_capability('theme/boost_union:configure', $context);
+
+// Set page URL.
+$PAGE->set_url('/theme/boost_union/settings_overview.php');
+
+// Set page layout.
+$PAGE->set_pagelayout('admin');
+
+// Set page context.
+$PAGE->set_context($context);
+
+// Set page title.
+$PAGE->set_title(get_string('settingsoverview_title', 'theme_boost_union'));
+
+// Start page output.
+echo $OUTPUT->header();
+
+// Show page heading.
+echo $OUTPUT->heading(get_string('settingsoverview_title', 'theme_boost_union'));
+
+// First, compose template context for Boost Union setting pages.
+$templatecontext['cards'][] = [
+    'label' => get_string('configtitlelook', 'theme_boost_union'),
+    'desc' => get_string('settingsoverview_look_desc', 'theme_boost_union'),
+    'btn' => 'primary',
+    'url' => new \moodle_url('/admin/settings.php', ['section' => 'theme_boost_union_look']),
+];
+$templatecontext['cards'][] = [
+    'label' => get_string('configtitlefeel', 'theme_boost_union'),
+    'desc' => get_string('settingsoverview_feel_desc', 'theme_boost_union'),
+    'btn' => 'primary',
+    'url' => new \moodle_url('/admin/settings.php', ['section' => 'theme_boost_union_feel']),
+];
+$templatecontext['cards'][] = [
+    'label' => get_string('configtitlecontent', 'theme_boost_union'),
+    'desc' => get_string('settingsoverview_content_desc', 'theme_boost_union'),
+    'btn' => 'primary',
+    'url' => new \moodle_url('/admin/settings.php', ['section' => 'theme_boost_union_content']),
+];
+$templatecontext['cards'][] = [
+    'label' => get_string('configtitlefunctionality', 'theme_boost_union'),
+    'desc' => get_string('settingsoverview_functionality_desc', 'theme_boost_union'),
+    'btn' => 'primary',
+    'url' => new \moodle_url('/admin/settings.php', ['section' => 'theme_boost_union_functionality']),
+];
+$templatecontext['cards'][] = [
+    'label' => get_string('configtitleflavours', 'theme_boost_union'),
+    'desc' => get_string('settingsoverview_flavours_desc', 'theme_boost_union'),
+    'btn' => 'primary',
+    'url' => new \moodle_url('/theme/boost_union/flavours/overview.php'),
+];
+$templatecontext['cards'][] = [
+    'label' => get_string('smartmenus', 'theme_boost_union'),
+    'desc' => get_string('settingsoverview_smartmenus_desc', 'theme_boost_union'),
+    'btn' => 'primary',
+    'url' => new \moodle_url('/theme/boost_union/smartmenus/menus.php'),
+];
+
+// Then, add additional cards from Boost Union Child themes.
+$pluginsfunction = get_plugins_with_function('extend_busettingsoverview', 'lib.php');
+foreach ($pluginsfunction as $plugintype => $plugins) {
+    foreach ($plugins as $function) {
+        try {
+            $buccards = $function();
+            $templatecontext['cards'] = array_merge($templatecontext['cards'], $buccards);
+        } catch (Throwable $e) {
+            debugging("Exception calling '$function'", DEBUG_DEVELOPER, $e->getTrace());
+        }
+    }
+}
+
+// Finally, add the category overview card.
+$templatecontext['cards'][] = [
+    'label' => get_string('settingsoverview_all', 'theme_boost_union'),
+    'desc' => get_string('settingsoverview_all_desc', 'theme_boost_union'),
+    'btn' => 'secondary',
+    'url' => new \moodle_url('/admin/category.php', ['category' => 'theme_boost_union']),
+];
+
+// Render template.
+echo $OUTPUT->render_from_template('theme_boost_union/settings-overview', $templatecontext);
+
+// Finish page.
+echo $OUTPUT->footer();

--- a/smartmenus/edit.php
+++ b/smartmenus/edit.php
@@ -46,7 +46,6 @@ require_capability('theme/boost_union:configure', $context);
 $PAGE->set_context($context);
 $PAGE->set_url(new moodle_url('/theme/boost_union/smartmenus/edit.php', ['id' => $id, 'sesskey' => sesskey()]));
 $PAGE->set_cacheable(false);
-$PAGE->navbar->add(get_string('themes', 'core'), new moodle_url('/admin/category.php', ['category' => 'themes']));
 $PAGE->navbar->add(get_string('pluginname', 'theme_boost_union'), new moodle_url('/admin/category.php',
         ['category' => 'theme_boost_union']));
 $PAGE->navbar->add(get_string('smartmenus', 'theme_boost_union'), new moodle_url('/theme/boost_union/smartmenus/menus.php'));

--- a/smartmenus/edit_items.php
+++ b/smartmenus/edit_items.php
@@ -65,7 +65,6 @@ if ($menuid == null && $id !== null) {
 // Prepare the page.
 $PAGE->set_context($context);
 $PAGE->set_url(new moodle_url('/theme/boost_union/smartmenus/edit_items.php', ['menu' => $menu->id, 'sesskey' => sesskey()]));
-$PAGE->navbar->add(get_string('themes', 'core'), new moodle_url('/admin/category.php', ['category' => 'themes']));
 $PAGE->navbar->add(get_string('pluginname', 'theme_boost_union'), new moodle_url('/admin/category.php',
         ['category' => 'theme_boost_union']));
 $PAGE->navbar->add(get_string('smartmenus', 'theme_boost_union'), new moodle_url('/theme/boost_union/smartmenus/menus.php'));

--- a/smartmenus/items.php
+++ b/smartmenus/items.php
@@ -65,7 +65,6 @@ require_capability('theme/boost_union:configure', $context);
 $PAGE->set_context($context);
 $PAGE->set_url($pageurl);
 $PAGE->set_cacheable(false);
-$PAGE->navbar->add(get_string('themes', 'core'), new moodle_url('/admin/category.php', ['category' => 'themes']));
 $PAGE->navbar->add(get_string('pluginname', 'theme_boost_union'), new moodle_url('/admin/category.php',
         ['category' => 'theme_boost_union']));
 $PAGE->navbar->add(get_string('smartmenus', 'theme_boost_union'), new moodle_url('/theme/boost_union/smartmenus/menus.php'));

--- a/templates/settings-overview.mustache
+++ b/templates/settings-overview.mustache
@@ -1,0 +1,60 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/settings-overview
+
+    Boost Union settings overview layout template.
+
+    Context variables required for this template:
+    * cards - Array of cards
+
+    Example context (json):
+    {
+        "cards": [
+            {
+                "label": "Look",
+                "desc": "On the 'Look' page, you can do awesome things.",
+                "btn": "primary",
+                "url": "https://moodle.test/admin/settings.php?section=theme_boost_union_look"
+            },
+            {
+                "label": "Feel",
+                "desc": "On the 'Feel' page, you can do awesome things as well.",
+                "btn": "secondary",
+                "url": "https://moodle.test/admin/settings.php?section=theme_boost_union_feel"
+            }
+        ]
+    }
+}}
+
+<div class="container-fluid">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-4">
+        {{#cards}}
+            <div class="col my-3">
+                <div class="card bg-light h-100">
+                    <div class="card-body text-center">
+                        <h5 class="card-title">{{label}}</h5>
+                        <p class="card-text">{{desc}}</p>
+                    </div>
+                    <div class="card-footer">
+                        <a href="{{url}}" class="btn btn-{{btn}} btn-block">{{label}}</a>
+                    </div>
+                </div>
+            </div>
+        {{/cards}}
+    </div>
+</div>

--- a/tests/behat/theme_boost_union_general.feature
+++ b/tests/behat/theme_boost_union_general.feature
@@ -4,14 +4,19 @@ Feature: Configuring the theme_boost_union plugin as admin
   As admin
   I need to be able to configure the theme Boost Union plugin
 
-#  @javascript
-#  Scenario: Redirect the user from the theme selector page to the Boost Union settings category page
-#    When I log in as "admin"
-#    And I follow "Site administration"
-#    And I navigate to "Appearance > Themes" in site administration
-#    And I click on "#theme-settings-boost_union" "css_element" in the "#theme-card-boost_union" "css_element"
-#    And I should see "Category: Boost Union"
-#    And I should see "Boost Union" in the ".breadcrumb" "css_element"
+  @javascript @testme
+  Scenario: Redirect the user from the Boost Union link on the 'Appearance' page to the Boost Union settings overview page
+# Replace the preceeding line with the next line when upgrading to 4.4:
+# Scenario: Redirect the user from the theme selector page to the Boost Union settings overview page
+    When I log in as "admin"
+    And I follow "Site administration"
+    And I navigate to "Appearance > Boost Union" in site administration
+# Replace the preceeding line with the next two lines when upgrading to 4.4:
+#   And I navigate to "Appearance > Themes" in site administration
+#   And I click on "#theme-settings-boost_union" "css_element" in the "#theme-card-boost_union" "css_element"
+    And I should see "Look" in the ".card-body" "css_element"
+    And I should see "Settings for branding your Moodle site"
+    And I should see "Settings overview" in the ".breadcrumb" "css_element"
 
   @javascript
   Scenario: Switch to the active Boost Union admin sub-tab after saving a setting and the following page reload


### PR DESCRIPTION
I refined the PR #609.

There is now a Boost Union settings overview page which looks like this:
<img width="1069" alt="grafik" src="https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/1092118/86ac1a32-f4e4-47cd-9970-9b8e90e7016e">

On Moodle 4.4dev, it is linked from the theme selector:
<img width="1067" alt="grafik" src="https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/1092118/30193056-43df-44a6-abe3-d851ba364c3a">

and the Appearance page only has the new Boost Union settings category:
<img width="1068" alt="grafik" src="https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/1092118/08345dbf-678c-40a4-b544-61750065e18e">

On Moodle 4.3, it is linked from the "Boost Union" link which is still auto-generated by Moodle core:
<img width="1067" alt="grafik" src="https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/assets/1092118/5ab478e9-b230-4357-8524-b57ae7fc0582">

I hope that this is a good compromise between a forward-facing fix for Moodle 4.4 and a not-so-big chance for 4.3 and older Moodle releases.