### PR TITLE
Regression: Migrating the before_standard_html_head() function to the new hook callback broke the login page on Moodle 4.3, resolves #613

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -504,6 +504,10 @@ function theme_boost_union_pluginfile($course, $cm, $context, $filearea, $args, 
  * @return string
  */
 function theme_boost_union_before_standard_html_head() {
+    global $CFG;
+
+    // Require local library.
+    require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
 
     // Call and return callback implementation.
     return theme_boost_union_callbackimpl_before_standard_html();


### PR DESCRIPTION
I did not add anything to CHANGES.md as there has not been any release between the integration of #605 and this PR.