### PR TITLE
Bugfix: Site support form success message is now shown above advert tiles / the slider on frontpage, partly resolves #488.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-04-01 - Bugfix: Site support form success message is now shown above advert tiles / the slider on frontpage, partly resolves #488.
 * 2024-04-01 - Bugfix: In smart menus, the search for cohorts in restrict visibility by cohorts didn't work for more than 25 cohorts, resolves #462.
 * 2024-04-01 - Improvement: Enhance the activitynavigation setting description to cover section navigation as well, resolves #536.
 * 2024-03-30 - Bugfix: Smart menu divider did not work for user menu submenus, resolves #537.

--- a/templates/theme_boost/drawers.mustache
+++ b/templates/theme_boost/drawers.mustache
@@ -207,15 +207,6 @@
             {{/regions.contentupper.hasblocks}}
             <div id="page-content" class="pb-3 d-print-block">
                 <div id="region-main-box">
-                    {{#sliderpositionbeforebefore}}
-                        {{> theme_boost_union/slider }}
-                    {{/sliderpositionbeforebefore}}
-                    {{#advtilespositionbefore}}
-                        {{> theme_boost_union/advertisementtiles }}
-                    {{/advtilespositionbefore}}
-                    {{#sliderpositionbeforeafter}}
-                        {{> theme_boost_union/slider }}
-                    {{/sliderpositionbeforeafter}}
                     {{#hasregionmainsettingsmenu}}
                     <div id="region-main-settings-menu" class="d-print-none">
                         <div> {{{ regionmainsettingsmenu }}} </div>
@@ -238,20 +229,29 @@
                             </div>
                         {{/overflow}}
                         {{{courserelatedhints}}}
+                        {{#sliderpositionbeforebefore}}
+                            {{> theme_boost_union/slider }}
+                        {{/sliderpositionbeforebefore}}
+                        {{#advtilespositionbefore}}
+                            {{> theme_boost_union/advertisementtiles }}
+                        {{/advtilespositionbefore}}
+                        {{#sliderpositionbeforeafter}}
+                            {{> theme_boost_union/slider }}
+                        {{/sliderpositionbeforeafter}}
                         {{{ output.main_content }}}
                         {{{ output.activity_navigation }}}
                         {{{ output.course_content_footer }}}
+                        {{#sliderpositionafterbefore}}
+                            {{> theme_boost_union/slider }}
+                        {{/sliderpositionafterbefore}}
+                        {{#advtilespositionafter}}
+                            {{> theme_boost_union/advertisementtiles }}
+                        {{/advtilespositionafter}}
+                        {{#sliderpositionafterafter}}
+                            {{> theme_boost_union/slider }}
+                        {{/sliderpositionafterafter}}
 
                     </section>
-                    {{#sliderpositionafterbefore}}
-                        {{> theme_boost_union/slider }}
-                    {{/sliderpositionafterbefore}}
-                    {{#advtilespositionafter}}
-                        {{> theme_boost_union/advertisementtiles }}
-                    {{/advtilespositionafter}}
-                    {{#sliderpositionafterafter}}
-                        {{> theme_boost_union/slider }}
-                    {{/sliderpositionafterafter}}
                 </div>
             </div>
             {{#regions.contentlower.hasblocks}}

--- a/tests/behat/theme_boost_union_contentsettings_advertisementtiles.feature
+++ b/tests/behat/theme_boost_union_contentsettings_advertisementtiles.feature
@@ -57,7 +57,7 @@ Feature: Configuring the theme_boost_union plugin for the "Advertisement tiles" 
       | tile1content          | This is a test content for tile 1 | theme_boost_union |
     When I log in as "teacher1"
     And I am on site homepage
-    Then "#themeboostunionadvtiles" "css_element" should appear <beforeafter> "#region-main" "css_element"
+    Then "#themeboostunionadvtiles" "css_element" should appear <beforeafter> "div[role='main']" "css_element"
 
     Examples:
       | position | beforeafter |

--- a/tests/behat/theme_boost_union_contentsettings_slider.feature
+++ b/tests/behat/theme_boost_union_contentsettings_slider.feature
@@ -76,7 +76,7 @@ Feature: Configuring the theme_boost_union plugin for the "Slider" tab on the "C
       | tile1content            | This is a test content for tile 1 | theme_boost_union |
     When I log in as "teacher1"
     And I am on site homepage
-    Then "#themeboostunionslider" "css_element" should appear <beforeafter1> "#region-main" "css_element"
+    Then "#themeboostunionslider" "css_element" should appear <beforeafter1> "div[role='main']" "css_element"
     And "#themeboostunionslider" "css_element" should appear <beforeafter2> "#themeboostunionadvtiles" "css_element"
 
     Examples:


### PR DESCRIPTION
This PR resolves #488 only partly.
I have commented in #488 what is fixed and what remains.
Issue #488 has to remain open when this PR is merged.