### PR TITLE
#98 further hints on hidden courses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-04-20 - Improvement: Add hint that notifications don't work within forums for hidden courses, resolves #98.
 * 2024-04-20 - Bugfix: Correct order for in-course breadcrumb when sections exist in it (First categories then sections), solves #317.
 * 2024-04-20 - Cleanup: Add proper JS promise error handling, resolves #435.
 

--- a/README.md
+++ b/README.md
@@ -545,6 +545,10 @@ In this tab there are the following settings:
 
 With this setting a hint will appear in the course header if the user has switched the role in the course.
 
+###### Show hint for forum notifications in hidden courses
+
+With this setting a hint will not only appear in the course header but also in forums as long as the visibility of the course is hidden.
+
 ###### Show hint in hidden courses
 
 With this setting a hint will appear in the course header as long as the visibility of the course is hidden.

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -933,10 +933,10 @@ $string['showhintcoursehiddensetting'] = 'Show hint in hidden courses';
 $string['showhintcoursehiddensetting_desc'] = 'With this setting a hint will appear in the course header as long as the visibility of the course is hidden. This helps to identify the visibility state of a course at a glance without the need for looking at the course settings.';
 $string['showhintcoursehiddengeneral'] = 'This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.';
 $string['showhintcoursehiddensettingslink'] = 'You can change the visibility in the <a href="{$a->url}">course settings</a>.';
-// ... ... Setting: Show hint that notifications don't work within forums for hidden courses.
-$string['showhintforumnotificationssetting'] = 'Show hint regarding notifications in hidden courses';
-$string['showhintforumnotificationssetting_desc'] = 'When a course is hidden notifications within a forum are not send to students. To clarify this a hint will appear on forums within a hidden course to help the teachers understand this circumstance.';
-$string['showhintforumnotifications'] = 'This course is currently <strong>hidden</strong>. Please note that this means that <strong>students will not be notified</strong> online or by email of any messages you post in this forum.';
+// ... ... Setting: Show hint for forum notifications in hidden courses.
+$string['showhintforumnotificationssetting'] = 'Show hint for forum notifications in hidden courses';
+$string['showhintforumnotificationssetting_desc'] = 'With this setting a hint will not only appear in the course header but also in forums as long as the visibility of the course is hidden. This is to clarify that notifications within a forum are not send to students and to help the teachers understand this circumstance.';
+$string['showhintforumnotifications'] = 'This course is currently <strong>hidden</strong>. This means that <strong>students will not be notified</strong> online or by email of any messages you post in this forum.';
 // ... ... Setting: Show hint for guest access.
 $string['showhintcoursguestaccesssetting'] = 'Show hint for guest access';
 $string['showhintcourseguestaccesssetting_desc'] = 'With this setting a hint will appear in the course header when a user is accessing it with the guest access feature. If the course provides an active self enrolment, a link to that page is also presented to the user.';

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -933,6 +933,10 @@ $string['showhintcoursehiddensetting'] = 'Show hint in hidden courses';
 $string['showhintcoursehiddensetting_desc'] = 'With this setting a hint will appear in the course header as long as the visibility of the course is hidden. This helps to identify the visibility state of a course at a glance without the need for looking at the course settings.';
 $string['showhintcoursehiddengeneral'] = 'This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.';
 $string['showhintcoursehiddensettingslink'] = 'You can change the visibility in the <a href="{$a->url}">course settings</a>.';
+// ... ... Setting: Show hint that notifications don't work within forums for hidden courses.
+$string['showhintforumnotificationssetting'] = 'Show hint regarding notifications in hidden courses';
+$string['showhintforumnotificationssetting_desc'] = 'When a course is hidden notifications within a forum are not send to students. To clarify this a hint will appear on forums within a hidden course to help the teachers understand this circumstance.';
+$string['showhintforumnotifications'] = 'This course is currently <strong>hidden</strong>. Please note that this means that <strong>students will not be notified</strong> online or by email of any messages you post in this forum.';
 // ... ... Setting: Show hint for guest access.
 $string['showhintcoursguestaccesssetting'] = 'Show hint for guest access';
 $string['showhintcourseguestaccesssetting_desc'] = 'With this setting a hint will appear in the course header when a user is accessing it with the guest access feature. If the course provides an active self enrolment, a link to that page is also presented to the user.';

--- a/locallib.php
+++ b/locallib.php
@@ -40,26 +40,43 @@ function theme_boost_union_get_course_related_hints() {
     // Initialize HTML code.
     $html = '';
 
-    // If the setting showhintcoursehidden is set and the visibility of the course is hidden and
+    // If the setting showhintcoursehidden is set and the visibility of the course is hidden
     // a hint for the visibility will be shown.
     if (get_config('theme_boost_union', 'showhintcoursehidden') == THEME_BOOST_UNION_SETTING_SELECT_YES
             && has_capability('theme/boost_union:viewhintinhiddencourse', \context_course::instance($COURSE->id))
             && $PAGE->has_set_url()
-            && $PAGE->url->compare(new moodle_url('/course/view.php'), URL_MATCH_BASE)
             && $COURSE->visible == false) {
 
-        // Prepare template context.
-        $templatecontext = ['courseid' => $COURSE->id];
+        // Initialize hint text.
+        $hintcoursehiddentext = '';
 
-        // If the user has the capability to change the course settings, an additional link to the course settings is shown.
-        if (has_capability('moodle/course:update', context_course::instance($COURSE->id))) {
-            $templatecontext['showcoursesettingslink'] = true;
-        } else {
-            $templatecontext['showcoursesettingslink'] = false;
+        // The general hint will only be shown when the course is viewed.
+        if ($PAGE->url->compare(new moodle_url('/course/view.php'), URL_MATCH_BASE)) {
+            // Use the default hint text for hidden courses.
+            $hintcoursehiddentext = get_string('showhintcoursehiddengeneral', 'theme_boost_union');
         }
 
-        // Render template and add it to HTML code.
-        $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-hidden', $templatecontext);
+        // If the setting showhintcoursehiddennotifications is set too and we view a forum (e.g. announcement) within a hidden
+        // course a hint will be shown that no notifications via forums will be sent out to students.
+        if (get_config('theme_boost_union', 'showhintforumnotifications') == THEME_BOOST_UNION_SETTING_SELECT_YES
+                && $PAGE->url->compare(new moodle_url('/mod/forum/view.php'), URL_MATCH_BASE)) {
+            // Use the specialized hint text for hidden courses on forum pages.
+            $hintcoursehiddentext = get_string('showhintforumnotifications', 'theme_boost_union');
+        }
+
+        // If we show any kind of hint for the hidden course, construct the hints HTML item via mustache.
+        if ($hintcoursehiddentext) {
+            // Prepare the templates context.
+            $templatecontext = [
+                'courseid' => $COURSE->id,
+                'hintcoursehiddentext' => $hintcoursehiddentext,
+                // If the user has the capability to change the course settings, an additional link to the course settings is shown.
+                'showcoursesettingslink' => has_capability('moodle/course:update', context_course::instance($COURSE->id)),
+            ];
+
+            // Render template and add it to HTML code.
+            $html .= $OUTPUT->render_from_template('theme_boost_union/course-hint-hidden', $templatecontext);
+        }
     }
 
     // If the setting showhintcourseguestaccess is set and the user is accessing the course with guest access,

--- a/locallib.php
+++ b/locallib.php
@@ -59,7 +59,9 @@ function theme_boost_union_get_course_related_hints() {
         // If the setting showhintcoursehiddennotifications is set too and we view a forum (e.g. announcement) within a hidden
         // course a hint will be shown that no notifications via forums will be sent out to students.
         if (get_config('theme_boost_union', 'showhintforumnotifications') == THEME_BOOST_UNION_SETTING_SELECT_YES
-                && $PAGE->url->compare(new moodle_url('/mod/forum/view.php'), URL_MATCH_BASE)) {
+                && ($PAGE->url->compare(new moodle_url('/mod/forum/view.php'), URL_MATCH_BASE) ||
+                        $PAGE->url->compare(new moodle_url('/mod/forum/discuss.php'), URL_MATCH_BASE) ||
+                        $PAGE->url->compare(new moodle_url('/mod/forum/post.php'), URL_MATCH_BASE))) {
             // Use the specialized hint text for hidden courses on forum pages.
             $hintcoursehiddentext = get_string('showhintforumnotifications', 'theme_boost_union');
         }

--- a/settings.php
+++ b/settings.php
@@ -2527,14 +2527,14 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
 
-        // Setting: Show hint at forums within hidden courses that notifications are not send.
+        // Setting: Show hint for forum notifications in hidden courses.
         $name = 'theme_boost_union/showhintforumnotifications';
         $title = get_string('showhintforumnotificationssetting', 'theme_boost_union', null, true);
         $description = get_string('showhintforumnotificationssetting_desc', 'theme_boost_union', null, true);
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
         $page->hide_if('theme_boost_union/showhintforumnotifications', 'theme_boost_union/showhintcoursehidden', 'neq',
-            THEME_BOOST_UNION_SETTING_SELECT_YES);
+                THEME_BOOST_UNION_SETTING_SELECT_YES);
 
         // Setting: Show hint guest for access.
         $name = 'theme_boost_union/showhintcourseguestaccess';

--- a/settings.php
+++ b/settings.php
@@ -2527,6 +2527,15 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
 
+        // Setting: Show hint at forums within hidden courses that notifications are not send.
+        $name = 'theme_boost_union/showhintforumnotifications';
+        $title = get_string('showhintforumnotificationssetting', 'theme_boost_union', null, true);
+        $description = get_string('showhintforumnotificationssetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/showhintforumnotifications', 'theme_boost_union/showhintcoursehidden', 'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES);
+
         // Setting: Show hint guest for access.
         $name = 'theme_boost_union/showhintcourseguestaccess';
         $title = get_string('showhintcoursguestaccesssetting', 'theme_boost_union', null, true);

--- a/templates/course-hint-hidden.mustache
+++ b/templates/course-hint-hidden.mustache
@@ -21,11 +21,13 @@
 
     Context variables required for this template:
     * courseid - The course ID
+    * hintcoursehiddentext - The info text shown on hidden courses,
     * showcoursesettingslink - The fact if a link to the course settings should be shown or not
 
     Example context (json):
     {
         "courseid": "123",
+        "hintcoursehiddentext: "This course is currently <strong>hidden</strong>. Only enrolled teachers can access this course when hidden.",
         "showcoursesettingslink": true
     }
 }}
@@ -33,7 +35,7 @@
     <div class="media">
         <div class="mr-3 icon-size-5"><i class="fa fa-exclamation-circle fa-3x"></i></div>
         <div class="media-body align-self-center">
-            {{#str}} showhintcoursehiddengeneral, theme_boost_union {{/str}}
+            {{{hintcoursehiddentext}}}
             {{#showcoursesettingslink}}
                 <br>{{#str}} showhintcoursehiddensettingslink, theme_boost_union, { "url": "{{config.wwwroot}}/course/edit.php?id={{courseid}}" } {{/str}}
             {{/showcoursesettingslink}}

--- a/tests/behat/theme_boost_union_functionalitysettings_courses.feature
+++ b/tests/behat/theme_boost_union_functionalitysettings_courses.feature
@@ -16,6 +16,11 @@ Feature: Configuring the theme_boost_union plugin for the "Courses" tab on the "
       | user     | course | role           |
       | teacher1 | C1     | editingteacher |
       | student1 | C1     | student        |
+    And the following "activity" exists:
+      | course   | C1            |
+      | activity | forum         |
+      | idnumber | Announcements |
+      | name     | Announcements |
 
   Scenario: Setting: Show hint for switched role - Enable the setting
     Given the following config values are set as admin:
@@ -47,6 +52,27 @@ Feature: Configuring the theme_boost_union plugin for the "Courses" tab on the "
       | Course visibility | Show |
     And I click on "Save and display" "button"
     Then I should not see "This course is currently hidden. Only enrolled teachers can access this course when hidden."
+    And ".course-hint-hidden" "css_element" should not exist
+
+  Scenario: Setting: Show hint at forums in hidden courses that notifications do not work - Enable the setting
+    Given the following config values are set as admin:
+      | config                     | value | plugin            |
+      | showhintcoursehidden       | yes   | theme_boost_union |
+      | showhintforumnotifications | yes   | theme_boost_union |
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    When I navigate to "Settings" in current page administration
+    And I set the following fields to these values:
+      | Course visibility | Hide |
+    And I click on "Save and display" "button"
+    When I am on the "Announcements" "forum activity" page
+    Then I should see "This course is currently hidden. Please note that this means that students will not be notified online or by email of any messages you post in this forum." in the ".course-hint-hidden" "css_element"
+    When I am on "Course 1" course homepage
+    When I navigate to "Settings" in current page administration
+    And I set the following fields to these values:
+      | Course visibility | Show |
+    And I click on "Save and display" "button"
+    Then I should not see "This course is currently hidden. Please note that this means that students will not be notified online or by email of any messages you post in this forum."
     And ".course-hint-hidden" "css_element" should not exist
 
   Scenario: Setting: Show hint guest for access - Enable the setting

--- a/tests/behat/theme_boost_union_functionalitysettings_courses.feature
+++ b/tests/behat/theme_boost_union_functionalitysettings_courses.feature
@@ -16,11 +16,6 @@ Feature: Configuring the theme_boost_union plugin for the "Courses" tab on the "
       | user     | course | role           |
       | teacher1 | C1     | editingteacher |
       | student1 | C1     | student        |
-    And the following "activity" exists:
-      | course   | C1            |
-      | activity | forum         |
-      | idnumber | Announcements |
-      | name     | Announcements |
 
   Scenario: Setting: Show hint for switched role - Enable the setting
     Given the following config values are set as admin:
@@ -41,38 +36,51 @@ Feature: Configuring the theme_boost_union plugin for the "Courses" tab on the "
       | showhintcoursehidden | yes   | theme_boost_union |
     When I log in as "teacher1"
     And I am on "Course 1" course homepage
-    When I navigate to "Settings" in current page administration
+    And I navigate to "Settings" in current page administration
     And I set the following fields to these values:
       | Course visibility | Hide |
     And I click on "Save and display" "button"
     Then I should see "This course is currently hidden. Only enrolled teachers can access this course when hidden." in the ".course-hint-hidden" "css_element"
     When I am on "Course 1" course homepage
-    When I navigate to "Settings" in current page administration
+    And I navigate to "Settings" in current page administration
     And I set the following fields to these values:
       | Course visibility | Show |
     And I click on "Save and display" "button"
     Then I should not see "This course is currently hidden. Only enrolled teachers can access this course when hidden."
     And ".course-hint-hidden" "css_element" should not exist
 
-  Scenario: Setting: Show hint at forums in hidden courses that notifications do not work - Enable the setting
-    Given the following config values are set as admin:
+  Scenario: Setting: Show hint for forum notifications in hidden courses - Enable the setting
+    Given the following "activity" exists:
+      | course   | C1            |
+      | activity | forum         |
+      | idnumber | Announcements |
+      | name     | Announcements |
+    And the following config values are set as admin:
       | config                     | value | plugin            |
       | showhintcoursehidden       | yes   | theme_boost_union |
       | showhintforumnotifications | yes   | theme_boost_union |
     When I log in as "teacher1"
     And I am on "Course 1" course homepage
-    When I navigate to "Settings" in current page administration
+    And I navigate to "Settings" in current page administration
     And I set the following fields to these values:
       | Course visibility | Hide |
     And I click on "Save and display" "button"
-    When I am on the "Announcements" "forum activity" page
-    Then I should see "This course is currently hidden. Please note that this means that students will not be notified online or by email of any messages you post in this forum." in the ".course-hint-hidden" "css_element"
+    And I am on the "Announcements" "forum activity" page
+    Then I should see "This course is currently hidden. This means that students will not be notified online or by email of any messages you post in this forum." in the ".course-hint-hidden" "css_element"
+    When I click on "Add discussion topic" "link"
+    And I click on "#id_advancedadddiscussion" "css_element"
+    Then I should see "This course is currently hidden. This means that students will not be notified online or by email of any messages you post in this forum." in the ".course-hint-hidden" "css_element"
+    And I set the field "Subject" to "My post"
+    And I set the field "Message" to "My message"
+    And I click on "Post to forum" "button"
+    When I click on "My post" "link"
+    Then I should see "This course is currently hidden. This means that students will not be notified online or by email of any messages you post in this forum." in the ".course-hint-hidden" "css_element"
     When I am on "Course 1" course homepage
-    When I navigate to "Settings" in current page administration
+    And I navigate to "Settings" in current page administration
     And I set the following fields to these values:
       | Course visibility | Show |
     And I click on "Save and display" "button"
-    Then I should not see "This course is currently hidden. Please note that this means that students will not be notified online or by email of any messages you post in this forum."
+    Then I should not see "This course is currently hidden. This means that students will not be notified online or by email of any messages you post in this forum."
     And ".course-hint-hidden" "css_element" should not exist
 
   Scenario: Setting: Show hint guest for access - Enable the setting

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2023102033;
+$plugin->version = 2023102034;
 $plugin->release = 'v4.3-r11';
 $plugin->requires = 2023100900;
 $plugin->supported = [403, 403];


### PR DESCRIPTION
This is a follow up for another closed PR: https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/pull/109

It solves See Issue https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues/98

I changed the logic a bit in comparison to the original Pull-Request: Now a single Mustache template is used for all hint messages for hidden courses.
