### PR TITLE
fix: smart menu menubar overlays course index, resolves #607

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-05-09 - Bugfix: Smart menu menubar overlaid course index, resolves #607
 * 2024-04-27 - Improvement: Add navigation to policy overview page, resolves #633
 
 ### v4.3-r12

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -1375,7 +1375,7 @@ body.theme_boost-union-footerbuttonnone.jsenabled {
                 z-index: 1031;
                 /* The position of the side drawer has been adjusted slightly below to accommodate the top header. */
                 ~ .drawer.drawer-left {
-                    top: 0;
+                    top: 101px;
                 }
                 ~ .drawer.drawer-right {
                     top: 101px;
@@ -2084,11 +2084,13 @@ body.theme_boost-union-footerbuttonnone.jsenabled {
         }
         /* When the menu in the left adn right drawer toggle button is clicked, its navigation drawer
             position appears below the header when the header menubar is disabled. */
+        ~ #theme_boost-drawers-primary,
+        ~ #theme_boost-drawers-courseindex,
         ~ .drawer.drawer-left,
         ~ .drawer.drawer-right {
             max-width: 315px;
             padding-bottom: 0;
-            /* top: 61px; */
+            top: 0;
         }
         /*~ #page.drawers {
             The position of the drawer button to toggle has been adjusted slightly


### PR DESCRIPTION
Remarks:

* I used absolute px values instead of calculated to be on par with existing css.
* in L2091 I opted to use explicit ID-selectors for nav- and courseindex drawers to be specific enough and omit the !important flag

