### PR TITLE
Feature: Allow admins to configure URLs from where Boost Union will fetch additional raw SCSS code, resolves #41

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased 
+
+* 2024-04-28 - Feature: Allow admins to configure URLs from where Boost Union will fetch additional raw SCSS code, resolves #41.
+
 ### v4.3-r13
 
 * 2024-05-13 - Improvement: Suppress icons in footer, resolves #649

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ This setting is already available in the Moodle core theme Boost. For more infor
 
 This setting is already available in the Moodle core theme Boost. For more information how to use it, please have a look at the official Moodle documentation: http://docs.moodle.org/en/Boost_theme
 
+##### External SCSS
+
+In addition to the raw SCSS settings above, Boost Union can load SCSS from an external source. It is included before the SCSS code which is defined above which means that you can manage a centralized external SCSS codebase and can still amend it with local SCSS additions.
+
 #### Tab "Page"
 
 In this tab there are the following settings:
@@ -614,6 +618,17 @@ These capabilities are used to control who is allowed to see a particular block 
 These capabilities are used to control who is allowed to edit a particular block region. By default, they are assigned to teachers, non-editing teachers and managers.
 
 
+Scheduled Tasks
+---------------
+
+This plugin also introduces these additional scheduled tasks:
+
+### \theme_boost_union\task\purge_cache
+
+This scheduled task can be used to purge the theme cache periodically, for example every night. It is especially there to fetch external SCSS code which might have been updated since the last purging of the theme cache.\
+By default, the task is disabled.
+
+
 How this theme works
 --------------------
 
@@ -783,6 +798,7 @@ Moodle an Hochschulen e.V. would like to thank these main contributors (in alpha
 * Hochschule Hannover - University of Applied Sciences and Arts: Code, Funding, Ideating
 * Käferfreie Software, Nina Herrmann: Code
 * lern.link GmbH, Alexander Bias: Code, Peer Review, Ideating, Funding
+* lern.link GmbH, Lukas MuLu Müller: Code
 * lern.link GmbH, Beata Waloszczyk: Code
 * Moodle.NRW / Ruhr University Bochum, Annika Lambert: Code
 * Moodle.NRW / Ruhr University Bochum, Matthias Buttgereit: Code, Ideating

--- a/classes/admin_setting_configtext_url.php
+++ b/classes/admin_setting_configtext_url.php
@@ -1,0 +1,71 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - Settings class file
+ *
+ * @package    theme_boost_union
+ * @copyright  2023 Lukas MuLu Müller, lern.link GmbH <mulu@lernlink.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace theme_boost_union;
+
+/**
+ * Special setting for configtextarea with URL validation.
+ *
+ * @package    theme_boost_union
+ * @copyright  2023 Lukas MuLu Müller, lern.link GmbH <mulu@lernlink.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class admin_setting_configtext_url extends \admin_setting_configtext {
+
+    /**
+     * Validate the contents of the configtext to ensure it's a valid URL.
+     *
+     * @param string $data The data from text field.
+     * @return mixed bool true for success or string:error on failure.
+     */
+    public function validate($data) {
+        global $CFG;
+
+        // If no entry is made validate true, otherwise the setting would always return an error and
+        // could not be saved.
+        if (empty($data)) {
+            return true;
+        }
+
+        // Require file library.
+        require_once($CFG->libdir.'/filelib.php');
+
+        // If the URL is invalid, respond with an error message.
+        if (filter_var($data, FILTER_VALIDATE_URL) === false) {
+            return get_string('invalidurl', 'theme_boost_union');
+        } else {
+            // Check if the URL is blocked.
+            $curl = new \curl();
+            $security = $curl->get_security();
+
+            // If the URL is blocked, return the reason as error message.
+            if ($security->url_is_blocked($data)) {
+                return $security->get_blocked_url_string();
+            }
+        }
+
+        // Return the result of the parent class' check of the data.
+        return parent::validate($data);
+    }
+}

--- a/classes/task/purge_cache.php
+++ b/classes/task/purge_cache.php
@@ -1,0 +1,61 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - Scheduled task for purging the cache.
+ *
+ * @package    theme_boost_union
+ * @copyright  2024 Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace theme_boost_union\task;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../../locallib.php');
+
+/**
+ * The theme_boost_union purge_cache task class.
+ *
+ * @package    theme_boost_union
+ * @copyright  2024 Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class purge_cache extends \core\task\scheduled_task {
+
+    /**
+     * Return localised task name.
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('task_purgecache', 'theme_boost_union');
+    }
+
+    /**
+     * Execute scheduled task.
+     *
+     * @return boolean
+     */
+    public function execute() {
+        // Simply reset the theme cache.
+        theme_reset_all_caches();
+
+        // Return true, just to keep the Moodle scheduler happy.
+        return true;
+    }
+}

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -15,19 +15,24 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Theme Boost Union - Version file
+ * Theme Boost Union - Scheduled tasks.
  *
  * @package    theme_boost_union
- * @copyright  2022 Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
+ * @copyright  2024 Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'theme_boost_union';
-$plugin->version = 2023102040;
-$plugin->release = 'v4.3-r13';
-$plugin->requires = 2023100900;
-$plugin->supported = [403, 403];
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = ['theme_boost' => 2023100900];
+$tasks = [
+    [
+        'classname' => '\theme_boost_union\task\purge_cache',
+        'blocking' => 1,
+        'minute' => '0',
+        'hour' => '0',
+        'day' => '*',
+        'dayofweek' => '*',
+        'month' => '*',
+        'disabled' => 1,
+    ],
+];

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -59,6 +59,48 @@ $string['scsstab'] = 'SCSS';
 // ... Section: Raw SCSS.
 $string['scssheading'] = 'Raw SCSS';
 
+// ... Section: External SCSS.
+$string['extscssheading'] = 'External SCSS';
+$string['extscssheading_desc'] = 'In addition to the raw SCSS settings above, Boost Union can load SCSS from an external source. It is included before the SCSS code which is defined above which means that you can manage a centralized external SCSS codebase and can still amend it with local SCSS additions.';
+$string['extscssheading_instr'] = 'Instructions:';
+$string['extscssheading_drop'] = 'If Boost Union cannot fetch the external SCSS file for any reason or if the fetched external SCSS code is invalid, it will simply ignore the external SCSS file to avoid hickups with SCSS compiling and broken frontends.';
+$string['extscssheading_structure'] = 'The external SCSS must be provided as plaintext file, without any headers or footers, containing just the SCSS code.';
+$string['extscssheading_prepost'] = 'Just like the raw SCSS settings above, the external SCSS is split into two pieces: Pre and Post SCSS. Pre SCSS can be used for initializing SCSS variables, Post SCSS is used for your actual SCSS code.';
+$string['extscssheading_sources'] = 'You can configure Boost Union to fetch the external SCSS file either from a public download URL (which will be accessed and fetched with an unauthenticated cURL request) or from a private Github repository (which will be accessed and fetched with a Github API token).';
+$string['extscssheading_task'] = 'There is a <a href="{$a}">scheduled task theme_boost_union\task\purge_cache</a> which is disabled by default but which you can enable if you want Boost Union to periodically fetch and compile the external SCSS code.';
+$string['invalidurl'] = 'The given URL is invalid';
+// ... ... Setting: External SCSS source.
+$string['extscsssource'] = 'External SCSS source';
+$string['extscsssource_desc'] = 'Pick the type of source from where you want to fetch the external SCSS.';
+$string['extscsssourcenone'] = 'None';
+$string['extscsssourcedownload'] = 'Public download URL';
+$string['extscsssourcegithub'] = 'Private Github repository';
+// ... ... Setting: External Pre SCSS download URL.
+$string['extscssurlpre'] = 'External Pre SCSS download URL';
+$string['extscssurlpre_desc'] = 'The public download URL from where the External Pre SCSS should be fetched.';
+// ... ... Setting: External Post SCSS download URL.
+$string['extscssurlpost'] = 'External Post SCSS download URL';
+$string['extscssurlpost_desc'] = 'The public download URL from where the external Post SCSS should be fetched.';
+// ... ... Setting: External SCSS Github API token.
+$string['extscssgithubtoken'] = 'External SCSS Github API token';
+$string['extscssgithubtoken_desc'] = 'The Github API token which will be used to fetch the SCSS code from the given private Github repository.';
+$string['extscssgithubtoken_docs'] = 'Go to <a href="https://github.com/settings/tokens">your Github token settings</a> to generate an API token and to see the official documentation.';
+// ... ... Setting: External SCSS Github API user.
+$string['extscssgithubuser'] = 'External SCSS Github API user';
+$string['extscssgithubuser_desc'] = 'The Github API user or organization which owns the private Github repository.';
+$string['extscssgithubuser_example'] = 'Example: If you can see the file in your Github account on https://github.com/moodle-an-hochschulen/moodle-theme_boost_union-extscsstest/blob/master/extscss.scss, the user will be <em>moodle-an-hochschulen</em>.';
+// ... ... Setting: External SCSS Github API repository.
+$string['extscssgithubrepo'] = 'External SCSS Github API repository';
+$string['extscssgithubrepo_desc'] = 'The private Github repository where the SCSS files are located.';
+$string['extscssgithubrepo_example'] = 'Example: If you can see the file in your Github account on https://github.com/moodle-an-hochschulen/moodle-theme_boost_union-extscsstest/blob/master/extscss.scss, the repository will be <em>moodle-theme_boost_union-extscsstest</em>.';
+// ... ... Setting: External Pre SCSS Github file path.
+$string['extscssgithubprefilepath'] = 'External Pre SCSS Github file path';
+$string['extscssgithubprefilepath_desc'] = 'The path within the private Github repository where the Pre SCSS file is located.';
+$string['extscssgithubfilepath_example'] = 'Example: If you can see the file in your Github account on https://github.com/moodle-an-hochschulen/moodle-theme_boost_union-extscsstest/blob/master/extscss.scss, the file path will be <em>/extscss.scss</em>.';
+// ... ... Setting: External Post SCSS Github file path.
+$string['extscssgithubpostfilepath'] = 'External Post SCSS Github file path';
+$string['extscssgithubpostfilepath_desc'] = 'The path within the private Github repository where the Post SCSS file is located.';
+
 // Settings: Page tab.
 $string['pagetab'] = 'Page';
 // ... Section: Page width.
@@ -1237,6 +1279,9 @@ $string['cachedef_flavours'] = 'Flavours which apply to a given page\'s category
 $string['cachedef_smartmenus'] = 'Smart menus';
 $string['cachedef_smartmenu_items'] = 'Smart menu items';
 $string['cachedef_touchiconsios'] = 'Touch icon files for iOS';
+
+// Scheduled tasks.
+$string['task_purgecache'] = 'Purge theme cache';
 
 // Upgrade notices.
 $string['upgradenotice_2022080922'] = 'From this release on, Boost Union has its own logo and compact logo settings and does not use these files from the Moodle core settings anymore.';

--- a/lib.php
+++ b/lib.php
@@ -124,6 +124,10 @@ define('THEME_BOOST_UNION_SETTING_COURSEOVERVIEW_SHOWCOURSEIMAGES_SUMMARY', 'sum
 define('THEME_BOOST_UNION_SETTING_MARKLINKS_WHOLEPAGE', 'wholepage');
 define('THEME_BOOST_UNION_SETTING_MARKLINKS_COURSEMAIN', 'coursemain');
 
+define('THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_NONE', 0);
+define('THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_DOWNLOAD', 1);
+define('THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_GITHUB', 2);
+
 /**
  * Returns the main SCSS content.
  *
@@ -135,6 +139,9 @@ function theme_boost_union_get_main_scss_content($theme) {
 
     $scss = '';
 
+    // Require Boost Core library.
+    require_once($CFG->dirroot.'/theme/boost/lib.php');
+
     // Include pre.scss from Boost Union.
     $scss .= file_get_contents($CFG->dirroot . '/theme/boost_union/scss/boost_union/pre.scss');
 
@@ -144,6 +151,13 @@ function theme_boost_union_get_main_scss_content($theme) {
 
     // Include post.scss from Boost Union.
     $scss .= file_get_contents($CFG->dirroot . '/theme/boost_union/scss/boost_union/post.scss');
+
+    // Get and include the external Post SCSS.
+    // This should actually be in theme_boost_union_get_extra_scss().
+    // But as the *_get_extra_scss() functions work in practice, this is not possible as the external Raw SCSS code
+    // would end of _after_ the code from theme_boost_get_extra_scss() and not _before_.
+    // Thus, we sadly have to get and include the external Post SCSS here already.
+    $scss .= theme_boost_union_get_external_scss('post');
 
     return $scss;
 }
@@ -235,6 +249,9 @@ function theme_boost_union_get_pre_scss($theme) {
 
     // Add custom Boost Union SCSS variable as goody for designers: $themerev.
     $scss .= '$themerev: '.$CFG->themerev.";\n";
+
+    // Get and include the external Pre SCSS.
+    $scss .= theme_boost_union_get_external_scss('pre');
 
     // Prepend pre-scss.
     if (get_config('theme_boost_union', 'scsspre')) {

--- a/settings.php
+++ b/settings.php
@@ -24,6 +24,7 @@
 
 use theme_boost_union\admin_setting_configdatetime;
 use theme_boost_union\admin_setting_configstoredfilealwayscallback;
+use theme_boost_union\admin_setting_configtext_url;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -177,6 +178,120 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $setting = new admin_setting_scsscode($name, $title, $description, $default, PARAM_RAW);
         $setting->set_updatedcallback('theme_reset_all_caches');
         $tab->add($setting);
+
+        // Create external SCSS heading.
+        $name = 'theme_boost_union/extscssheading';
+        $title = get_string('extscssheading', 'theme_boost_union', null, true);
+        $taskurl = new moodle_url('/admin/tool/task/scheduledtasks.php',
+                ['action' => 'edit', 'task' => 'theme_boost_union\task\purge_cache']);
+        $description = get_string('extscssheading_desc', 'theme_boost_union', null, true).'<br /><br />'.
+                get_string('extscssheading_instr', 'theme_boost_union', null, true).
+                '<ul><li>'.get_string('extscssheading_sources', 'theme_boost_union', null, true).'</li>'.
+                '<li>'.get_string('extscssheading_prepost', 'theme_boost_union', null, true).'</li>'.
+                '<li>'.get_string('extscssheading_structure', 'theme_boost_union', null, true).'</li>'.
+                '<li>'.get_string('extscssheading_drop', 'theme_boost_union', null, true).'</li>'.
+                '<li>'.get_string('extscssheading_task', 'theme_boost_union', $taskurl->out(), true).'</li></ul>';
+        $setting = new admin_setting_heading($name, $title, $description);
+        $tab->add($setting);
+
+        // Setting: External SCSS source.
+        $extscsssourceoptions = [
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_NONE =>
+                        get_string('extscsssourcenone', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_DOWNLOAD =>
+                        get_string('extscsssourcedownload', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_GITHUB =>
+                        get_string('extscsssourcegithub', 'theme_boost_union'),
+        ];
+        $name = 'theme_boost_union/extscsssource';
+        $title = get_string('extscsssource', 'theme_boost_union', null, true);
+        $description = get_string('extscsssource_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description,
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_NONE, $extscsssourceoptions);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Setting: External Pre SCSS download URL.
+        $name = 'theme_boost_union/extscssurlpre';
+        $title = get_string('extscssurlpre', 'theme_boost_union', null, true);
+        $description = get_string('extscssurlpre_desc', 'theme_boost_union', null, true);
+        $default = '';
+        $setting = new admin_setting_configtext_url($name, $title, $description, $default, PARAM_URL);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/extscssurlpre', 'theme_boost_union/extscsssource', 'neq',
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_DOWNLOAD);
+
+        // Setting: External Post SCSS download URL.
+        $name = 'theme_boost_union/extscssurlpost';
+        $title = get_string('extscssurlpost', 'theme_boost_union', null, true);
+        $description = get_string('extscssurlpost_desc', 'theme_boost_union', null, true);
+        $default = '';
+        $setting = new admin_setting_configtext_url($name, $title, $description, $default, PARAM_URL);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/extscssurlpost', 'theme_boost_union/extscsssource', 'neq',
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_DOWNLOAD);
+
+        // Setting: External SCSS Github API token.
+        $name = 'theme_boost_union/extscssgithubtoken';
+        $title = get_string('extscssgithubtoken', 'theme_boost_union', null, true);
+        $description = get_string('extscssgithubtoken_desc', 'theme_boost_union', null, true).'<br />'.
+                get_string('extscssgithubtoken_docs', 'theme_boost_union', null, true);
+        $default = '';
+        $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_ALPHANUMEXT);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/extscssgithubtoken', 'theme_boost_union/extscsssource', 'neq',
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_GITHUB);
+
+        // Setting: External SCSS Github API user.
+        $name = 'theme_boost_union/extscssgithubuser';
+        $title = get_string('extscssgithubuser', 'theme_boost_union', null, true);
+        $description = get_string('extscssgithubuser_desc', 'theme_boost_union', null, true).'<br />'.
+                get_string('extscssgithubuser_example', 'theme_boost_union', null, true);
+        $default = '';
+        $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_ALPHANUMEXT);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/extscssgithubuser', 'theme_boost_union/extscsssource', 'neq',
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_GITHUB);
+
+        // Setting: External SCSS Github API repository.
+        $name = 'theme_boost_union/extscssgithubrepo';
+        $title = get_string('extscssgithubrepo', 'theme_boost_union', null, true);
+        $description = get_string('extscssgithubrepo_desc', 'theme_boost_union', null, true).'<br />'.
+                get_string('extscssgithubrepo_example', 'theme_boost_union', null, true);
+        $default = '';
+        $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_ALPHANUMEXT);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/extscssgithubrepo', 'theme_boost_union/extscsssource', 'neq',
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_GITHUB);
+
+        // Setting: External Pre SCSS Github file path.
+        $name = 'theme_boost_union/extscssgithubprefilepath';
+        $title = get_string('extscssgithubprefilepath', 'theme_boost_union', null, true);
+        $description = get_string('extscssgithubprefilepath_desc', 'theme_boost_union', null, true).'<br />'.
+                get_string('extscssgithubfilepath_example', 'theme_boost_union', null, true);
+        $default = '';
+        $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_PATH);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/extscssgithubprefilepath', 'theme_boost_union/extscsssource', 'neq',
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_GITHUB);
+
+        // Setting: External Post SCSS Github file path.
+        $name = 'theme_boost_union/extscssgithubpostfilepath';
+        $title = get_string('extscssgithubpostfilepath', 'theme_boost_union', null, true);
+        $description = get_string('extscssgithubpostfilepath_desc', 'theme_boost_union', null, true).'<br />'.
+                get_string('extscssgithubfilepath_example', 'theme_boost_union', null, true);
+        $default = '';
+        $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_PATH);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/extscssgithubpostfilepath', 'theme_boost_union/extscsssource', 'neq',
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_GITHUB);
 
         // Add tab to settings page.
         $page->add($tab);

--- a/tests/behat/theme_boost_union_looksettings_scss.feature
+++ b/tests/behat/theme_boost_union_looksettings_scss.feature
@@ -38,3 +38,79 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
     And I press "Save changes"
     And I am on "Course 1" course homepage
     Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
+
+  @javascript
+  Scenario Outline: Setting: External SCSS - Add external SCSS download URL to the theme
+    Given the following config values are set as admin:
+      | config        | value | plugin            |
+      | extscsssource | 1     | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
+    # We add a small CSS snippet to the page which hides the heading in the page header.
+    # This is just to make it easy to detect the effect of this custom SCSS code.
+    And I set the following fields to these values:
+      | <urlfield> | <url> |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
+
+    Examples:
+      | urlfield                        | url                                                                                                                 |
+      | External Pre SCSS download URL  | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/master/tests/fixtures/extscss.scss |
+      | External Post SCSS download URL | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/master/tests/fixtures/extscss.scss |
+
+  @javascript
+  Scenario Outline: Setting: External SCSS - Add external SCSS from Github API to the theme
+    Given the following config values are set as admin:
+      | config        | value | plugin            |
+      | extscsssource | 2     | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
+    # We add a small CSS snippet to the page which hides the heading in the page header.
+    # This is just to make it easy to detect the effect of this custom SCSS code.
+    And I set the following fields to these values:
+      | External SCSS Github API token      | github_pat_<githubkey1><githubkey2><githubkey3> |
+      | External SCSS Github API user       | moodle-an-hochschulen                           |
+      | External SCSS Github API repository | moodle-theme_boost_union-extscsstest            |
+      | <pathfield>                         | <filepath>                                      |
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
+
+    Examples:
+      # The Github key which is placed here is is a fine-grained access token which was especially created for this Behat scenario and which will expire on 2025-05-06 due to Github's token lifetime policy.
+      # It is sliced into three pieces to avoid that Github's code scanning engine will find and invalidate it.
+      | pathfield                           | filepath      | githubkey1                   | githubkey3                   | githubkey2                 |
+      | External Pre SCSS Github file path  | /extscss.scss | 11AAIKUFQ0r5mGRLvI53V1_spQkU | 7kSEWBd25CNtUJE7UBA6dPdya3zM | C5O4Xo453LqQgKoXVAsmuKuC1q |
+      | External Post SCSS Github file path | /extscss.scss | 11AAIKUFQ0r5mGRLvI53V1_spQkU | 7kSEWBd25CNtUJE7UBA6dPdya3zM | C5O4Xo453LqQgKoXVAsmuKuC1q |
+
+  @javascript
+  Scenario Outline: Setting: External SCSS - Add a broken SCSS download URL / invalid external SCSS code to the theme
+    Given the following config values are set as admin:
+      | config        | value | plugin            |
+      | extscsssource | 1     | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
+    # We first add a valid CSS snippet to the page which is just there to detect later that SCSS has been compiled correctly.
+    And I set the field "Raw SCSS" to multiline:
+    """
+    #page-header h1 { display: none; }
+    """
+    And I press "Save changes"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
+    # And then we add a broken SCSS URL / invalid external SCSS code to the theme.
+    And I set the field "External Post SCSS download URL" to "<url>"
+    And I press "Save changes"
+    And I am on "Course 1" course homepage
+    # Regardless of the fact that broken / invalid SCSS code has been fetched from the external source, the SCSS
+    # should be compiled correctly.
+    Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
+
+    Examples:
+      | url                                                                                                                         |
+      | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/broken/tests/fixtures/extscss.scss         |
+      | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/master/tests/fixtures/extscss-invalid.scss |

--- a/tests/behat/theme_boost_union_tasks.feature
+++ b/tests/behat/theme_boost_union_tasks.feature
@@ -1,0 +1,25 @@
+@theme @theme_boost_union @theme_boost_union_tasks
+Feature: Running tasks in the theme_boost_union plugin
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname |
+      | Course 1 | C1        |
+
+  @javascript
+  Scenario: Running the \theme_boost_union\task\purge_cache task
+    Given the following config values are set as admin:
+      | config         | value                                                                                                               | plugin            |
+      | extscsssource  | 1                                                                                                                   | theme_boost_union |
+      | extscssurlpost | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/master/tests/fixtures/extscss.scss | theme_boost_union |
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I should see "Course 1" in the "#page-header .page-header-headings" "css_element"
+    And I run the scheduled task "\theme_boost_union\task\purge_cache"
+    And I reload the page
+    # The page must be reloaded a second time as the updated theme revision might not be shipped on the direct subsequent page load.
+    And I reload the page
+    Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"

--- a/tests/fixtures/extscss-invalid.scss
+++ b/tests/fixtures/extscss-invalid.scss
@@ -1,0 +1,1 @@
+brokenstuff

--- a/tests/fixtures/extscss.scss
+++ b/tests/fixtures/extscss.scss
@@ -1,0 +1,1 @@
+#page-header h1 { display: none; }


### PR DESCRIPTION
To allow Github actions to run on the peer review branch, the `tests/behat/theme_boost_union_tasks.feature` and `tests/behat/theme_boost_union_looksettings_scss.feature` files contain references to the issue-41 branch.

As soon as Github actions are green for this PR or during the integration of this PR at the latest, `issue-41` should be replaced with `master` in both files.