### PR TITLE
Cleanup: Fix CSS warnings in external SCSS tests, resolves #674.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased 
+
+* 2024-06-12 - Cleanup: Fix CSS warnings in external SCSS tests, resolves #674.
+
 ### v4.3-r14 
 
 * 2024-06-10 - Cleanup: Introduce a dedicated Behat step to deactivate and activate debugging, resolves #670.

--- a/tests/fixtures/extscss-invalid.scss
+++ b/tests/fixtures/extscss-invalid.scss
@@ -1,1 +1,2 @@
+/* stylelint-disable-next-line */
 brokenstuff

--- a/tests/fixtures/extscss.scss
+++ b/tests/fixtures/extscss.scss
@@ -1,1 +1,3 @@
-#page-header h1 { display: none; }
+#page-header h1 {
+    display: none;
+}


### PR DESCRIPTION
This PR is a no-brainer.
As soon as the tests have passed, it can be integrated.

However, we won't know if it really solves the problem which is described in #674 before the next release on moodle.org