### PR TITLE
Bugfix: Allow external SCSS to use SCSS variables by disabling the SCSS validation, resolves #683.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased 
 
+* 2024-07-11 - Bugfix: Allow external SCSS to use SCSS variables by disabling the SCSS validation, resolves #683.
 * 2024-06-23 - Upstream change: Adopt change in view-chards.mustache from MDL-70829.
 * 2024-06-18 - Release: Let codechecker ignore some sniffs in the language pack.
 * 2024-06-13 - Cleanup: Change @codingStandardsIgnore tags to phpcs:disable, resolves #676.

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -67,7 +67,7 @@ $string['scssheading'] = 'Raw SCSS';
 $string['extscssheading'] = 'External SCSS';
 $string['extscssheading_desc'] = 'In addition to the raw SCSS settings above, Boost Union can load SCSS from an external source. It is included before the SCSS code which is defined above which means that you can manage a centralized external SCSS codebase and can still amend it with local SCSS additions.';
 $string['extscssheading_instr'] = 'Instructions:';
-$string['extscssheading_drop'] = 'If Boost Union cannot fetch the external SCSS file for any reason or if the fetched external SCSS code is invalid, it will simply ignore the external SCSS file to avoid hickups with SCSS compiling and broken frontends.';
+$string['extscssheading_drop'] = 'If Boost Union cannot fetch the external SCSS file for any reason, it will simply ignore the external SCSS file to avoid hickups with SCSS compiling and broken frontends.';
 $string['extscssheading_structure'] = 'The external SCSS must be provided as plaintext file, without any headers or footers, containing just the SCSS code.';
 $string['extscssheading_prepost'] = 'Just like the raw SCSS settings above, the external SCSS is split into two pieces: Pre and Post SCSS. Pre SCSS can be used for initializing SCSS variables, Post SCSS is used for your actual SCSS code.';
 $string['extscssheading_sources'] = 'You can configure Boost Union to fetch the external SCSS file either from a public download URL (which will be accessed and fetched with an unauthenticated cURL request) or from a private Github repository (which will be accessed and fetched with a Github API token).';
@@ -104,6 +104,9 @@ $string['extscssgithubfilepath_example'] = 'Example: If you can see the file in 
 // ... ... Setting: External Post SCSS Github file path.
 $string['extscssgithubpostfilepath'] = 'External Post SCSS Github file path';
 $string['extscssgithubpostfilepath_desc'] = 'The path within the private Github repository where the Post SCSS file is located.';
+// ... ... Setting: External SCSS validation.
+$string['extscssvalidationsetting'] = 'External SCSS validation';
+$string['extscssvalidationsetting_desc'] = 'If this setting is enabled, the external SCSS is validated if it can be compiled before it is added to the SCSS stack. External SCSS code which can\'t be compiled is silently ignored and not used. However, this validation is only run on the external SCSS code only, it is not run on the combined SCSS stack which would be the result of the integration of the external SCSS. This means that, as soon as you use SCSS variables from Moodle core or Bootstrap in your external SCSS, you have to disable the validation and verify yourself that the SCSS code is valid to avoid broken frontends.';
 
 // Settings: Page tab.
 $string['pagetab'] = 'Page';

--- a/locallib.php
+++ b/locallib.php
@@ -2171,13 +2171,16 @@ function theme_boost_union_get_external_scss($type) {
         return '';
     }
 
-    // If the fetched SCSS code cannot be compiled, return directly
-    // (as we must not include broken SCSS code).
-    $compiler = new core_scss();
-    try {
-        $compiler->compile($extscss);
-    } catch (Exception $e) {
-        return '';
+    // If external SCSS validation is enabled.
+    if (get_config('theme_boost_union', 'extscssvalidation') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+        // If the fetched SCSS code cannot be compiled, return directly
+        // (as we must not include broken SCSS code).
+        $compiler = new core_scss();
+        try {
+            $compiler->compile($extscss);
+        } catch (Exception $e) {
+            return '';
+        }
     }
 
     // Now return the (hopefully valid and working) SCSS code.

--- a/settings.php
+++ b/settings.php
@@ -292,6 +292,16 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $page->hide_if('theme_boost_union/extscssgithubpostfilepath', 'theme_boost_union/extscsssource', 'neq',
                 THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_GITHUB);
 
+        // Setting: External SCSS validation.
+        $name = 'theme_boost_union/extscssvalidation';
+        $title = get_string('extscssvalidationsetting', 'theme_boost_union', null, true);
+        $description = get_string('extscssvalidationsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_YES, $yesnooption);
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+        $page->hide_if('theme_boost_union/extscssvalidation', 'theme_boost_union/extscsssource', 'eq',
+                THEME_BOOST_UNION_SETTING_EXTSCSSSOURCE_NONE);
+
         // Add tab to settings page.
         $page->add($tab);
 

--- a/tests/behat/theme_boost_union_looksettings_scss.feature
+++ b/tests/behat/theme_boost_union_looksettings_scss.feature
@@ -95,7 +95,7 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
       | External Post SCSS Github file path | /extscss.scss | 11AAIKUFQ0r5mGRLvI53V1_spQkU | 7kSEWBd25CNtUJE7UBA6dPdya3zM | C5O4Xo453LqQgKoXVAsmuKuC1q |
 
   @javascript
-  Scenario Outline: Setting: External SCSS - Add a broken SCSS download URL / invalid external SCSS code to the theme
+  Scenario Outline: Setting: External SCSS - Add a broken SCSS download URL to the theme
     Given the following config values are set as admin:
       | config        | value | plugin            |
       | extscsssource | 1     | theme_boost_union |
@@ -111,12 +111,42 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
     And I press "Save changes"
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
-    # And then we add a broken SCSS URL / invalid external SCSS code to the theme.
+    # And then we add a broken SCSS URL to the theme.
     And I set the field "External Post SCSS download URL" to "<url>"
     And I press "Save changes"
     And Behat debugging is enabled
     And I am on "Course 1" course homepage
-    # Regardless of the fact that broken / invalid SCSS code has been fetched from the external source, the SCSS
+    # Regardless of the fact that the broken URL was configured as external source, the SCSS
+    # should be compiled correctly.
+    Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
+
+    Examples:
+      | url                                                                                                                 |
+      | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/broken/tests/fixtures/extscss.scss |
+
+  @javascript
+  Scenario Outline: Setting: External SCSS - Add an invalid external SCSS code to the theme and validate it
+    Given the following config values are set as admin:
+      | config            | value | plugin            |
+      | extscsssource     | 1     | theme_boost_union |
+      | extscssvalidation | yes   | theme_boost_union |
+    When I log in as "admin"
+    And Behat debugging is disabled
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
+    # We first add a valid CSS snippet to the page which is just there to detect later that SCSS has been compiled correctly.
+    And I set the field "Raw SCSS" to multiline:
+    """
+    #page-header h1 { display: none; }
+    """
+    And I press "Save changes"
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I set the field "External Post SCSS download URL" to "<url>"
+    And I press "Save changes"
+    And Behat debugging is enabled
+    And I am on "Course 1" course homepage
+    # Regardless of the fact that invalid SCSS code has been fetched from the external source, the SCSS
     # should be compiled correctly.
     Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
 
@@ -124,3 +154,27 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
       | url                                                                                                                         |
       | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/broken/tests/fixtures/extscss.scss         |
       | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/master/tests/fixtures/extscss-invalid.scss |
+
+  @javascript @testme
+  Scenario Outline: Setting: External SCSS - Add an external SCSS code with Bootstrap variables to the theme and validate it
+    Given the following config values are set as admin:
+      | config            | value      | plugin            |
+      | extscsssource     | 1          | theme_boost_union |
+      | extscssvalidation | <validate> | theme_boost_union |
+    When I log in as "admin"
+    And Behat debugging is disabled
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
+    # And then we add external SCSS code with Bootstrap variables to the theme.
+    And I set the field "External Post SCSS download URL" to "<url>"
+    And I press "Save changes"
+    And Behat debugging is enabled
+    And I am on "Course 1" course homepage
+    # Regardless of the fact that broken / invalid SCSS code has been fetched from the external source, the SCSS
+    # should be compiled correctly.
+    Then I <shouldornot> see "Course 1" in the "#page-header .page-header-headings" "css_element"
+
+    Examples:
+      | validate | shouldornot | url                                                                                                                                |
+      | yes      | should      | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/master/tests/fixtures/extscss-with-variables.scss |
+      | no       | should not  | https://raw.githubusercontent.com/moodle-an-hochschulen/moodle-theme_boost_union/master/tests/fixtures/extscss-with-variables.scss |

--- a/tests/fixtures/extscss-with-variables.scss
+++ b/tests/fixtures/extscss-with-variables.scss
@@ -1,0 +1,6 @@
+body {
+    color: $primary;
+}
+#page-header h1 {
+    display: none;
+}


### PR DESCRIPTION
The tests of this PR will fail as they try to download a new SCSS file from the master branch. I have run the test locally successfully and they will be green after the branch is integrated into master.