### PR TITLE
Bugfix: footer displacement on pages with minimal content, resolves #655.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-11-18 - Bugfix: Footer displacement on pages with minimal content, resolves #655.
 * 2024-11-18 - Upstream change: Adopt changes from MDL-77732 ('Custom menu items do not receive active behaviour'), resolves #436 #620 #384 #715.
 * 2024-11-13 - Upstream change: Adopt changes from MDL-78999 ('Site logo does not appear in mobile view'), resolves #753.
 * 2024-11-11 - Release: Add ssystems GmbH to the list of maintainers in README.md.

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -649,10 +649,13 @@ body.theme-boost-union-commincourse {
 
 /* To support additional block regions around the main content area, Boost Union introduced
    the main-inner-wrapper HTML element. Unfortunately, this breaks the Flexbox flow of Moodle core.
-   To make it work again, we have to set the Flexbox flex attribute in the main-inner-wrapper element as well. */
-.main-inner-wrapper {
+   To make it work again, we have to set the Flexbox flex attribute in the main-inner-wrapper element as well.
+   In addition to that, we set the Flexbox attribute for the #page element as well as it turned out to be necessary. */
+.main-inner-wrapper,
+#page-wrapper #page {
     flex: 1 0 auto;
 }
+
 
 /*---------------------------------------
  * Settings: Additional block regions - The offcanvas region.


### PR DESCRIPTION
Issue: https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues/655

This should be a quick and easy fix. However I don't know if it has any drawbacks I haven't thought of.