### PR TITLE
Bugfix: set active navigation node when smartmenus are enabled, resoves #620, #384 and #694.

### DIFF
--- a/tests/behat/theme_boost_union_smartmenusettings_menus_presentation.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menus_presentation.feature
@@ -424,3 +424,70 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
       | 1        | 0        | 0        | after     | before    | after     |
       | 0        | 0        | 2        | before    | after     | after     |
       | 0        | 1        | 2        | before    | after     | before    |
+
+  @javascript
+  Scenario: Smartmenu: Menus: Presentation - Verify that the correct menu item is displayed as active when viewing the main menu item's page.
+    Given I log in as "admin"
+    And I create smart menu with the following fields to these values:
+      | Title             | Quick links |
+      | Menu location(s)  | Main        |
+      | Menu mode         | Inline      |
+    And I set "Quick links" smart menu items with the following fields to these values:
+      | Title          | Test node                           |
+      | Menu item type | Static                              |
+      | URL            | /admin/tool/dataprivacy/summary.php |
+      | CSS class      | testnode01                          |
+    When I am on site homepage
+    Then the "class" attribute of ".primary-navigation [data-key='home'] a" "css_element" should contain "active"
+    And the "class" attribute of ".primary-navigation .testnode01 a" "css_element" should not contain "active"
+    And "//a[@aria-current = 'true']" "xpath" should exist in the ".primary-navigation [data-key='home']" "css_element"
+    And "//a[@aria-current = 'true']" "xpath" should not exist in the ".primary-navigation .testnode01" "css_element"
+    And I click on "Test node" "link" in the ".primary-navigation" "css_element"
+    Then the "class" attribute of ".primary-navigation [data-key='home'] a" "css_element" should not contain "active"
+    And the "class" attribute of ".primary-navigation .testnode01 a" "css_element" should contain "active"
+    And "//a[@aria-current = 'true']" "xpath" should not exist in the ".primary-navigation [data-key='home']" "css_element"
+    And "//a[@aria-current = 'true']" "xpath" should exist in the ".primary-navigation .testnode01" "css_element"
+
+  @javascript
+  Scenario: Smartmenu: Menus: Presentation - Verify that the correct menu item is displayed as active when viewing the submenu item's page.
+    Given I log in as "admin"
+    And I create smart menu with the following fields to these values:
+      | Title             | Quick links |
+      | Menu location(s)  | Main        |
+      | Menu mode         | Submenu     |
+      | CSS class         | testnode01  |
+    And I set "Quick links" smart menu items with the following fields to these values:
+      | Title          | Test node                           |
+      | Menu item type | Static                              |
+      | URL            | /admin/tool/dataprivacy/summary.php |
+    When I am on site homepage
+    Then the "class" attribute of ".primary-navigation [data-key='home'] a" "css_element" should contain "active"
+    And the "class" attribute of ".primary-navigation .testnode01 a" "css_element" should not contain "active"
+    And "//a[@aria-current = 'true']" "xpath" should exist in the ".primary-navigation [data-key='home']" "css_element"
+    And "//a[@aria-current = 'true']" "xpath" should not exist in the ".primary-navigation .testnode01" "css_element"
+    And I click on "Quick links" "link" in the ".primary-navigation" "css_element"
+    And I click on "Test node" "link" in the ".primary-navigation" "css_element"
+    Then the "class" attribute of ".primary-navigation [data-key='home'] a" "css_element" should not contain "active"
+    And the "class" attribute of ".primary-navigation .testnode01 a" "css_element" should contain "active"
+    And "//a[@aria-current = 'true']" "xpath" should not exist in the ".primary-navigation [data-key='home']" "css_element"
+    And "//a[@aria-current = 'true']" "xpath" should exist in the ".primary-navigation .testnode01" "css_element"
+
+  @javascript
+  Scenario: Smartmenu: Menus: Presentation - Verify that the correct _custom_ menu item is displayed as active when viewing the custom menu item's page (Moodle core behaviour which must not be broken by the smart menus)
+    Given I log in as "admin"
+    And I navigate to "Appearance > Advanced theme settings" in site administration
+    And I set the field "Custom menu items" to multiline:
+    """
+    Test node|/admin/tool/dataprivacy/summary.php
+    """
+    And I click on "Save changes" "button"
+    When I am on site homepage
+    Then the "class" attribute of ".primary-navigation [data-key='home'] a" "css_element" should contain "active"
+    And the "class" attribute of ".primary-navigation .nav-item:nth-child(5) a" "css_element" should not contain "active"
+    And "//a[@aria-current = 'true']" "xpath" should exist in the ".primary-navigation [data-key='home']" "css_element"
+    And "//a[@aria-current = 'true']" "xpath" should not exist in the ".primary-navigation .nav-item:nth-child(5)" "css_element"
+    And I click on "Test node" "link" in the ".primary-navigation" "css_element"
+    Then the "class" attribute of ".primary-navigation [data-key='home'] a" "css_element" should not contain "active"
+    And the "class" attribute of ".primary-navigation .nav-item:nth-child(5) a" "css_element" should contain "active"
+    And "//a[@aria-current = 'true']" "xpath" should not exist in the ".primary-navigation [data-key='home']" "css_element"
+    And "//a[@aria-current = 'true']" "xpath" should exist in the ".primary-navigation .nav-item:nth-child(5)" "css_element"


### PR DESCRIPTION
Another summer time _theme_boost_union_ fix.

This targets at solving the issues #620, #384 and #694.

In the file `classes/output/navigation/primary.php` when  _smartmenus_ were enabled the `parent:export_for_template` does not get called ( parent class is `core\navigation\output\primary`).

**Cause of the bug:** The menu with the smartmenu nodes are just merged with the primary navigation and the custommenus via the PHP function `array_merge`. 

**Fix:** Now the smartmenus and the custommenus are merged via array_merge and later merged with the primary menu nodes via the function `merge_primary_and_custom`. This function checks for the active node, the same way it happens when smartmenus are disabled.

Maybe this should also be adjusted when the variable `$mobileprimarynav` gets set, too.

**To-Do:**
- [x] Write new acceptance tests that cover the flag

**At reviewers:**
There is still a bug when clicking on external static link in the smartmenu and using the browsers return function, that multiple nodes (the actual active one and the external one) are shown as active. But I don't have any idea how to fix this edge case.