### PR TITLE
Fix removed /cache/classes/loaders.php, resolves #708

### DIFF
--- a/classes/cache/loader.php
+++ b/classes/cache/loader.php
@@ -26,12 +26,12 @@ namespace theme_boost_union\cache;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/cache/classes/loaders.php');
+use core_cache\application_cache;
 
 /**
  * Custom cache loader to handle the smart menus and items deletion.
  */
-class loader extends \cache_application {
+class loader extends application_cache {
 
     /**
      * Delete the cached menus or menu items for all of its users.


### PR DESCRIPTION
Also, `cache_application` was renamed to `application_cache`.