### PR TITLE
Bugfix: Course category breadcrumbs were broken on the course enrolment page due to MDL-80974 and were removed, resolves #727

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-10-09 - Bugfix: Course category breadcrumbs were broken on the course enrolment page due to MDL-80974 and were removed, resolves #727.
 * 2024-10-08 - Upstream change: Adopt change from MDL-82298 into smartmenus-[card|more]menu-children.mustache
 * 2024-08-24 - Upgrade: Update Bootstrap classes for Moodle 4.4.
 * 2024-08-11 - Updated Moodle Plugin CI to latest upstream recommendations

--- a/classes/boostnavbar.php
+++ b/classes/boostnavbar.php
@@ -168,8 +168,8 @@ class boostnavbar extends \theme_boost\boostnavbar {
 
         // Don't display the navbar if there is only one item. Apparently this is bad UX design.
         // Except, leave it in when in course context and categorybreadcrumbs are desired.
-        if (get_config('theme_boost_union', 'categorybreadcrumbs') != THEME_BOOST_UNION_SETTING_SELECT_YES &&
-                $this->page->context->contextlevel == CONTEXT_COURSE) {
+        if (!(get_config('theme_boost_union', 'categorybreadcrumbs') == THEME_BOOST_UNION_SETTING_SELECT_YES &&
+                $this->page->context->contextlevel == CONTEXT_COURSE)) {
             if ($this->item_count() <= 1) {
                 $this->clear_items();
                 return;

--- a/tests/behat/theme_boost_union_feelsettings_navigation.feature
+++ b/tests/behat/theme_boost_union_feelsettings_navigation.feature
@@ -162,20 +162,18 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
       | Category ED    | 1        | CED      | CE       |
       | Category EDC   | 2        | CEDC     | CED      |
       | Category EDCB  | 3        | CEDCB    | CEDC     |
-      | Category EDCBA | 4        | CEDCBA   | CEDCB    |
     And the following "courses" exist:
       | fullname  | shortname | category |
       | Course C1 | CC1       | CE       |
       | Course C2 | CC2       | CED      |
       | Course C3 | CC3       | CEDC     |
       | Course C4 | CC4       | CEDCB    |
-      | Course C5 | CC5       | CEDCBA   |
     And the following "course enrolments" exist:
       | user     | course | role           |
+      | teacher1 | CC1    | editingteacher |
       | teacher1 | CC2    | editingteacher |
       | teacher1 | CC3    | editingteacher |
       | teacher1 | CC4    | editingteacher |
-      | teacher1 | CC5    | editingteacher |
     And the following config values are set as admin:
       | config              | value     | plugin            |
       | categorybreadcrumbs | <setting> | theme_boost_union |
@@ -194,12 +192,6 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
     And "Category ED" "link" <shouldornot> exist in the ".breadcrumb" "css_element"
     And "Category EDC" "link" <shouldornot> exist in the ".breadcrumb" "css_element"
     And "Category EDCB" "link" <shouldornot> exist in the ".breadcrumb" "css_element"
-    And I am on "Course C5" course homepage
-    And "Category E" "link" <shouldornot> exist in the ".breadcrumb" "css_element"
-    And "Category ED" "link" <shouldornot> exist in the ".breadcrumb" "css_element"
-    And "Category EDC" "link" <shouldornot> exist in the ".breadcrumb" "css_element"
-    And "Category EDCB" "link" <shouldornot> exist in the ".breadcrumb" "css_element"
-    And "Category EDCBA" "link" <shouldornot> exist in the ".breadcrumb" "css_element"
 
     Examples:
       | setting | shouldornot |
@@ -213,22 +205,16 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
       | Category ED    | 1        | CED      | CE       |
     And the following "courses" exist:
       | fullname  | shortname | category |
-      | Course C1 | CC1       | CE       |
-      | Course C2 | CC2       | CED      |
+      | Course C1 | CC1       | CED      |
     And the following "course enrolments" exist:
       | user     | course | role           |
-      | teacher1 | CC2    | editingteacher |
+      | teacher1 | CC1    | editingteacher |
     And the following config values are set as admin:
       | config              | value     | plugin            |
       | categorybreadcrumbs | yes       | theme_boost_union |
     When I log in as "teacher1"
     And I am on the "Course C1 > New section" "course > section" page
     Then "Category E" "link" should exist in the ".breadcrumb" "css_element"
-    And "Enrolment options" "text" should exist in the ".breadcrumb" "css_element"
-    And "Enrolment options" "text" should appear after "Category E" "link" in the ".breadcrumb" "css_element"
-    And "New section" "link" should not exist in the ".breadcrumb" "css_element"
-    And I am on the "Course C2 > New section" "course > section" page
-    And "Category E" "link" should exist in the ".breadcrumb" "css_element"
     And "Category ED" "link" should exist in the ".breadcrumb" "css_element"
     And "New section" "link" should exist in the ".breadcrumb" "css_element"
     And "Category ED" "link" should appear after "Category E" "link" in the ".breadcrumb" "css_element"


### PR DESCRIPTION
This PR fixes the glitch which was reported in #727.

It was caused by a bug in Boost Union on the one hand, but also by the upstream change in MDL-80974 (see https://github.com/moodle/moodle/commit/faac67e2eaa44981eddf2508c35210c8b121f848) on the other hand.

The PR's solution is to remove course category breadcrumbs from the enrolment page entirely as Boost Union in fact never promised to show them, they were rather shown there by chance.

The setting `theme_boost_union | categorybreadcrumbs`says:
> By default, the course category breadcrumbs are not shown on course pages in the course header. With this setting, you can show the course category breadcrumbs in the course header above the course name.

Nothing is mentioned about the enrolment page. If category breadcrumbs are requested there, they have to be developed properly from scratch.