### PR TITLE
Backport: Use the before_session_start() callback instead of the after_config() callback on Moodle 4.4, resolves #721.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2024-10-23 - Backport: Use the before_session_start() callback instead of the after_config() callback on Moodle 4.4, resolves #721.
+
 ### v4.4-r3
 
 * 2024-10-21 - Improvement: Add link to policyoverviewnavigation setting, resolves #732.

--- a/README.md
+++ b/README.md
@@ -675,16 +675,29 @@ In addition to our mission to provide admin settings for each and every feature 
 Exceptions to our main design principle
 ---------------------------------------
 
-As you have read in the introduction, the main design principle of Boost Union is not to change anything in the GUI until a particular feature is enabled in the theme settings. However, due to the way how Moodle core and Boost in Moodle core is built, this main design principle sometimes could not be fully satisfied:
+As you have read in the introduction, the main design principle of Boost Union is not to change anything in the GUI until Boost Union is set as active theme and a particular feature is enabled in the theme settings. However, due to the way how Moodle core and Boost in Moodle core is built, this main design principle sometimes could not be fully satisfied:
 
 * Footer popover:
   As soon as you click the footer button (questionmark icon) in the bottom right corner of the screen, a popover with several links appears. However, the content of this link list is far from being well-structured and looks more like a garage sale. When implementing the settings to individually suppress each of these popover links, we had to make some code re-arrangements which result in the fact that the popover links are slightly more well-structured even if you do not enable any setting in Boost Union.
+* Suppress footer outputs by plugin / core component:
+  Due to the way how the settings `theme_boost_union | footersuppressstandardfooter_*` had to be built, it was not possible to quickly and reliably detect if Boost Union (or a Boost Union child theme) is the active theme. Thus, these settings are also applied if another theme than Boost Union is active. Please make sure to disable these settings if Boost Union is installed but should not be used.
 
 
 Companion plugin local_navbarplus
 ---------------------------------
 
 With the footersuppressusertour setting, you can disable the possibility to reset a user tour in the footer popover. If you have enabled this setting, you might want to have a look at our plugin local_navbarplus as a companion plugin which allows you, among other things, to add a "Reset user tour" link to the navigation bar instead. local_navbarplus is published on https://moodle.org/plugins/local_navbarplus and on https://github.com/moodle-an-hochschulen/moodle-local_navbarplus.
+
+
+Interference with forced settings in config.php
+-----------------------------------------------
+
+Due to the way how some Boost Union features had to be built, you have to be aware of the following interferences if you force settings in config.php:
+
+* $CFG->hooks_callback_overrides:
+  With this setting, you can override hook definitions in config.php - see https://moodledev.io/docs/4.4/apis/core/hooks#hooks-overview-page.
+  However, if you use the `theme_boost_union | footersuppressstandardfooter_*` settings, this forced setting will be set as well during each page load.
+  Using the Boost Union settings and overriding hooks manually in config.php at the same time should work, but is not officially supported and tested by Boost Union.
 
 
 Support for other companion plugins

--- a/db/caches.php
+++ b/db/caches.php
@@ -83,4 +83,12 @@ $definitions = [
                 'simpledata' => false,
                 'overrideclass' => '\theme_boost_union\cache\loader',
         ],
+        // This cache stores the hook overrides.
+        'hookoverrides' => [
+                'mode' => cache_store::MODE_APPLICATION,
+                'simplekeys' => true,
+                'simpledata' => false,
+                'canuselocalstore' => true,
+                'staticacceleration' => false,
+        ],
 ];

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -686,7 +686,7 @@ $string['footersuppressstandardfootercore'] = 'Suppress footer output by core co
 $string['footersuppressstandardfootercore_desc'] = 'With this setting, you can entirely suppress the footer output by the core component \'{$a}\'. Core components can add additional content to the footer by implementing a particular hook or function. This core component has implemented this hook / function and might add content to the footer in certain circumstances.';
 // ... ... Setting: Suppress footer output by plugins.
 $string['footersuppressstandardfooter'] = 'Suppress footer output by plugin \'{$a}\'';
-$string['footersuppressstandardfooter_desc'] = 'With this setting, you can entirely suppress the footer output by plugin \'{$a}\'. Plugins (even if they are shipped with Moodle core, but are still technically plugins) can add additional content to the footer by implementing a particular hook or function. This plugin has implemented this hook / function and might add content to the footer in certain circumstances.';
+$string['footersuppressstandardfooter_desc'] = 'With this setting, you can entirely suppress the footer output by plugin \'{$a}\'. Plugins (even if they are shipped with Moodle core, but are still technically plugins) can add additional content to the footer by implementing a particular hook or function. This plugin has implemented this hook / function and might add content to the footer in certain circumstances.<br />Please note: Due to the way how the suppressing feature is implemented, the setting might not take effect before the second page load after saving the setting.';
 
 // Settings: Static pages tab.
 $string['staticpagestab'] = 'Static pages';
@@ -1320,6 +1320,7 @@ $string['cachedef_flavours'] = 'Flavours which apply to a given page\'s category
 $string['cachedef_smartmenus'] = 'Smart menus';
 $string['cachedef_smartmenu_items'] = 'Smart menu items';
 $string['cachedef_touchiconsios'] = 'Touch icon files for iOS';
+$string['cachedef_hookoverrides'] = 'Hook overrides';
 
 // Scheduled tasks.
 $string['task_purgecache'] = 'Purge theme cache';

--- a/lib.php
+++ b/lib.php
@@ -645,20 +645,21 @@ function theme_boost_union_render_navbar_output() {
 }
 
 /**
- * Triggered as soon as practical on every moodle bootstrap after config has been loaded.
+ * Triggered as soon as practical on every moodle bootstrap before session is started.
  *
  * We use this callback function to manipulate / set settings which would normally be manipulated / set through
  * /config.php, but we do not want to urge the admin to add stuff to /config.php when installing Boost Union.
  */
-function theme_boost_union_after_config() {
+function theme_boost_union_before_session_start() {
     global $CFG;
+
+    // Note: At this point, the $PAGE object does not exist yet. Thus, we cannot quickly and reliably detect if Boost Union
+    // (or a Boost Union child theme) is the active theme. Thus, the following code is executed for every theme.
+    // This fact is noted in the README.
 
     // Require own local library.
     require_once($CFG->dirroot.'/theme/boost_union/locallib.php');
 
-    // If this is not called by a CLI script or an AJAX script.
-    if (!CLI_SCRIPT && !AJAX_SCRIPT) {
-        // Manipulate Moodle core hooks.
-        theme_boost_union_manipulate_hooks();
-    }
+    // Manipulate Moodle core hooks.
+    theme_boost_union_manipulate_hooks();
 }

--- a/settings.php
+++ b/settings.php
@@ -1994,7 +1994,7 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
             $name = 'theme_boost_union/footersuppressstandardfooter_'.$pluginname;
             $setting = new admin_setting_configselect($name, $hooklabeltitle, $hooklabeldesc,
                     THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
-            $setting->set_updatedcallback('theme_boost_union_remove_hookmanipulation_marker');
+            $setting->set_updatedcallback('theme_boost_union_remove_hookmanipulation');
             $tab->add($setting);
             $page->hide_if('theme_boost_union/footersuppressstandardfooter_'.$pluginname,
                     'theme_boost_union/enablefooterbutton', 'eq', THEME_BOOST_UNION_SETTING_ENABLEFOOTER_NONE);


### PR DESCRIPTION
This PR will backport the patch for #721 which was integrated into BU 4.5 into BU 4.4 as well (in a slightly modified way).
The goal is to align both codebases in this aspect.