### PR TITLE
Fix thirdparty icon size in 4.4 courseindex drawer, resolves #755

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### v4.4-r6
 
+* 2024-11-19 - Bugfix: Port the activity icon sizes in the nav drawer back to stable versions, resolves #755.
 * 2024-11-19 - Upgrade: Support more seamless upgrade to 4.5 by only requiring /cache/classes/loaders.php if it is present, resolves #708.
 * 2024-11-19 - Bugfix: The starred courses popover showed a JavaScript error in the browser JS console, resolves #759.
 * 2024-11-19 - Bugfix: The starred courses popover in the navbar must only be shown if Boost Union or Boost Union child is active, resolves #759.

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -405,7 +405,9 @@ body.hascourseindexcmicons {
             justify-content: center;
             align-items: center;
             .icon {
+                height: 24px;
                 margin-right: unset;
+                width: 24px;
             }
         }
 


### PR DESCRIPTION
This PR provides explicit width and height for icons in the courseindex drawer for Moodle 4.4.

As mentioned in the issue, this is needed if icons exceed a specific size as seen with some thridparty plugins.

To provide consitency with 4.4. styling, 24px were used as values.