### PR TITLE
Behat optimisations, addresses #765.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-12-06 - Tests: Add several Behat optimisations to bring down the test suite run time, resolves #765.
 * 2024-12-06 - Upstream change: Adopt changes from MDL-83759 ('System notification navbar popover is misplaced in Moodle 4.4 and 4.5')
 * 2024-12-06 - Upstream change: Adopt changes from MDL-75610 ('Quiz activity name no longer being displayed in quiz landing page when using Safe Exam Browser'), resolves #766.
 

--- a/classes/form/smartmenu_edit_form.php
+++ b/classes/form/smartmenu_edit_form.php
@@ -80,10 +80,7 @@ class smartmenu_edit_form extends \moodleform {
         $mform->addRule('location', get_string('required'), 'required');
 
         // Add mode as select element.
-        $modeoptions = [
-                smartmenu::MODE_SUBMENU => get_string('smartmenusmodesubmenu', 'theme_boost_union'),
-                smartmenu::MODE_INLINE => get_string('smartmenusmodeinline', 'theme_boost_union'),
-        ];
+        $modeoptions = smartmenu::get_mode_options();
         $mform->addElement('select', 'mode', get_string('smartmenusmenumode', 'theme_boost_union'), $modeoptions);
         $mform->setDefault('mode', smartmenu::MODE_SUBMENU);
         $mform->setType('mode', PARAM_INT);
@@ -102,12 +99,7 @@ class smartmenu_edit_form extends \moodleform {
         $mform->addHelpButton('type', 'smartmenusmenutype', 'theme_boost_union');
 
         // Add show description as select element.
-        $showdescriptionoptions = [
-                smartmenu::DESC_NEVER => get_string('smartmenusmenushowdescriptionnever', 'theme_boost_union'),
-                smartmenu::DESC_ABOVE => get_string('smartmenusmenushowdescriptionabove', 'theme_boost_union'),
-                smartmenu::DESC_BELOW => get_string('smartmenusmenushowdescriptionbelow', 'theme_boost_union'),
-                smartmenu::DESC_HELP => get_string('smartmenusmenushowdescriptionhelp', 'theme_boost_union'),
-        ];
+        $showdescriptionoptions = smartmenu::get_showdescription_options();
         $mform->addElement('select', 'showdesc', get_string('smartmenusmenushowdescription', 'theme_boost_union'),
                 $showdescriptionoptions);
         $mform->setDefault('showdesc', smartmenu::DESC_NEVER);
@@ -115,11 +107,7 @@ class smartmenu_edit_form extends \moodleform {
         $mform->addHelpButton('showdesc', 'smartmenusmenushowdescription', 'theme_boost_union');
 
         // Add more menu behavior as select element.
-        $moremenuoptions = [
-                smartmenu::MOREMENU_DONOTCHANGE => get_string('dontchange', 'theme_boost_union'),
-                smartmenu::MOREMENU_INTO => get_string('smartmenusmenumoremenubehaviorforceinto', 'theme_boost_union'),
-                smartmenu::MOREMENU_OUTSIDE => get_string('smartmenusmenumoremenubehaviorkeepoutside', 'theme_boost_union'),
-        ];
+        $moremenuoptions = smartmenu::get_moremenu_options();
         $mform->addElement('select', 'moremenubehavior', get_string('smartmenusmenumoremenubehavior', 'theme_boost_union'),
                 $moremenuoptions);
         $mform->setDefault('moremenubehavior', smartmenu::MOREMENU_DONOTCHANGE);
@@ -132,12 +120,7 @@ class smartmenu_edit_form extends \moodleform {
         $mform->setType('cssclass', PARAM_TEXT);
 
         // Add card size as select element.
-        $cardsizeoptions = [
-                smartmenu::CARDSIZE_TINY => get_string('smartmenusmenucardsizetiny', 'theme_boost_union').' (50px)',
-                smartmenu::CARDSIZE_SMALL => get_string('smartmenusmenucardsizesmall', 'theme_boost_union').' (100px)',
-                smartmenu::CARDSIZE_MEDIUM => get_string('smartmenusmenucardsizemedium', 'theme_boost_union').' (150px)',
-                smartmenu::CARDSIZE_LARGE => get_string('smartmenusmenucardsizelarge', 'theme_boost_union').' (200px)',
-        ];
+        $cardsizeoptions = smartmenu::get_cardsize_options();
         $mform->addElement('select', 'cardsize', get_string('smartmenusmenucardsize', 'theme_boost_union'), $cardsizeoptions);
         $mform->setDefault('cardsize', smartmenu::CARDSIZE_TINY);
         $mform->setType('cardsize', PARAM_INT);
@@ -145,16 +128,7 @@ class smartmenu_edit_form extends \moodleform {
         $mform->addHelpButton('cardsize', 'smartmenusmenucardsize', 'theme_boost_union');
 
         // Add card form as select element.
-        $cardformoptions = [
-                smartmenu::CARDFORM_SQUARE =>
-                        get_string('smartmenusmenucardformsquare', 'theme_boost_union').' (1/1)',
-                smartmenu::CARDFORM_PORTRAIT =>
-                        get_string('smartmenusmenucardformportrait', 'theme_boost_union').' (2/3)',
-                smartmenu::CARDFORM_LANDSCAPE =>
-                        get_string('smartmenusmenucardformlandscape', 'theme_boost_union').' (3/2)',
-                smartmenu::CARDFORM_FULLWIDTH =>
-                        get_string('smartmenusmenucardformfullwidth', 'theme_boost_union'),
-        ];
+        $cardformoptions = smartmenu::get_cardform_options();
         $mform->addElement('select', 'cardform',
                 get_string('smartmenusmenucardform', 'theme_boost_union'), $cardformoptions);
         $mform->setDefault('cardform', smartmenu::CARDFORM_SQUARE);
@@ -163,12 +137,7 @@ class smartmenu_edit_form extends \moodleform {
         $mform->addHelpButton('cardform', 'smartmenusmenucardform', 'theme_boost_union');
 
         // Add card overflow behaviour as select element.
-        $cardoverflowoptions = [
-                smartmenu::CARDOVERFLOWBEHAVIOUR_NOWRAP =>
-                        get_string('smartmenusmenucardoverflowbehaviornowrap', 'theme_boost_union'),
-                smartmenu::CARDOVERFLOWBEHAVIOUR_WRAP =>
-                        get_string('smartmenusmenucardoverflowbehaviorwrap', 'theme_boost_union'),
-        ];
+        $cardoverflowoptions = smartmenu::get_cardoverflowbehaviour_options();
         $mform->addElement('select', 'cardoverflowbehavior',
                 get_string('smartmenusmenucardoverflowbehavior', 'theme_boost_union'), $cardoverflowoptions);
         $mform->setDefault('cardoverflowbehaviour', smartmenu::CARDOVERFLOWBEHAVIOUR_NOWRAP);
@@ -199,10 +168,7 @@ class smartmenu_edit_form extends \moodleform {
         $mform->addHelpButton('roles', 'smartmenusbyrole', 'theme_boost_union');
 
         // Add context as select element.
-        $rolecontext = [
-                smartmenu::ANYCONTEXT => get_string('any'),
-                smartmenu::SYSTEMCONTEXT => get_string('coresystem'),
-        ];
+        $rolecontext = smartmenu::get_rolecontext_options();
         $mform->addElement('select', 'rolecontext', get_string('smartmenusrolecontext', 'theme_boost_union'), $rolecontext);
         $mform->setDefault('rolecontext', smartmenu::ANYCONTEXT);
         $mform->setType('rolecontext', PARAM_INT);
@@ -249,10 +215,7 @@ class smartmenu_edit_form extends \moodleform {
         $mform->addHelpButton('cohorts', 'smartmenusbycohort', 'theme_boost_union');
 
         // Add operator as select element.
-        $operatoroptions = [
-                smartmenu::ANY => get_string('any'),
-                smartmenu::ALL => get_string('all'),
-        ];
+        $operatoroptions = smartmenu::get_operator_options();
         $mform->addElement('select', 'operator', get_string('smartmenusoperator', 'theme_boost_union'), $operatoroptions);
         $mform->setDefault('operator', smartmenu::ANY);
         $mform->setType('operator', PARAM_INT);

--- a/classes/form/smartmenu_edit_form.php
+++ b/classes/form/smartmenu_edit_form.php
@@ -182,12 +182,8 @@ class smartmenu_edit_form extends \moodleform {
         }
 
         // Add restriction as select element.
-        $rolecontext = [
-            smartmenu::BYADMIN_ALL => get_string('smartmenusbyadmin_all', 'theme_boost_union'),
-            smartmenu::BYADMIN_ADMINS => get_string('smartmenusbyadmin_admins', 'theme_boost_union'),
-            smartmenu::BYADMIN_NONADMINS => get_string('smartmenusbyadmin_nonadmins', 'theme_boost_union'),
-        ];
-        $mform->addElement('select', 'byadmin', get_string('smartmenusbyadmin', 'theme_boost_union'), $rolecontext);
+        $byadminoptions = smartmenu::get_byadmin_options();
+        $mform->addElement('select', 'byadmin', get_string('smartmenusbyadmin', 'theme_boost_union'), $byadminoptions);
         $mform->setDefault('byadmin', smartmenu::BYADMIN_ALL);
         $mform->setType('byadmin', PARAM_INT);
         $mform->addHelpButton('byadmin', 'smartmenusbyadmin', 'theme_boost_union');

--- a/classes/form/smartmenu_item_edit_form.php
+++ b/classes/form/smartmenu_item_edit_form.php
@@ -98,10 +98,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $mform->addHelpButton('url', 'smartmenusmenuitemurl', 'theme_boost_union');
 
         // Add mode as select element.
-        $modeoptions = [
-                smartmenu_item::MODE_INLINE => get_string('smartmenusmodeinline', 'theme_boost_union'),
-                smartmenu_item::MODE_SUBMENU => get_string('smartmenusmodesubmenu', 'theme_boost_union'),
-        ];
+        $modeoptions = smartmenu_item::get_mode_options();
         $mform->addElement('select', 'mode', get_string('smartmenusmenuitemmode', 'theme_boost_union'), $modeoptions);
         $mform->setDefault('mode', smartmenu_item::MODE_INLINE);
         $mform->setType('mode', PARAM_INT);
@@ -138,14 +135,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $mform->addHelpButton('enrolmentrole', 'smartmenusdynamiccoursesenrolmentrole', 'theme_boost_union');
 
         // Add completion status (for the dynamic courses menu item type) as autocomplete element.
-        $completionstatusoptions = [
-                smartmenu_item::COMPLETION_ENROLLED =>
-                        get_string('smartmenusdynamiccoursescompletionstatusenrolled', 'theme_boost_union'),
-                smartmenu_item::COMPLETION_INPROGRESS =>
-                        get_string('smartmenusdynamiccoursescompletionstatusinprogress', 'theme_boost_union'),
-                smartmenu_item::COMPLETION_COMPLETED =>
-                        get_string('smartmenusdynamiccoursescompletionstatuscompleted', 'theme_boost_union'),
-        ];
+        $completionstatusoptions = smartmenu_item::get_completionstatus_options();
         $completionstatuswidget = $mform->addElement('autocomplete', 'completionstatus',
                 get_string('smartmenusmenuitemtypedynamiccourses', 'theme_boost_union').': '.
                 get_string('smartmenusdynamiccoursescompletionstatus', 'theme_boost_union'), $completionstatusoptions);
@@ -155,14 +145,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $mform->addHelpButton('completionstatus', 'smartmenusdynamiccoursescompletionstatus', 'theme_boost_union');
 
         // Add date range (for the dynamic courses menu item type) as autocomplete element.
-        $daterangeoptions = [
-                smartmenu_item::RANGE_PAST =>
-                        get_string('smartmenusdynamiccoursesdaterangepast', 'theme_boost_union'),
-                smartmenu_item::RANGE_PRESENT =>
-                        get_string('smartmenusdynamiccoursesdaterangepresent', 'theme_boost_union'),
-                smartmenu_item::RANGE_FUTURE =>
-                        get_string('smartmenusdynamiccoursesdaterangefuture', 'theme_boost_union'),
-        ];
+        $daterangeoptions = smartmenu_item::get_daterange_options();
         $daterangewidget = $mform->addElement('autocomplete', 'daterange',
                 get_string('smartmenusmenuitemtypedynamiccourses', 'theme_boost_union').': '.
                 get_string('smartmenusdynamiccoursesdaterange', 'theme_boost_union'), $daterangeoptions);
@@ -196,13 +179,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $PAGE->requires->js_call_amd('theme_boost_union/fontawesome-popover', 'init', ['#id_menuicon', $systemcontextid]);
 
         // Add title presentation and select element.
-        $displayoptions = [
-            smartmenu_item::DISPLAY_SHOWTITLEICON =>
-                    get_string('smartmenusmenuitemdisplayoptionsshowtitleicon', 'theme_boost_union'),
-            smartmenu_item::DISPLAY_HIDETITLE => get_string('smartmenusmenuitemdisplayoptionshidetitle', 'theme_boost_union'),
-            smartmenu_item::DISPLAY_HIDETITLEMOBILE =>
-                    get_string('smartmenusmenuitemdisplayoptionshidetitlemobile', 'theme_boost_union'),
-        ];
+        $displayoptions = smartmenu_item::get_display_options();
         $mform->addElement('select', 'display', get_string('smartmenusmenuitemdisplayoptions', 'theme_boost_union'),
                 $displayoptions);
         $mform->setDefault('display', smartmenu_item::DISPLAY_SHOWTITLEICON);
@@ -215,10 +192,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $mform->addHelpButton('tooltip', 'smartmenusmenuitemtooltip', 'theme_boost_union');
 
         // Add link target as select element.
-        $targetoptions = [
-                smartmenu_item::TARGET_SAME => get_string('smartmenusmenuitemlinktargetsamewindow', 'theme_boost_union'),
-                smartmenu_item::TARGET_NEW => get_string('smartmenusmenuitemlinktargetnewtab', 'theme_boost_union'),
-        ];
+        $targetoptions = smartmenu_item::get_target_options();
         $mform->addElement('select', 'target', get_string('smartmenusmenuitemlinktarget', 'theme_boost_union'),
                 $targetoptions);
         $mform->setDefault('target', smartmenu_item::TARGET_SAME);
@@ -256,24 +230,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $mform->addHelpButton('cssclass', 'smartmenusmenuitemcssclass', 'theme_boost_union');
 
         // Add course list ordering (for the dynamic courses menu item type) as select element.
-        $listsortoptions = [
-                smartmenu_item::LISTSORT_FULLNAME_ASC =>
-                        get_string('smartmenusmenuitemlistsortfullnameasc', 'theme_boost_union'),
-                smartmenu_item::LISTSORT_FULLNAME_DESC =>
-                        get_string('smartmenusmenuitemlistsortfullnamedesc', 'theme_boost_union'),
-                smartmenu_item::LISTSORT_SHORTNAME_ASC =>
-                        get_string('smartmenusmenuitemlistsortshortnameasc', 'theme_boost_union'),
-                smartmenu_item::LISTSORT_SHORTNAME_DESC =>
-                        get_string('smartmenusmenuitemlistsortshortnamedesc', 'theme_boost_union'),
-                smartmenu_item::LISTSORT_COURSEID_ASC =>
-                        get_string('smartmenusmenuitemlistsortcourseidasc', 'theme_boost_union'),
-                smartmenu_item::LISTSORT_COURSEID_DESC =>
-                        get_string('smartmenusmenuitemlistsortcourseiddesc', 'theme_boost_union'),
-                smartmenu_item::LISTSORT_COURSEIDNUMBER_ASC =>
-                        get_string('smartmenusmenuitemlistsortcourseidnumberasc', 'theme_boost_union'),
-                smartmenu_item::LISTSORT_COURSEIDNUMBER_DESC =>
-                        get_string('smartmenusmenuitemlistsortcourseidnumberdesc', 'theme_boost_union'),
-        ];
+        $listsortoptions = smartmenu_item::get_listsort_options();
         $mform->addElement('select', 'listsort',
                 get_string('smartmenusmenuitemtypedynamiccourses', 'theme_boost_union').': '.
                 get_string('smartmenusmenuitemlistsort', 'theme_boost_union'), $listsortoptions);
@@ -283,10 +240,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $mform->addHelpButton('listsort', 'smartmenusmenuitemlistsort', 'theme_boost_union');
 
         // Add course name presentation (for the dynamic courses menu item type) as select element.
-        $displayfieldoptions = [
-                smartmenu_item::FIELD_FULLNAME => get_string('smartmenusmenuitemdisplayfieldcoursefullname', 'theme_boost_union'),
-                smartmenu_item::FIELD_SHORTNAME => get_string('smartmenusmenuitemdisplayfieldcourseshortname', 'theme_boost_union'),
-        ];
+        $displayfieldoptions = smartmenu_item::get_displayfield_options();
         $mform->addElement('select', 'displayfield',
                 get_string('smartmenusmenuitemtypedynamiccourses', 'theme_boost_union').': '.
                 get_string('smartmenusmenuitemdisplayfield', 'theme_boost_union'), $displayfieldoptions);
@@ -318,14 +272,7 @@ class smartmenu_item_edit_form extends \moodleform {
             $mform->addHelpButton('image', 'smartmenusmenuitemcardimage', 'theme_boost_union');
 
             // Add card text position as select element.
-            $textpositionoptions = [
-                    smartmenu_item::POSITION_BELOW =>
-                            get_string('smartmenusmenuitemtextpositionbelowimage', 'theme_boost_union'),
-                    smartmenu_item::POSITION_OVERLAYTOP =>
-                            get_string('smartmenusmenuitemtextpositionoverlaytop', 'theme_boost_union'),
-                    smartmenu_item::POSITION_OVERLAYBOTTOM =>
-                            get_string('smartmenusmenuitemtextpositionoverlaybottom', 'theme_boost_union'),
-            ];
+            $textpositionoptions = smartmenu_item::get_textposition_options();
             $mform->addElement('select', 'textposition',
                     get_string('smartmenusmenuitemtextposition', 'theme_boost_union'), $textpositionoptions);
             $mform->setDefault('textposition', smartmenu_item::POSITION_BELOW);
@@ -368,10 +315,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $mform->addHelpButton('roles', 'smartmenusbyrole', 'theme_boost_union');
 
         // Add context as select element.
-        $rolecontext = [
-                smartmenu::ANYCONTEXT => get_string('any'),
-                smartmenu::SYSTEMCONTEXT => get_string('coresystem'),
-        ];
+        $rolecontext = smartmenu::get_rolecontext_options();
         $mform->addElement('select', 'rolecontext', get_string('smartmenusrolecontext', 'theme_boost_union'), $rolecontext);
         $mform->setDefault('rolecontext', smartmenu::ANYCONTEXT);
         $mform->setType('rolecontext', PARAM_INT);
@@ -418,10 +362,7 @@ class smartmenu_item_edit_form extends \moodleform {
         $mform->addHelpButton('cohorts', 'smartmenusbycohort', 'theme_boost_union');
 
         // Add operator as select element.
-        $operatoroptions = [
-                smartmenu::ANY => get_string('any'),
-                smartmenu::ALL => get_string('all'),
-        ];
+        $operatoroptions = smartmenu::get_operator_options();
         $mform->addElement('select', 'operator', get_string('smartmenusoperator', 'theme_boost_union'), $operatoroptions);
         $mform->setDefault('operator', smartmenu::ANY);
         $mform->setType('operator', PARAM_INT);

--- a/classes/form/smartmenu_item_edit_form.php
+++ b/classes/form/smartmenu_item_edit_form.php
@@ -329,12 +329,8 @@ class smartmenu_item_edit_form extends \moodleform {
         }
 
         // Add restriction as select element.
-        $rolecontext = [
-            smartmenu::BYADMIN_ALL => get_string('smartmenusbyadmin_all', 'theme_boost_union'),
-            smartmenu::BYADMIN_ADMINS => get_string('smartmenusbyadmin_admins', 'theme_boost_union'),
-            smartmenu::BYADMIN_NONADMINS => get_string('smartmenusbyadmin_nonadmins', 'theme_boost_union'),
-        ];
-        $mform->addElement('select', 'byadmin', get_string('smartmenusbyadmin', 'theme_boost_union'), $rolecontext);
+        $byadminoptions = smartmenu::get_byadmin_options();
+        $mform->addElement('select', 'byadmin', get_string('smartmenusbyadmin', 'theme_boost_union'), $byadminoptions);
         $mform->setDefault('byadmin', smartmenu::BYADMIN_ALL);
         $mform->setType('byadmin', PARAM_INT);
         $mform->addHelpButton('byadmin', 'smartmenusbyadmin', 'theme_boost_union');

--- a/classes/smartmenu.php
+++ b/classes/smartmenu.php
@@ -592,11 +592,18 @@ class smartmenu {
                 return false;
             }
 
+            // Add marker class to make clear that this is a Boost Union smart menu.
             $this->menu->classes[] = 'boost-union-smartmenu';
+
+            // Add custom CSS class.
+            $this->menu->classes[] = $this->menu->cssclass;
+
+            // Add CSS classes for card menus.
             $this->menu->classes[] = $this->get_cardform(); // Html class for the card form size, Potrait, Square, landscape.
             $this->menu->classes[] = $this->get_cardsize(); // HTML class for the card Size, tiny, small, medium, large.
             $this->menu->classes[] = $this->get_cardwrap(); // HtML class for the card overflow behaviour.
-            $this->menu->classes[] = $this->menu->cssclass;// Custom class selector for menu.
+
+            // Add CSS classes for more behaviour.
             $this->menu->classes[] = ($this->menu->moremenubehavior == self::MOREMENU_OUTSIDE) ? "force-menu-out" : '';
 
             // Card type menus doesn't supports inline menus.

--- a/classes/smartmenu.php
+++ b/classes/smartmenu.php
@@ -592,6 +592,7 @@ class smartmenu {
                 return false;
             }
 
+            $this->menu->classes[] = 'boost-union-smartmenu';
             $this->menu->classes[] = $this->get_cardform(); // Html class for the card form size, Potrait, Square, landscape.
             $this->menu->classes[] = $this->get_cardsize(); // HTML class for the card Size, tiny, small, medium, large.
             $this->menu->classes[] = $this->get_cardwrap(); // HtML class for the card overflow behaviour.
@@ -883,6 +884,136 @@ class smartmenu {
     public static function get_type($type) {
         $types = self::get_types();
         return $types[$type] ?? false;
+    }
+
+    /**
+     * Return options for the mode setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_mode_options(): array {
+        return [
+            self::MODE_SUBMENU => get_string('smartmenusmodesubmenu', 'theme_boost_union'),
+            self::MODE_INLINE => get_string('smartmenusmodeinline', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return options for the showdescription setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_showdescription_options(): array {
+        return [
+            self::DESC_NEVER => get_string('smartmenusmenushowdescriptionnever', 'theme_boost_union'),
+            self::DESC_ABOVE => get_string('smartmenusmenushowdescriptionabove', 'theme_boost_union'),
+            self::DESC_BELOW => get_string('smartmenusmenushowdescriptionbelow', 'theme_boost_union'),
+            self::DESC_HELP => get_string('smartmenusmenushowdescriptionhelp', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return options for the moremenu setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_moremenu_options(): array {
+        return [
+            self::MOREMENU_DONOTCHANGE => get_string('dontchange', 'theme_boost_union'),
+            self::MOREMENU_INTO => get_string('smartmenusmenumoremenubehaviorforceinto', 'theme_boost_union'),
+            self::MOREMENU_OUTSIDE => get_string('smartmenusmenumoremenubehaviorkeepoutside', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return options for the cardsize setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_cardsize_options(): array {
+        return [
+            self::CARDSIZE_TINY => get_string('smartmenusmenucardsizetiny', 'theme_boost_union').' (50px)',
+            self::CARDSIZE_SMALL => get_string('smartmenusmenucardsizesmall', 'theme_boost_union').' (100px)',
+            self::CARDSIZE_MEDIUM => get_string('smartmenusmenucardsizemedium', 'theme_boost_union').' (150px)',
+            self::CARDSIZE_LARGE => get_string('smartmenusmenucardsizelarge', 'theme_boost_union').' (200px)',
+        ];
+    }
+
+    /**
+     * Return options for the cardform setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_cardform_options(): array {
+        return[
+            self::CARDFORM_SQUARE =>
+                get_string('smartmenusmenucardformsquare', 'theme_boost_union').' (1/1)',
+            self::CARDFORM_PORTRAIT =>
+                get_string('smartmenusmenucardformportrait', 'theme_boost_union').' (2/3)',
+            self::CARDFORM_LANDSCAPE =>
+                get_string('smartmenusmenucardformlandscape', 'theme_boost_union').' (3/2)',
+            self::CARDFORM_FULLWIDTH =>
+                get_string('smartmenusmenucardformfullwidth', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return options for the cardoverflowbehaviour setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_cardoverflowbehaviour_options(): array {
+        return [
+            self::CARDOVERFLOWBEHAVIOUR_NOWRAP =>
+                get_string('smartmenusmenucardoverflowbehaviornowrap', 'theme_boost_union'),
+            self::CARDOVERFLOWBEHAVIOUR_WRAP =>
+                get_string('smartmenusmenucardoverflowbehaviorwrap', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return options for the rolecontext setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_rolecontext_options(): array {
+        return [
+            self::ANYCONTEXT => get_string('any'),
+            self::SYSTEMCONTEXT => get_string('coresystem'),
+        ];
+    }
+
+    /**
+     * Return options for the byadmin setting.
+     *
+     * @return array
+     */
+    public static function get_byadmin_options(): array {
+        return [
+            self::BYADMIN_ALL => get_string('smartmenusbyadmin_all', 'theme_boost_union'),
+            self::BYADMIN_ADMINS => get_string('smartmenusbyadmin_admins', 'theme_boost_union'),
+            self::BYADMIN_NONADMINS => get_string('smartmenusbyadmin_nonadmins', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return options for the operator setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_operator_options(): array {
+        return [
+            self::ANY => get_string('any'),
+            self::ALL => get_string('all'),
+        ];
     }
 
     /**

--- a/classes/smartmenu_item.php
+++ b/classes/smartmenu_item.php
@@ -1043,6 +1043,7 @@ class smartmenu_item {
         }
 
         // Add custom css class.
+        $class[] = 'boost-union-smartitem';
         $class[] = $this->item->cssclass;
         // Add classes for hide items in specific viewport.
         $class[] = $this->item->desktop ? 'd-lg-none' : 'd-lg-inline-flex';
@@ -1337,12 +1338,129 @@ class smartmenu_item {
      */
     public static function get_display_options(?int $option = null) {
         $displayoptions = [
-                self::DISPLAY_SHOWTITLEICON => get_string('smartmenusmenuitemdisplayoptionsshowtitleicon', 'theme_boost_union'),
-                self::DISPLAY_HIDETITLE => get_string('smartmenushidetitle', 'theme_boost_union'),
-                self::DISPLAY_HIDETITLEMOBILE => get_string('smartmenushidetitlemobile', 'theme_boost_union'),
+            self::DISPLAY_SHOWTITLEICON => get_string('smartmenusmenuitemdisplayoptionsshowtitleicon', 'theme_boost_union'),
+            self::DISPLAY_HIDETITLE => get_string('smartmenusmenuitemdisplayoptionshidetitle', 'theme_boost_union'),
+            self::DISPLAY_HIDETITLEMOBILE => get_string('smartmenusmenuitemdisplayoptionshidetitlemobile', 'theme_boost_union'),
         ];
 
         return ($option !== null && isset($displayoptions[$option])) ? $displayoptions[$option] : $displayoptions;
+    }
+
+    /**
+     * Return the options for the target setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_target_options(): array {
+        return [
+            self::TARGET_SAME => get_string('smartmenusmenuitemlinktargetsamewindow', 'theme_boost_union'),
+            self::TARGET_NEW => get_string('smartmenusmenuitemlinktargetnewtab', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return the options for the completionstatus setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_completionstatus_options(): array {
+        return [
+            self::COMPLETION_ENROLLED =>
+                get_string('smartmenusdynamiccoursescompletionstatusenrolled', 'theme_boost_union'),
+            self::COMPLETION_INPROGRESS =>
+                get_string('smartmenusdynamiccoursescompletionstatusinprogress', 'theme_boost_union'),
+            self::COMPLETION_COMPLETED =>
+                get_string('smartmenusdynamiccoursescompletionstatuscompleted', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return the options for the daterange setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_daterange_options(): array {
+        return [
+            self::RANGE_PAST =>
+                get_string('smartmenusdynamiccoursesdaterangepast', 'theme_boost_union'),
+            self::RANGE_PRESENT =>
+                get_string('smartmenusdynamiccoursesdaterangepresent', 'theme_boost_union'),
+            self::RANGE_FUTURE =>
+                get_string('smartmenusdynamiccoursesdaterangefuture', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return the options for the listsort setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_listsort_options(): array {
+        return [
+            self::LISTSORT_FULLNAME_ASC =>
+                get_string('smartmenusmenuitemlistsortfullnameasc', 'theme_boost_union'),
+            self::LISTSORT_FULLNAME_DESC =>
+                get_string('smartmenusmenuitemlistsortfullnamedesc', 'theme_boost_union'),
+            self::LISTSORT_SHORTNAME_ASC =>
+                get_string('smartmenusmenuitemlistsortshortnameasc', 'theme_boost_union'),
+            self::LISTSORT_SHORTNAME_DESC =>
+                get_string('smartmenusmenuitemlistsortshortnamedesc', 'theme_boost_union'),
+            self::LISTSORT_COURSEID_ASC =>
+                get_string('smartmenusmenuitemlistsortcourseidasc', 'theme_boost_union'),
+            self::LISTSORT_COURSEID_DESC =>
+                get_string('smartmenusmenuitemlistsortcourseiddesc', 'theme_boost_union'),
+            self::LISTSORT_COURSEIDNUMBER_ASC =>
+                get_string('smartmenusmenuitemlistsortcourseidnumberasc', 'theme_boost_union'),
+            self::LISTSORT_COURSEIDNUMBER_DESC =>
+                get_string('smartmenusmenuitemlistsortcourseidnumberdesc', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return the options for the displayfield setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_displayfield_options(): array {
+        return [
+            self::FIELD_FULLNAME => get_string('smartmenusmenuitemdisplayfieldcoursefullname', 'theme_boost_union'),
+            self::FIELD_SHORTNAME => get_string('smartmenusmenuitemdisplayfieldcourseshortname', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return the options for the mode setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_mode_options(): array {
+        return [
+            self::MODE_INLINE => get_string('smartmenusmodeinline', 'theme_boost_union'),
+            self::MODE_SUBMENU => get_string('smartmenusmodesubmenu', 'theme_boost_union'),
+        ];
+    }
+
+    /**
+     * Return the options for the testposition setting.
+     *
+     * @return array
+     * @throws \coding_exception
+     */
+    public static function get_textposition_options(): array {
+        return [
+            self::POSITION_BELOW =>
+                get_string('smartmenusmenuitemtextpositionbelowimage', 'theme_boost_union'),
+            self::POSITION_OVERLAYTOP =>
+                get_string('smartmenusmenuitemtextpositionoverlaytop', 'theme_boost_union'),
+            self::POSITION_OVERLAYBOTTOM =>
+                get_string('smartmenusmenuitemtextpositionoverlaybottom', 'theme_boost_union'),
+        ];
     }
 
     /**

--- a/classes/smartmenu_item.php
+++ b/classes/smartmenu_item.php
@@ -1042,9 +1042,12 @@ class smartmenu_item {
             return false;
         }
 
-        // Add custom css class.
-        $class[] = 'boost-union-smartitem';
+        // Add marker class to make clear that this is a Boost Union smart menu item.
+        $class[] = 'boost-union-smartmenuitem';
+
+        // Add custom CSS class.
         $class[] = $this->item->cssclass;
+
         // Add classes for hide items in specific viewport.
         $class[] = $this->item->desktop ? 'd-lg-none' : 'd-lg-inline-flex';
         $class[] = $this->item->tablet ? 'd-md-none' : 'd-md-inline-flex';
@@ -1052,11 +1055,14 @@ class smartmenu_item {
 
         // Add classes for item title placement on card.
         $class[] = $this->get_textposition_class();
-        // Menu item class.
+
+        // Add menu item class.
         $types = [self::TYPESTATIC => 'static', self::TYPEDYNAMIC => 'dynamic', self::TYPEHEADING => 'heading'];
         $class[] = 'menu-item-'.($types[$this->item->type] ?? '');
+
         // Add classes to item data.
         $this->item->classes = $class;
+
         // Load the location of menu, used to collect menus for locations in menu inline mode.
         $this->item->location = $this->menu->location;
 
@@ -1330,20 +1336,17 @@ class smartmenu_item {
     }
 
     /**
-     * Returns the display options for the menu items.
+     * Return the options for the display setting.
      *
-     * @param int|null $option The display option to retrieve. If null, returns all display options.
-     * @return array|string The array of display options if $option is null, or the display option string if $option is set.
-     * @throws coding_exception if $option is set but invalid.
+     * @return array
+     * @throws \coding_exception
      */
-    public static function get_display_options(?int $option = null) {
-        $displayoptions = [
+    public static function get_display_options() {
+        return [
             self::DISPLAY_SHOWTITLEICON => get_string('smartmenusmenuitemdisplayoptionsshowtitleicon', 'theme_boost_union'),
             self::DISPLAY_HIDETITLE => get_string('smartmenusmenuitemdisplayoptionshidetitle', 'theme_boost_union'),
             self::DISPLAY_HIDETITLEMOBILE => get_string('smartmenusmenuitemdisplayoptionshidetitlemobile', 'theme_boost_union'),
         ];
-
-        return ($option !== null && isset($displayoptions[$option])) ? $displayoptions[$option] : $displayoptions;
     }
 
     /**

--- a/tests/behat/behat_theme_boost_union.php
+++ b/tests/behat/behat_theme_boost_union.php
@@ -1,0 +1,342 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Standard behat step data providers for theme_boost_union
+ *
+ * @package   theme_boost_union
+ * @copyright 2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
+ * @author    Mark Johnson <mark.johnson@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_theme_boost_union extends behat_base {
+    /**
+     * Convert page names to URLs for steps like 'When I am on the "[page name]" page'.
+     *
+     * Tabbed settings pages support an optional "> Tabname" suffix, otherwise they will load the default tab.
+     *
+     * Recognised page names are:
+     * | Settings      | Settings overview             |
+     * | Look          | "Look" settings page          |
+     * | Feel          | "Feel" settings page          |
+     * | Content       | "Content" settings page       |
+     * | Functionality | "Functionality" settings page |
+     * | Flavours      | Flavours listing page         |
+     * | Smart menus   | Smart menus listing page      |
+     *
+     * @param string $page name of the page, with the component name removed e.g. 'Admin notification'.
+     * @return moodle_url the corresponding URL.
+     * @throws Exception with a meaningful error message if the specified page cannot be found.
+     */
+    protected function resolve_page_url(string $page): moodle_url {
+        $parts = explode('>', strtolower($page));
+        $section = trim($parts[0]);
+        if (count($parts) < 2) {
+            return match ($section) {
+                'settings' => new moodle_url('/theme/boost_union/settings_overview.php'),
+                'look' => new moodle_url('/admin/settings.php?section=theme_boost_union_look'),
+                'feel' => new moodle_url('/admin/settings.php?section=theme_boost_union_feel'),
+                'content' => new moodle_url('/admin/settings.php?section=theme_boost_union_content'),
+                'functionality' => new moodle_url('/admin/settings.php?section=theme_boost_union_functionality'),
+                'flavours' => new moodle_url('/theme/boost_union/flavours/overview.php'),
+                'smart menus' => new moodle_url('/theme/boost_union/smartmenus/menus.php'),
+                default => throw new Exception('Unrecognised theme_boost_union page "' . $page . '."')
+            };
+        }
+        $suffix = trim($parts[1]);
+        $tabs = [];
+        switch ($section) {
+            case 'look':
+                $tabs = [
+                    'general',
+                    'scss',
+                    'page',
+                    'sitebranding',
+                    'activitybranding',
+                    'loginpage',
+                    'dashboard',
+                    'blocks',
+                    'course',
+                    'emailbranding',
+                    'resources',
+                    'h5p',
+                    'mobile',
+                ];
+                $suffix = match ($suffix) {
+                    'general', 'general settings' => 'general',
+                    'my courses', 'dashboard / my courses' => 'dashboard',
+                    default => str_replace([' ', '-'], ['', ''], $suffix)
+                };
+                break;
+
+            case 'feel':
+                $tabs = [
+                    'navigation',
+                    'blocks',
+                    'pagelayouts',
+                    'links',
+                    'misc',
+                ];
+                $suffix = match ($suffix) {
+                    'miscellaneous' => 'misc',
+                    default => str_replace([' ', '-'], ['', ''], $suffix)
+                };
+                break;
+
+            case 'content':
+                $tabs = [
+                    'footer',
+                    'staticpages',
+                    'infobanner',
+                    'tiles',
+                    'slider',
+                ];
+                $suffix = match ($suffix) {
+                    'advertisement tiles' => 'tiles',
+                    default => str_replace([' ', '-'], ['', ''], $suffix)
+                };
+                $section = match ($suffix) {
+                    'infobanner' => 'infobanners',
+                    'tiles', 'slider' => '',
+                    default => $section,
+                };
+                break;
+
+            case 'functionality':
+                $tabs = [
+                    'courses',
+                    'administration',
+                ];
+                break;
+
+            default:
+                throw new Exception('Unrecognised theme_boost_union page "' . $page . '."');
+        }
+
+        if (!in_array($suffix, $tabs)) {
+            throw new Exception('Unrecognised theme_boost_union page "' . $page . '."');
+        }
+        return new moodle_url('/admin/settings.php?section=theme_boost_union_' . $section . '_' . $suffix);
+    }
+
+    /**
+     * Convert page names to URLs for steps like 'When I am on the "[identifier]" "[page type]" page'.
+     *
+     * Recognised page names are:
+     * | pagetype            | name meaning                | description                                               |
+     * | Flavour > Preview   | Flavour title               | The flavour preview page (flavours/preview.php)           |
+     * | Flavour > Edit      | Flavour title               | The flavour edit page (flavours/edit.php)                 |
+     * | Smart menu > Edit   | Menu title                  | The smart menu edit page (smartmenus/edit.php)            |
+     * | Smart menu > Items  | Menu title                  | The smart menu items page (smartmenus/items.php)          |
+     * | Smart menu item     | Menu title > Item title     | The smart menu item edit page (smartmenus/edit_items.php) |
+     * | Course completion   | Course identifier           | The course completion form                                |
+     *
+     * @param string $type identifies which type of page this is, e.g. 'Smart menu item'.
+     * @param string $identifier identifies the particular page, e.g. 'Menu 1 > Item 1'.
+     * @return moodle_url the corresponding URL.
+     * @throws Exception with a meaningful error message if the specified page cannot be found.
+     */
+    protected function resolve_page_instance_url(string $type, string $identifier): moodle_url {
+        $parts = explode('>', strtolower($type));
+        $pagetype = trim($parts[0]);
+
+        switch ($pagetype) {
+            case 'flavour':
+                $page = trim($parts[1]);
+                if (!in_array($page, ['preview', 'edit'])) {
+                    throw new Exception('Unrecognised theme_boost_union page type "' . $type . '."');
+                }
+                return new moodle_url(
+                    '/theme/boost_union/flavours/' . $page . '.php',
+                    [
+                        'id' => $this->get_flavour_id_by_title($identifier),
+                        'sesskey' => $this->get_sesskey(),
+                    ]
+                );
+
+            case 'smart menu':
+                $page = trim($parts[1]);
+                if (!in_array($page, ['edit', 'items'])) {
+                    throw new Exception('Unrecognised theme_boost_union page type "' . $type . '."');
+                }
+                $idparam = $page == 'edit' ? 'id' : 'menu';
+                return new moodle_url(
+                    '/theme/boost_union/smartmenus/' . $page . '.php',
+                    [
+                        $idparam => $this->get_smartmenu_id_by_title($identifier),
+                        'sesskey' => $this->get_sesskey(),
+                    ]
+                );
+
+            case 'smart menu item':
+                $idparts = explode('>', $identifier);
+                $menutitle = trim($idparts[0]);
+                $itemtitle = trim($idparts[1]);
+                $menuid = $this->get_smartmenu_id_by_title($menutitle);
+                return new moodle_url(
+                    '/theme/boost_union/smartmenus/edit_items.php',
+                    [
+                        'id' => $this->get_smartmenu_item_id_by_title($menuid, $itemtitle),
+                        'sesskey' => $this->get_sesskey(),
+                    ]
+                );
+
+            case 'course completion':
+                return new moodle_url(
+                    '/course/completion.php',
+                    [
+                        'id' => $this->get_course_id($identifier),
+                    ]
+                );
+
+            default:
+                throw new Exception('Unrecognised quiz page type "' . $type . '."');
+        }
+    }
+
+    /**
+     * Return named selectors for use with steps like `the following "locator" "identifier" should exist`.
+     *
+     * Supported selectors:
+     * - "Smart menu" - The menu button for a smart menu. Locator = Smart menu title.
+     * - "Smart menu item" - The menu button for a smart menu item. Locator = Item title.
+     * - "Main menu smart menu" - The submenu for a smart menu within the main menu. Locator = Smart menu title.
+     * - "Main menu smart menu item" - A smart menu item within the main menu. Locator = Item title.
+     * - "Menu bar smart menu" - The submenu for a smart menu within top menu bar. Locator = Smart menu title.
+     * - "Menu bar smart menu item" - A smart menu item within top menu bar. Locator = Item title.
+     * - "User menu smart menu" - The submenu for a smart menu within top user menu. Locator = Smart menu title.
+     * - "User menu smart menu item" - A smart menu item within a user menu submenu. Locator = Item title.
+     * - "Bottom bar smart menu" - The submenu for a smart menu within bottom menu bar. Locator = Smart menu title.
+     * - "Bottom bar smart menu item" - A smart menu item within bottom menu bar. Locator = Item title.
+     *
+     * @return array|behat_component_named_selector[]
+     */
+    public static function get_exact_named_selectors(): array {
+        return [
+            new behat_component_named_selector(
+                'Smart menu',
+                [".//a[@role = 'menuitem'][contains(text(), %locator%)]"],
+            ),
+            new behat_component_named_selector(
+                'Smart menu item',
+                [".//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]"],
+            ),
+            new behat_component_named_selector(
+                'Main menu smart menu',
+                [
+                    ".//div[contains(@class, 'primary-navigation')]//li[contains(@class, 'boost-union-smartmenu')]" .
+                        "/a[contains(text(), %locator%)]/../div[@role = 'menu']",
+                ],
+            ),
+            new behat_component_named_selector(
+                'Main menu smart menu item',
+                [
+                    ".//div[contains(@class, 'primary-navigation')]" .
+                        "//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]",
+                ],
+            ),
+            new behat_component_named_selector(
+                'Menu bar smart menu',
+                [
+                    ".//nav[contains(@class, 'boost-union-menubar')]//li[contains(@class, 'boost-union-smartmenu')]" .
+                        "/a[contains(text(), %locator%)]/../div[@role = 'menu']",
+                ],
+            ),
+            new behat_component_named_selector(
+                'Menu bar smart menu item',
+                [
+                    ".//nav[contains(@class, 'boost-union-menubar')]" .
+                        "//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]",
+                ],
+            ),
+            new behat_component_named_selector(
+                'User menu smart menu',
+                [
+                    ".//div[@id = 'usermenu-carousel']//div[contains(@class, 'carousel-item')][@aria-label = %locator%]",
+                ],
+            ),
+            new behat_component_named_selector(
+                'User menu smart menu item',
+                [
+                    ".//div[@id = 'usermenu-carousel']//div[contains(@class, 'carousel-item')]" .
+                        "//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]",
+                ],
+            ),
+            new behat_component_named_selector(
+                'Bottom bar smart menu',
+                [
+                    ".//nav[contains(@class, 'boost-union-bottom-menu')]//li[contains(@class, 'boost-union-smartmenu')]" .
+                        "/a[contains(text(), %locator%)]/../div[@role = 'menu']"],
+            ),
+            new behat_component_named_selector(
+                'Bottom bar smart menu item',
+                [
+                    ".//nav[contains(@class, 'boost-union-bottom-menu')]" .
+                        "//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]",
+                ],
+            ),
+        ];
+    }
+
+    /**
+     * Given the title of a Flavour, return the ID.
+     *
+     * @param string $title
+     * @return int
+     * @throws dml_exception
+     */
+    protected function get_flavour_id_by_title(string $title): int {
+        global $DB;
+        $id = $DB->get_field('theme_boost_union_flavours', 'id', ['title' => $title]);
+        if (!$id) {
+            throw new Exception('Cannot find Boost Union flavour with title "' . $title . '"');
+        }
+        return $id;
+    }
+
+    /**
+     * Given the title of a Smart menu, return the ID.
+     *
+     * @param string $title
+     * @return int
+     * @throws dml_exception
+     */
+    protected function get_smartmenu_id_by_title(string $title): int {
+        global $DB;
+        $id = $DB->get_field('theme_boost_union_menus', 'id', ['title' => $title]);
+        if (!$id) {
+            throw new Exception('Cannot find Boost Union smart menu with title "' . $title . '"');
+        }
+        return $id;
+    }
+
+    /**
+     * Given the menu ID and title of a Smart menu item, return the item ID.
+     *
+     * @param int $menuid
+     * @param string $title
+     * @return int
+     * @throws dml_exception
+     */
+    protected function get_smartmenu_item_id_by_title(int $menuid, string $title): int {
+        global $DB;
+        $id = $DB->get_field('theme_boost_union_menuitems', 'id', ['menu' => $menuid, 'title' => $title]);
+        if (!$id) {
+            throw new Exception('Cannot find Boost Union smart menu item with title "' . $title . '"');
+        }
+        return $id;
+    }
+}

--- a/tests/behat/behat_theme_boost_union.php
+++ b/tests/behat/behat_theme_boost_union.php
@@ -15,12 +15,12 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Standard behat step data providers for theme_boost_union
+ * Theme Boost Union - Standard behat step data providers.
  *
- * @package   theme_boost_union
- * @copyright 2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
- * @author    Mark Johnson <mark.johnson@catalyst-eu.net>
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    theme_boost_union
+ * @copyright  2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
+ * @author     Mark Johnson <mark.johnson@catalyst-eu.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_theme_boost_union extends behat_base {
     /**
@@ -203,7 +203,7 @@ class behat_theme_boost_union extends behat_base {
                 );
 
             default:
-                throw new Exception('Unrecognised quiz page type "' . $type . '."');
+                throw new Exception('Unrecognised theme_boost_union page type "' . $type . '."');
         }
     }
 
@@ -232,7 +232,7 @@ class behat_theme_boost_union extends behat_base {
             ),
             new behat_component_named_selector(
                 'Smart menu item',
-                [".//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]"],
+                [".//a[contains(@class, 'boost-union-smartmenuitem')][contains(text(), %locator%)]"],
             ),
             new behat_component_named_selector(
                 'Main menu smart menu',
@@ -245,7 +245,7 @@ class behat_theme_boost_union extends behat_base {
                 'Main menu smart menu item',
                 [
                     ".//div[contains(@class, 'primary-navigation')]" .
-                        "//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]",
+                        "//a[contains(@class, 'boost-union-smartmenuitem')][contains(text(), %locator%)]",
                 ],
             ),
             new behat_component_named_selector(
@@ -259,7 +259,7 @@ class behat_theme_boost_union extends behat_base {
                 'Menu bar smart menu item',
                 [
                     ".//nav[contains(@class, 'boost-union-menubar')]" .
-                        "//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]",
+                        "//a[contains(@class, 'boost-union-smartmenuitem')][contains(text(), %locator%)]",
                 ],
             ),
             new behat_component_named_selector(
@@ -272,7 +272,7 @@ class behat_theme_boost_union extends behat_base {
                 'User menu smart menu item',
                 [
                     ".//div[@id = 'usermenu-carousel']//div[contains(@class, 'carousel-item')]" .
-                        "//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]",
+                        "//a[contains(@class, 'boost-union-smartmenuitem')][contains(text(), %locator%)]",
                 ],
             ),
             new behat_component_named_selector(
@@ -285,7 +285,7 @@ class behat_theme_boost_union extends behat_base {
                 'Bottom bar smart menu item',
                 [
                     ".//nav[contains(@class, 'boost-union-bottom-menu')]" .
-                        "//a[contains(@class, 'boost-union-smartitem')][contains(text(), %locator%)]",
+                        "//a[contains(@class, 'boost-union-smartmenuitem')][contains(text(), %locator%)]",
                 ],
             ),
         ];

--- a/tests/behat/theme_boost_union_feelsettings_blocks.feature
+++ b/tests/behat/theme_boost_union_feelsettings_blocks.feature
@@ -20,10 +20,8 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | teacher1 | C1     | editingteacher |
       | student1 | C1     | student        |
 
-  @javascript
   Scenario Outline: Setting: Enable additional block regions (on a course page and the frontpage where all regions are offered)
-    When I log in as "admin"
-    And I am on site homepage
+    When I am on the "Acceptance test site" "Course" page logged in as "admin"
     And I turn editing mode on
     Then "#theme-block-region-<region>" "css_element" should not exist
     And the following config values are set as admin:
@@ -31,8 +29,7 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | blockregionsforfrontpage | <settingvalue> | theme_boost_union |
     And I reload the page
     Then "#theme-block-region-<region>" "css_element" <should> exist
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
+    And I am on "Course 1" course homepage with editing mode on
     Then "#theme-block-region-<region>" "css_element" should not exist
     And the following config values are set as admin:
       | config                | value          | plugin            |
@@ -57,10 +54,8 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | outside-top      | outside-bottom                                                                                                                                                                  | should not |
       | outside-top      | footer-left,footer-right                                                                                                                                                        | should not |
 
-  @javascript
   Scenario Outline: Setting: Enable additional block regions (on the Dashboard page where all but the content-* regions are offered)
-    When I log in as "admin"
-    And I follow "Dashboard"
+    When I am on the "Homepage" page logged in as "admin"
     And I turn editing mode on
     Then "#theme-block-region-<region>" "css_element" should not exist
     And the following config values are set as admin:
@@ -86,7 +81,6 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | outside-top      | outside-bottom                                                                                                                                      | should not |
       | outside-top      | footer-left,footer-right                                                                                                                            | should not |
 
-  @javascript
   Scenario Outline: Setting: Enable additional block regions (on the admin overview page where not all regions are offered)
     When I log in as "admin"
     And I follow "Site administration"
@@ -115,30 +109,18 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | outside-top      | outside-bottom                                                                                                    | should not |
       | outside-top      | footer-left,footer-right                                                                                          | should not |
 
-  @javascript
   Scenario Outline: Setting: Use additional block regions (on a course page and the frontpage where all regions are offered)
     Given the following config values are set as admin:
       | config                   | value          | plugin            |
       | blockregionsforfrontpage | <settingvalue> | theme_boost_union |
       | blockregionsforcourse    | <settingvalue> | theme_boost_union |
-    When I log in as "admin"
-    And I am on site homepage
-    And I turn editing mode on
-    And I should see "Add a block" in the "#theme-block-region-<region>" "css_element"
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Online users" in the ".modal-body" "css_element"
-    And I click on "Online users" "link" in the ".modal-body" "css_element"
-    And I am on site homepage
-    And I turn editing mode off
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference            | pagetypepattern | defaultregion |
+      | online_users   | Course       | Acceptance test site | site-index      | <region>      |
+      | calendar_month | Course       | C1                   | course-view-*   | <region>      |
+    When I am on the "Acceptance test site" "Course" page logged in as "admin"
     Then I should see "Online users" in the "#theme-block-region-<region>" "css_element"
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
-    And I should see "Add a block" in the "#theme-block-region-<region>" "css_element"
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Calendar" in the ".modal-body" "css_element"
-    And I click on "Calendar" "link" in the ".modal-body" "css_element"
-    And I am on "Course 1" course homepage
-    And I turn editing mode off
+    When I am on "Course 1" course homepage
     Then I should see "Calendar" in the "#theme-block-region-<region>" "css_element"
 
     Examples:
@@ -154,20 +136,14 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | content-lower  | content-lower  |
       | header         | header         |
 
-  @javascript
   Scenario Outline: Setting: Use additional block regions (on the Dashboard page where all but the content-* regions are offered)
     Given the following config values are set as admin:
       | config                     | value          | plugin            |
       | blockregionsformydashboard | <settingvalue> | theme_boost_union |
-    When I log in as "admin"
-    And I follow "Dashboard"
-    And I turn editing mode on
-    And I should see "Add a block" in the "#theme-block-region-<region>" "css_element"
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Online users" in the ".modal-body" "css_element"
-    And I click on "Online users" "link" in the ".modal-body" "css_element"
-    And I follow "Dashboard"
-    And I turn editing mode off
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference | pagetypepattern | defaultregion |
+      | online_users   | System       | 1         | my-index        | <region>      |
+    When I am on the "Homepage" page logged in as "admin"
     Then I should see "Online users" in the "#theme-block-region-<region>" "css_element"
 
     Examples:
@@ -181,20 +157,15 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | footer-center  | footer-center  |
       | header         | header         |
 
-  @javascript
   Scenario Outline: Setting: Use additional block regions (on the admin overview page where not all regions are offered)
     Given the following config values are set as admin:
       | config               | value          | plugin            |
       | blockregionsforadmin | <settingvalue> | theme_boost_union |
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference | pagetypepattern | defaultregion |
+      | online_users   | System       | 1         | admin-search    | <region>      |
     When I log in as "admin"
     And I follow "Site administration"
-    And I turn editing mode on
-    And I should see "Add a block" in the "#theme-block-region-<region>" "css_element"
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Online users" in the ".modal-body" "css_element"
-    And I click on "Online users" "link" in the ".modal-body" "css_element"
-    And I follow "Site administration"
-    And I turn editing mode off
     Then I should see "Online users" in the "#theme-block-region-<region>" "css_element"
 
     Examples:
@@ -207,8 +178,7 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
 
   @javascript
   Scenario Outline: Setting: Enable and use the off-canvas block regions (Compared to the other regions, these regions are slightly different and thus they are not covered in the Scenario outlines above).
-    When I log in as "admin"
-    And I am on site homepage
+    When I am on the "Acceptance test site" "Course" page logged in as "admin"
     Then "#theme_boost_union-offcanvas-btn" "css_element" should not exist
     And "#theme_boost_union-drawers-offcanvas" "css_element" should not exist
     And "#theme-block-region-offcanvas-editing" "css_element" should not be visible
@@ -239,9 +209,9 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     And "#theme-block-region-<region>" "css_element" should exist
     And "#theme-block-region-<region>" "css_element" should be visible
     And I should see "Add a block" in the "#theme-block-region-<region>" "css_element"
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Online users" in the ".modal-body" "css_element"
-    And I click on "Online users" "link" in the ".modal-body" "css_element"
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference            | pagetypepattern | defaultregion |
+      | online_users   | Course       | Acceptance test site | site-index      | <region>      |
     And I am on site homepage
     And I turn editing mode off
     Then "#theme_boost_union-offcanvas-btn" "css_element" should exist
@@ -263,20 +233,14 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | offcanvas-center | offcanvas-center                                                                                                                             |
       | offcanvas-left   | outside-top,outside-left,outside-right,outside-bottom,footer-left,footer-right,footer-center,offcanvas-left,offcanvas-center,offcanvas-right |
 
-  @javascript
   Scenario Outline: Setting: Set capabilities to control the editability of additional block regions (for all regions except offcanvas regions)
     Given the following config values are set as admin:
       | config                | value    | plugin            |
       | blockregionsforcourse | <region> | theme_boost_union |
-    When I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Online users" in the ".modal-body" "css_element"
-    And I click on "Online users" "link" in the ".modal-body" "css_element"
-    And I log out
-    And I log in as "teacher1"
-    And I am on "Course 1" course homepage
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference | pagetypepattern | defaultregion |
+      | online_users   | Course       | C1        | course-view-*   | <region>      |
+    When I am on the "Course 1" "Course" page logged in as "teacher1"
     And I turn editing mode on
     Then "#theme-block-region-<region>" "css_element" should exist
     And I should see "Add a block" in the "#theme-block-region-<region>" "css_element"
@@ -305,16 +269,10 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     Given the following config values are set as admin:
       | config                | value    | plugin            |
       | blockregionsforcourse | <region> | theme_boost_union |
-    When I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
-    And I click on "#theme_boost_union-offcanvas-btn" "css_element"
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Online users" in the ".modal-body" "css_element"
-    And I click on "Online users" "link" in the ".modal-body" "css_element"
-    And I log out
-    And I log in as "teacher1"
-    And I am on "Course 1" course homepage
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference | pagetypepattern | defaultregion |
+      | online_users   | Course       | C1        | course-view-*   | <region>      |
+    When I am on the "Course 1" "Course" page logged in as "teacher1"
     And I turn editing mode on
     And I click on "#theme_boost_union-offcanvas-btn" "css_element"
     Then "#theme-block-region-<region>" "css_element" should exist
@@ -333,20 +291,14 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | offcanvas-center | editregionoffcanvascenter |
       | offcanvas-right  | editregionoffcanvasright  |
 
-  @javascript
   Scenario Outline: Setting: Set capabilities to control the visibility of additional block regions (for all regions except offcanvas regions)
     Given the following config values are set as admin:
       | config                | value    | plugin            |
       | blockregionsforcourse | <region> | theme_boost_union |
-    When I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Online users" in the ".modal-body" "css_element"
-    And I click on "Online users" "link" in the ".modal-body" "css_element"
-    And I log out
-    And I log in as "teacher1"
-    And I am on "Course 1" course homepage
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference | pagetypepattern | defaultregion |
+      | online_users   | Course       | C1        | course-view-*   | <region>      |
+    When I am on the "Course 1" "Course" page logged in as "teacher1"
     Then "#theme-block-region-<region>" "css_element" should exist
     And I should see "Online users" in the "#theme-block-region-<region>" "css_element"
     And the following "permission overrides" exist:
@@ -374,16 +326,10 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     Given the following config values are set as admin:
       | config                | value    | plugin            |
       | blockregionsforcourse | <region> | theme_boost_union |
-    When I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
-    And I click on "#theme_boost_union-offcanvas-btn" "css_element"
-    And I click on "Add a block" "link" in the "#theme-block-region-<region>" "css_element"
-    And I should see "Online users" in the ".modal-body" "css_element"
-    And I click on "Online users" "link" in the ".modal-body" "css_element"
-    And I log out
-    And I log in as "teacher1"
-    And I am on "Course 1" course homepage
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference | pagetypepattern | defaultregion |
+      | online_users   | Course       | C1        | course-view-*   | <region>      |
+    When I am on the "Course 1" "Course" page logged in as "teacher1"
     And I click on "#theme_boost_union-offcanvas-btn" "css_element"
     Then "#theme-block-region-<region>" "css_element" should exist
     And I should see "Online users" in the "#theme-block-region-<region>" "css_element"
@@ -408,8 +354,7 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | blockregionsforcourse | <region>       | theme_boost_union |
       | <config>              | <settingvalue> | theme_boost_union |
     And the theme cache is purged and the theme is reloaded
-    When I log in as "admin"
-    And I am on "Course 1" course homepage
+    When I am on the "Course 1" "Course" page logged in as "admin"
     And I turn editing mode on
     And I should see "Add a block" in the "#theme-block-region-<region>" "css_element"
     Then DOM element "#theme-block-region-<region>" should have computed style "width" "<settingvalue>"
@@ -426,8 +371,7 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | config                | value          | plugin            |
       | blockregionsforcourse | <region>       | theme_boost_union |
       | <config>              | <settingvalue> | theme_boost_union |
-    When I log in as "admin"
-    And I am on "Course 1" course homepage
+    When I am on the "Course 1" "Course" page logged in as "admin"
     And I turn editing mode on
     And I should see "Add a block" in the "#theme-block-region-<region>" "css_element"
     Then the "class" attribute of "#theme-block-region-<region>" "css_element" should contain "theme-block-region-outside-<settingvalue>"
@@ -446,8 +390,7 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | config                | value          | plugin            |
       | blockregionsforcourse | footer-left    | theme_boost_union |
       | <config>              | <settingvalue> | theme_boost_union |
-    When I log in as "admin"
-    And I am on "Course 1" course homepage
+    When I am on the "Course 1" "Course" page logged in as "admin"
     And I turn editing mode on
     And I should see "Add a block" in the "#theme-block-region-footer-left" "css_element"
     Then the "class" attribute of "#theme-block-region-footer" "css_element" should contain "theme-block-region-footer-<settingvalue>"
@@ -462,8 +405,7 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     Given the following config values are set as admin:
       | config                  | value          | plugin            |
       | outsideregionsplacement | <settingvalue> | theme_boost_union |
-    When I log in as "admin"
-    And I am on site homepage
+    When I am on the "Acceptance test site" "Course" page logged in as "admin"
     And I turn editing mode on
     Then the "class" attribute of ".main-inner-wrapper" "css_element" should contain "<classcontain>"
     And the "class" attribute of ".main-inner-wrapper" "css_element" should not contain "<classnotcontain>"
@@ -473,13 +415,11 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | nextmaincontent | main-inner-outside-nextmaincontent | main-inner-outside-nearwindowedges |
       | nearwindowedges | main-inner-outside-nearwindowedges | main-inner-outside-nextmaincontent |
 
-  @javascript
   Scenario: Verify orders of all block regions
     Given the following config values are set as admin:
       | config                   | value                                                                                                                                                                           | plugin            |
       | blockregionsforfrontpage | outside-top,outside-left,outside-right,outside-bottom,footer-left,footer-right,footer-center,offcanvas-left,offcanvas-right,offcanvas-center,content-upper,content-lower,header | theme_boost_union |
-    When I log in as "admin"
-    And I am on site homepage
+    When I am on the "Acceptance test site" "Course" page logged in as "admin"
     And I turn editing mode on
     Then "#theme-block-region-offcanvas-editing" "css_element" should appear before "#theme-block-region-outside-top" "css_element"
     And "#theme-block-region-outside-top" "css_element" should appear before "#theme-block-region-header" "css_element"
@@ -505,18 +445,10 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     Given the following config values are set as admin:
       | config                                       | value     | plugin            |
       | showsitehomerighthandblockdraweronfirstlogin | <setting> | theme_boost_union |
-    And I log in as "admin"
-    And I am on site homepage
-    And I turn editing mode on
-    And I add the "Text" block
-    And I configure the "(new text block)" block
-    And I set the following fields to these values:
-      | Text block title | Text on all pages            |
-      | Content          | This is visible on all pages |
-    And I press "Save changes"
-    And I log out
-    When I log in as "student1"
-    And I am on site homepage
+    And the following "blocks" exist:
+      | blockname    | contextlevel | reference            | pagetypepattern | defaultregion |
+      | online_users | Course       | Acceptance test site | site-index      | side-pre      |
+    When I am on the "Acceptance test site" "Course" page logged in as "student1"
     Then the "class" attribute of ".drawer-right" "css_element" <shouldcontain> "show"
 
     Examples:
@@ -528,16 +460,9 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     Given the following config values are set as admin:
       | config                                  | value     | plugin            |
       | showsitehomerighthandblockdraweronvisit | <setting> | theme_boost_union |
-    And I log in as "admin"
-    And I am on site homepage
-    And I turn editing mode on
-    And I add the "Text" block
-    And I configure the "(new text block)" block
-    And I set the following fields to these values:
-      | Text block title | Text on all pages            |
-      | Content          | This is visible on all pages |
-    And I press "Save changes"
-    And I log out
+    And the following "blocks" exist:
+      | blockname    | contextlevel | reference            | pagetypepattern | defaultregion |
+      | online_users | Course       | Acceptance test site | site-index      | side-pre      |
     When I am on site homepage
     Then the "class" attribute of ".drawer-right" "css_element" <shouldcontain> "show"
 
@@ -550,16 +475,9 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     Given the following config values are set as admin:
       | config                                       | value     | plugin            |
       | showsitehomerighthandblockdraweronguestlogin | <setting> | theme_boost_union |
-    And I log in as "admin"
-    And I am on site homepage
-    And I turn editing mode on
-    And I add the "Text" block
-    And I configure the "(new text block)" block
-    And I set the following fields to these values:
-      | Text block title | Text on all pages            |
-      | Content          | This is visible on all pages |
-    And I press "Save changes"
-    And I log out
+    And the following "blocks" exist:
+      | blockname    | contextlevel | reference            | pagetypepattern | defaultregion |
+      | online_users | Course       | Acceptance test site | site-index      | side-pre      |
     When I log in as "guest"
     And I am on site homepage
     Then the "class" attribute of ".drawer-right" "css_element" <shouldcontain> "show"

--- a/tests/behat/theme_boost_union_smartmenusettings_menuitems_dynamiccourses.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menuitems_dynamiccourses.feature
@@ -37,23 +37,19 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
       | student1 | C2     | student        |
       | student1 | C3     | student        |
       | student1 | C4     | student        |
-    And I log in as "admin"
-    And I create smart menu with the following fields to these values:
-      | Title            | List menu                |
-      | Menu location(s) | Main, Menu, User, Bottom |
-      | CSS class        | dynamiccoursetest        |
-    And I set "List menu" smart menu items with the following fields to these values:
-      | Title          | Dynamic courses |
-      | Menu item type | Dynamic courses |
+    And the following "theme_boost_union > smart menu" exists:
+      | title    | List menu                                        |
+      | location | Main navigation, Menu bar, User menu, Bottom bar |
+      | cssclass | dynamiccoursetest                                |
 
   @javascript
   Scenario: Smartmenus: Menu items: Dynamic courses - Check the smart menu item settings fields which are shown conditionally for dynamic courses
-    When I log in as "admin"
-    And I navigate to smart menus
-    And I should see "List menu" in the "smartmenus" "table"
-    And I click on ".action-list-items" "css_element" in the "List menu" "table_row"
-    Then I should see "Dynamic courses"
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu     | List menu       |
+      | title    | Dynamic courses |
+      | itemtype | Dynamic courses |
+    And I am logged in as "admin"
+    When I am on the "List menu > Dynamic courses" "theme_boost_union > smart menu item" page
     And I should see "Dynamic courses: Course category"
     And I should see "Dynamic courses: Enrolment role"
     And I should see "Dynamic courses: Completion status"
@@ -61,34 +57,44 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
 
   @javascript
   Scenario: Smartmenus: Menu items: Dynamic courses - Compose the dynamic course list based on all existing courses (without any condition)
-    When I log in as "student1"
-    Then I should see smart menu "List menu" item "Course 01" in location "Main, Menu, User, Bottom"
-    And I should see smart menu "List menu" item "Course 02" in location "Main, Menu, User, Bottom"
-    And I should see smart menu "List menu" item "Course 03" in location "Main, Menu, User, Bottom"
-    And I should see smart menu "List menu" item "Course 04" in location "Main, Menu, User, Bottom"
-    And I should see smart menu "List menu" item "Course 05" in location "Main, Menu, User, Bottom"
-    And I should see smart menu "List menu" item "Course 06" in location "Main, Menu, User, Bottom"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu     | List menu       |
+      | title    | Dynamic courses |
+      | itemtype | Dynamic courses |
+    When I am logged in as "student1"
+    Then "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Menu bar smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > User menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
+    And "Course 02" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 03" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 04" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 05" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 06" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And I should see smart menu "List menu" item "Course 01" in location "Main, Menu, User, Bottom"
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Dynamic courses - Compose the dynamic course list based on a category condition
-    When I log in as "admin"
-    And I navigate to smart menu "List menu" items
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
-    And I set the field "Dynamic courses: Course category" to "<category>"
-    And I press "Save changes"
-    And I log out
-    And I log in as "<user>"
-    Then I <course1> see smart menu "List menu" item "Course 01" in location "Main, Menu, User, Bottom"
-    And I <course2> see smart menu "List menu" item "Course 02" in location "Main, Menu, User, Bottom"
-    And I <course3> see smart menu "List menu" item "Course 03" in location "Main, Menu, User, Bottom"
-    And I <course4> see smart menu "List menu" item "Course 04" in location "Main, Menu, User, Bottom"
-    And I <course5> see smart menu "List menu" item "Course 05" in location "Main, Menu, User, Bottom"
-    And I <course6> see smart menu "List menu" item "Course 06" in location "Main, Menu, User, Bottom"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu       | List menu       |
+      | title      | Dynamic courses |
+      | itemtype   | Dynamic courses |
+      | categories | <category>      |
+    When I am logged in as "student1"
+    Then "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Menu bar smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > User menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
+    And "Course 02" "theme_boost_union > Smart menu item" <course2> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 03" "theme_boost_union > Smart menu item" <course3> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 04" "theme_boost_union > Smart menu item" <course4> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 05" "theme_boost_union > Smart menu item" <course5> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 06" "theme_boost_union > Smart menu item" <course6> exist in the "List menu" "theme_boost_union > Main menu smart menu"
 
     Examples:
-      | category    | user     | course1    | course2    | course3    | course4    | course5    | course6    |
-      | Category 01 | student1 | should     | should     | should     | should not | should not | should not |
-      | Category 02 | student1 | should not | should not | should not | should     | should     | should not |
+      | category | course1    | course2    | course3    | course4    | course5    | course6    |
+      | CAT1     | should     | should     | should     | should not | should not | should not |
+      | CAT2     | should not | should not | should not | should     | should     | should not |
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Dynamic courses - Compose the dynamic course list based on a category condition (with or without subcategories)
@@ -107,18 +113,20 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
       | student1 | C1a    | student |
       | student1 | C1b    | student |
       | student1 | C1aa   | student |
-    When I log in as "admin"
-    And I navigate to smart menu "List menu" items
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
-    And I set the field "Dynamic courses: Course category" to "Category 01"
-    And I set the field "Include subcategories" to "<subcat>"
-    And I press "Save changes"
-    And I log out
-    And I log in as "student1"
-    Then I should see smart menu "List menu" item "Course 01" in location "Main, Menu, User, Bottom"
-    And I <shouldornot> see smart menu "List menu" item "Course 01a" in location "Main, Menu, User, Bottom"
-    And I <shouldornot> see smart menu "List menu" item "Course 01b" in location "Main, Menu, User, Bottom"
-    And I <shouldornot> see smart menu "List menu" item "Course 01aa" in location "Main, Menu, User, Bottom"
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu             | List menu       |
+      | title            | Dynamic courses |
+      | itemtype         | Dynamic courses |
+      | categories       | CAT1            |
+      | category_subcats | <subcat>        |
+    When I log in as "student1"
+    Then "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01a" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01a" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Menu bar smart menu"
+    And "Course 01a" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > User menu smart menu"
+    And "Course 01a" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
+    And "Course 01b" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01aa" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Main menu smart menu"
 
     Examples:
       | subcat | shouldornot |
@@ -127,56 +135,50 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Dynamic courses - Compose the dynamic course list based on a enrolment role condition
-    When I log in as "admin"
     # Empty menus are hidden from view. To prevent that the whole menu is missing and the test fails,
     # a sample item is created.
-    And I set "List menu" smart menu items with the following fields to these values:
-      | Title          | Info    |
-      | Menu item type | Heading |
-    And I navigate to smart menu "List menu" items
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
-    And I set the field "Dynamic courses: Enrolment role" to "<role>"
-    And I press "Save changes"
-    And I log out
-    And I log in as "<user>"
-    Then I <course1> see smart menu "List menu" item "Course 01" in location "Main, Menu, User, Bottom"
-    And I <course2> see smart menu "List menu" item "Course 02" in location "Main, Menu, User, Bottom"
-    And I <course3> see smart menu "List menu" item "Course 03" in location "Main, Menu, User, Bottom"
-    And I <course4> see smart menu "List menu" item "Course 04" in location "Main, Menu, User, Bottom"
-    And I <course5> see smart menu "List menu" item "Course 05" in location "Main, Menu, User, Bottom"
-    And I <course6> see smart menu "List menu" item "Course 06" in location "Main, Menu, User, Bottom"
+    Given the following "theme_boost_union > smart menu items" exist:
+      | menu      | title           | itemtype        | enrolmentrole |
+      | List menu | Info            | Heading         |               |
+      | List menu | Dynamic courses | Dynamic courses | <role>        |
+    When I log in as "<user>"
+    Then "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Menu bar smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > User menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
+    And "Course 02" "theme_boost_union > Smart menu item" <course2> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 03" "theme_boost_union > Smart menu item" <course3> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 04" "theme_boost_union > Smart menu item" <course4> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 05" "theme_boost_union > Smart menu item" <course5> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 06" "theme_boost_union > Smart menu item" <course6> exist in the "List menu" "theme_boost_union > Main menu smart menu"
 
     Examples:
-      | role                         | user     | course1    | course2    | course3    | course4    | course5    | course6    |
-      | Non-editing teacher, Teacher | student1 | should not | should not | should not | should not | should not | should not |
-      | Non-editing teacher, Teacher | teacher  | should     | should not | should not | should not | should     | should     |
-      | Student                      | student1 | should     | should     | should     | should     | should not | should not |
-      | Student                      | teacher  | should not | should not | should not | should not | should not | should not |
+      | role                    | user     | course1    | course2    | course3    | course4    | course5    | course6    |
+      | teacher, editingteacher | student1 | should not | should not | should not | should not | should not | should not |
+      | teacher, editingteacher | teacher  | should     | should not | should not | should not | should     | should     |
+      | student                 | student1 | should     | should     | should     | should     | should not | should not |
+      | student                 | teacher  | should not | should not | should not | should not | should not | should not |
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Dynamic courses - Compose the dynamic course list based on a completion status condition
-    When I log in as "admin"
-    And I navigate to smart menu "List menu" items
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
-    And I set the field "Dynamic courses: Completion status" to "<completionstatus>"
-    And I press "Save changes"
-    And I am on "Course 01" course homepage with editing mode on
-    And I navigate to "Course completion" in current page administration
-    And I click on "Condition: Activity completion" "link"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu             | List menu          |
+      | title            | Dynamic courses    |
+      | itemtype         | Dynamic courses    |
+      | completionstatus | <completionstatus> |
+    And I am on the "Course 01" "theme_boost_union > Course completion" page logged in as "admin"
+    And I expand all fieldsets
     And I set the following fields to these values:
       | Assignment - Test assignment name1 | 1 |
       | Assignment - Test assignment name2 | 1 |
     And I press "Save changes"
-    And I am on "Course 02" course homepage with editing mode on
-    And I navigate to "Course completion" in current page administration
-    And I click on "Condition: Activity completion" "link"
+    And I am on the "Course 02" "theme_boost_union > Course completion" page
+    And I expand all fieldsets
     And I set the following fields to these values:
       | Assignment - Test assignment name3 | 1 |
       | Assignment - Test assignment name4 | 1 |
     And I press "Save changes"
-    And I log out
-    And I log in as "<user>"
-    And I am on "Course 01" course homepage
+    And I am on the "Course 01" "course" page logged in as "student1"
     And the manual completion button of "Test assignment name1" is displayed as "Mark as done"
     And I toggle the manual completion state of "Test assignment name1"
     And the manual completion button of "Test assignment name2" is displayed as "Mark as done"
@@ -185,82 +187,73 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
     And the manual completion button of "Test assignment name3" is displayed as "Mark as done"
     And I toggle the manual completion state of "Test assignment name3"
     And I follow "Dashboard"
-    Then I <course1> see smart menu "List menu" item "Course 01" in location "Main, Menu, User, Bottom"
-    And I <course2> see smart menu "List menu" item "Course 02" in location "Main, Menu, User, Bottom"
-    And I <course3> see smart menu "List menu" item "Course 03" in location "Main, Menu, User, Bottom"
-    And I <course4> see smart menu "List menu" item "Course 04" in location "Main, Menu, User, Bottom"
-    And I <course5> see smart menu "List menu" item "Course 05" in location "Main, Menu, User, Bottom"
+    Then "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Menu bar smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > User menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
+    And "Course 02" "theme_boost_union > Smart menu item" <course2> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 03" "theme_boost_union > Smart menu item" <course3> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 04" "theme_boost_union > Smart menu item" <course4> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 05" "theme_boost_union > Smart menu item" <course5> exist in the "List menu" "theme_boost_union > Main menu smart menu"
 
     Examples:
-      | completionstatus                 | user     | course1    | course2    | course3    | course4    | course5    |
-      | Enrolled, In progress, Completed | student1 | should     | should     | should     | should     | should not |
-      | In progress, Completed           | student1 | should     | should     | should not | should not | should not |
-      | Enrolled                         | student1 | should not | should not | should     | should     | should not |
-      | Completed                        | student1 | should     | should not | should not | should not | should not |
-      | In progress                      | student1 | should not | should     | should not | should not | should not |
+      | completionstatus                 | course1    | course2    | course3    | course4    | course5    |
+      | Enrolled, In progress, Completed | should     | should     | should     | should     | should not |
+      | In progress, Completed           | should     | should     | should not | should not | should not |
+      | Enrolled                         | should not | should not | should     | should     | should not |
+      | Completed                        | should     | should not | should not | should not | should not |
+      | In progress                      | should not | should     | should not | should not | should not |
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Dynamic courses - Compose the dynamic course list based on a date range condition
-    When I log in as "admin"
-    And I navigate to smart menu "List menu" items
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
-    And I set the field "Dynamic courses: Date range" to "<daterange>"
-    And I press "Save changes"
-    And I log out
-    And I log in as "<user>"
-    Then I <course1> see smart menu "List menu" item "Course 01" in location "Main, Menu, User, Bottom"
-    And I <course2> see smart menu "List menu" item "Course 02" in location "Main, Menu, User, Bottom"
-    And I <course3> see smart menu "List menu" item "Course 03" in location "Main, Menu, User, Bottom"
-    And I <course4> see smart menu "List menu" item "Course 04" in location "Main, Menu, User, Bottom"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu             | List menu       |
+      | title            | Dynamic courses |
+      | itemtype         | Dynamic courses |
+      | daterange        | <daterange>     |
+    When I log in as "student1"
+    Then "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Menu bar smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > User menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
+    And "Course 02" "theme_boost_union > Smart menu item" <course2> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 03" "theme_boost_union > Smart menu item" <course3> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 04" "theme_boost_union > Smart menu item" <course4> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 05" "theme_boost_union > Smart menu item" <course5> exist in the "List menu" "theme_boost_union > Main menu smart menu"
 
     Examples:
-      | daterange             | user     | course1    | course2    | course3    | course4    | course5    |
-      | Past, Present, Future | student1 | should     | should     | should     | should     | should     |
-      | Future                | student1 | should not | should not | should     | should not | should not |
-      | Present               | student1 | should     | should not | should not | should     | should     |
-      | Past                  | student1 | should not | should     | should not | should not | should not |
+      | daterange             | course1    | course2    | course3    | course4    | course5    |
+      | Past, Present, Future | should     | should     | should     | should     | should     |
+      | Future                | should not | should not | should     | should not | should not |
+      | Present               | should     | should not | should not | should     | should     |
+      | Past                  | should not | should     | should not | should not | should not |
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Dynamic courses - Compose the dynamic course list based on a course field condition
     Given the following "custom field categories" exist:
       | name   | component   | area   | itemid |
       | Others | core_course | course | 0      |
-    And I log in as "admin"
-    And I navigate to "Courses > Course custom fields" in site administration
-    And I click on "Add a new custom field" "link"
-    And I click on "Short text" "link"
-    And I set the following fields to these values:
-      | Name       | Test field |
-      | Short name | testfield  |
-    And I click on "Save changes" "button" in the "Adding a new Short text" "dialogue"
-    And I follow "Dashboard"
-    And I am on "Course 01" course homepage
-    And I navigate to "Settings" in current page administration
-    And I set the following fields to these values:
-      | Test field | value1 |
-    And I click on "Save and display" "button"
-    And I am on "Course 02" course homepage
-    And I navigate to "Settings" in current page administration
-    And I set the following fields to these values:
-      | Test field | value1 |
-    And I click on "Save and display" "button"
-    And I am on "Course 03" course homepage
-    And I navigate to "Settings" in current page administration
-    And I set the following fields to these values:
-      | Test field | value2 |
-    And I click on "Save and display" "button"
-    When I log in as "admin"
-    And I navigate to smart menu "List menu" items
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
-    And I should see "Test field"
-    And I set the field "Test field" to "<value>"
-    And I press "Save changes"
-    And I log out
-    And I log in as "<user>"
-    Then I <course1> see smart menu "List menu" item "Course 01" in location "Main, Menu, User, Bottom"
-    And I <course2> see smart menu "List menu" item "Course 02" in location "Main, Menu, User, Bottom"
-    And I <course3> see smart menu "List menu" item "Course 03" in location "Main, Menu, User, Bottom"
-    And I <course4> see smart menu "List menu" item "Course 04" in location "Main, Menu, User, Bottom"
+    And the following "custom fields" exist:
+      | name       | category  | type | shortname |
+      | Test field | Others    | text | testfield |
+    And the following "courses" exist:
+      | fullname  | shortname | customfield_testfield |
+      | Course 07 | C7        | value1                |
+      | Course 08 | C8        | value1                |
+      | Course 09 | C9        | value2                |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu             | List menu           |
+      | title            | Dynamic courses     |
+      | itemtype         | Dynamic courses     |
+      | customfields     | Test field: <value> |
+    When I log in as "<user>"
+    Then "Course 07" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 07" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Menu bar smart menu"
+    And "Course 07" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > User menu smart menu"
+    And "Course 07" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
+    And "Course 08" "theme_boost_union > Smart menu item" <course2> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 09" "theme_boost_union > Smart menu item" <course3> exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 04" "theme_boost_union > Smart menu item" <course4> exist in the "List menu" "theme_boost_union > Main menu smart menu"
 
     Examples:
       | value  | user     | course1    | course2    | course3    | course4    |
@@ -274,58 +267,52 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
       | AAA Course | BBB       | CAT1     | CCC      |
       | BBB Course | AAA       | CAT1     | BBB      |
       | CCC Course | CCC       | CAT1     | AAA      |
-    When I log in as "admin"
-    And I navigate to smart menu "List menu" items
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
-    And I set the field "Dynamic courses: Course list sorting" to "<sorting>"
-    And I press "Save changes"
-    And I log out
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu             | List menu       |
+      | title            | Dynamic courses |
+      | itemtype         | Dynamic courses |
+      | listsort         | <sorting>       |
     When I log in as "student1"
-    And I click on ".dynamiccoursetest" "css_element"
+    And I click on "List menu" "theme_boost_union > Smart menu"
     Then "<thisbeforethat1>" "text" should appear before "<thisbeforethat2>" "text" in the ".dynamiccoursetest .dropdown-menu" "css_element"
     And "<thisbeforethat2>" "text" should appear before "<thisbeforethat3>" "text" in the ".dynamiccoursetest .dropdown-menu" "css_element"
 
     Examples:
-      | sorting | thisbeforethat1 | thisbeforethat2 | thisbeforethat3 |
-      # Option: Course fullname ascending
-      | 0       | AAA Course      | BBB Course      | CCC Course      |
-      # Option: Course fullname descending
-      | 1       | CCC Course      | BBB Course      | AAA Course      |
-      # Option: Course shortname ascending
-      | 2       | BBB Course      | AAA Course      | CCC Course      |
-      # Option: Course shortname descending
-      | 3       | CCC Course      | AAA Course      | BBB Course      |
-      # Option: Course ID ascending
-      | 4       | AAA Course      | BBB Course      | CCC Course      |
-      # Option: Course ID descending
-      | 5       | CCC Course      | BBB Course      | AAA Course      |
-      # Option: Course ID number ascending
-      | 6       | CCC Course      | BBB Course      | AAA Course      |
-      # Option: Course ID number descending
-      | 7       | AAA Course      | BBB Course      | CCC Course      |
+      | sorting                     | thisbeforethat1 | thisbeforethat2 | thisbeforethat3 |
+      | Course fullname ascending   | AAA Course      | BBB Course      | CCC Course      |
+      | Course fullname descending  | CCC Course      | BBB Course      | AAA Course      |
+      | Course shortname ascending  | BBB Course      | AAA Course      | CCC Course      |
+      | Course shortname descending | CCC Course      | AAA Course      | BBB Course      |
+      | Course ID ascending         | AAA Course      | BBB Course      | CCC Course      |
+      | Course ID descending        | CCC Course      | BBB Course      | AAA Course      |
+      | Course ID number ascending  | CCC Course      | BBB Course      | AAA Course      |
+      | Course ID number descending | AAA Course      | BBB Course      | CCC Course      |
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Dynamic courses - Hide empty menus
-    When I log in as "admin"
-    And I navigate to smart menus
-    And I click on ".action-edit" "css_element" in the "List menu" "table_row"
-    And I set the field "Menu mode" to "<menumode>"
-    And I click on "Save and configure items" "button"
-    And I click on ".action-edit" "css_element" in the "Dynamic courses" "table_row"
-    And I set the field "Dynamic courses: Enrolment role" to "<role>"
-    And I set the field "Menu item mode" to "<menumode>"
-    And I press "Save changes"
-    And I log out
-    And I log in as "<user>"
-    Then I <shouldornot> see smart menu "<menutitle>" in location "Main, Menu, User, Bottom"
+    And the following "theme_boost_union > smart menu" exists:
+      | title    | Mode menu                                        |
+      | location | Main navigation, Menu bar, User menu, Bottom bar |
+      | mode     | <menumode>                                       |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu          | Mode menu       |
+      | title         | Dynamic courses |
+      | itemtype      | Dynamic courses |
+      | itemmode      | <menumode>      |
+      | enrolmentrole | <role>          |
+    When I log in as "<user>"
+    Then "<menutitle>" "theme_boost_union > Main menu <locator>" <shouldornot> exist
+    And "<menutitle>" "theme_boost_union > Menu bar <locator>" <shouldornot> exist
+    And "<menutitle>" "theme_boost_union > User menu <locator>" <shouldornot> exist
+    And "<menutitle>" "theme_boost_union > Bottom bar <locator>" <shouldornot> exist
 
     Examples:
-      | role                         | user     | shouldornot | menutitle | menumode |
-      | Non-editing teacher, Teacher | student1 | should not  | List menu | Submenu  |
-      | Non-editing teacher, Teacher | teacher  | should      | List menu | Submenu  |
-      | Student                      | student1 | should      | List menu | Submenu  |
-      | Student                      | teacher  | should not  | List menu | Submenu  |
-      | Non-editing teacher, Teacher | student1 | should not  | Course 01 | Inline   |
-      | Non-editing teacher, Teacher | teacher  | should      | Course 01 | Inline   |
-      | Student                      | student1 | should      | Course 01 | Inline   |
-      | Student                      | teacher  | should not  | Course 01 | Inline   |
+      | role                    | user     | shouldornot | menutitle | menumode | locator         |
+      | teacher, editingteacher | student1 | should not  | Mode menu | Submenu  | smart menu      |
+      | teacher, editingteacher | teacher  | should      | Mode menu | Submenu  | smart menu      |
+      | student                 | student1 | should      | Mode menu | Submenu  | smart menu      |
+      | student                 | teacher  | should not  | Mode menu | Submenu  | smart menu      |
+      | teacher, editingteacher | student1 | should not  | Course 01 | Inline   | smart menu item |
+      | teacher, editingteacher | teacher  | should      | Course 01 | Inline   | smart menu item |
+      | student                 | student1 | should      | Course 01 | Inline   | smart menu item |
+      | student                 | teacher  | should not  | Course 01 | Inline   | smart menu item |

--- a/tests/behat/theme_boost_union_smartmenusettings_menuitems_dynamiccourses.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menuitems_dynamiccourses.feature
@@ -121,10 +121,10 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
       | category_subcats | <subcat>        |
     When I log in as "student1"
     Then "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Main menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Menu bar smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > User menu smart menu"
+    And "Course 01" "theme_boost_union > Smart menu item" should exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
     And "Course 01a" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Main menu smart menu"
-    And "Course 01a" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Menu bar smart menu"
-    And "Course 01a" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > User menu smart menu"
-    And "Course 01a" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Bottom bar smart menu"
     And "Course 01b" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Main menu smart menu"
     And "Course 01aa" "theme_boost_union > Smart menu item" <shouldornot> exist in the "List menu" "theme_boost_union > Main menu smart menu"
 
@@ -246,7 +246,7 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
       | title            | Dynamic courses     |
       | itemtype         | Dynamic courses     |
       | customfields     | Test field: <value> |
-    When I log in as "<user>"
+    When I log in as "student1"
     Then "Course 07" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Main menu smart menu"
     And "Course 07" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > Menu bar smart menu"
     And "Course 07" "theme_boost_union > Smart menu item" <course1> exist in the "List menu" "theme_boost_union > User menu smart menu"
@@ -256,9 +256,9 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
     And "Course 04" "theme_boost_union > Smart menu item" <course4> exist in the "List menu" "theme_boost_union > Main menu smart menu"
 
     Examples:
-      | value  | user     | course1    | course2    | course3    | course4    |
-      | value1 | student1 | should     | should     | should not | should not |
-      | value2 | student1 | should not | should not | should     | should not |
+      | value  | course1    | course2    | course3    | course4    |
+      | value1 | should     | should     | should not | should not |
+      | value2 | should not | should not | should     | should not |
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Dynamic courses - Sort the course list based on the given setting

--- a/tests/behat/theme_boost_union_smartmenusettings_menuitems_presentation.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menuitems_presentation.feature
@@ -5,8 +5,7 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
   I need to be able to configure the theme Boost Union plugin
 
   Background:
-    Given I log in as "admin"
-    And the following "courses" exist:
+    Given the following "courses" exist:
       | fullname               | shortname | category |
       | Test course1           | C1        | 0        |
       | Test course2           | C2        | 0        |
@@ -14,32 +13,33 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
     And the following "users" exist:
       | username |
       | user1    |
-    And I create smart menu with the following fields to these values:
-      | Title            | Quick links              |
-      | Menu location(s) | Main, Menu, User, Bottom |
+    And the following "theme_boost_union > smart menu" exists:
+      | title    | Quick links                                      |
+      | location | Main navigation, Menu bar, User menu, Bottom bar |
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Presentation - Open the smart menu items in different targets
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu     | Quick links       |
+      | title    | Available courses |
+      | itemtype | Dynamic courses   |
+      | category | 0                 |
+      | itemmode | Inline            |
+      | target   | <setting>         |
     When I log in as "admin"
-    And I set "Quick links" smart menu items with the following fields to these values:
-      | Title                            | Available courses |
-      | Menu item type                   | Dynamic courses   |
-      | Dynamic courses: Course category | Category 1        |
-      | Menu item mode                   | Inline            |
-      | Link target                      | <setting>         |
-    And I should see "Available courses" in the "smartmenus_items" "table"
     # Menu items in main navigation
+    Then "Test course1" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Main menu smart menu"
     Then I should see smart menu "Quick links" item "Test course1" in location "Main"
     And the "target" attribute of "//div[@class='primary-navigation']//a[contains(normalize-space(.), 'Test course1')]" "xpath_element" <should>
     # Menu items in user menu.
-    And I should see smart menu "Quick links" item "Test course1" in location "User"
+    Then "Test course1" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > User menu smart menu"
     And the "target" attribute of "//div[contains(@class, 'carousel-item')]//a[contains(normalize-space(.), 'Test course1')]" "xpath_element" <should>
     # Menu items in bottom menu.
-    Then I should see smart menu "Quick links" item "Test course1" in location "Bottom"
+    Then "Test course1" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
     And the "target" attribute of "//div[@class='bottom-navigation']//a[contains(normalize-space(.), 'Test course1')]" "xpath_element" <should>
     Then I change the viewport size to "large"
     # Menu items in menubar.
-    And I should see smart menu "Quick links" item "Test course1" in location "Menu"
+    Then "Test course1" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
     And the "target" attribute of "//nav[contains(@class, 'menubar')]//a[contains(normalize-space(.), 'Test course1')]" "xpath_element" <should>
 
     Examples:
@@ -49,18 +49,14 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
 
   @javascript
   Scenario: Smartmenus: Menu items: Presentation - Include the custom css class for a smart menu item
-    When I log in as "admin"
-    And I set "Quick links" smart menu items with the following fields to these values:
-      | Title          | Resources         |
-      | Menu item type | Static            |
-      | Menu item URL  | http://moodle.org |
-    And I navigate to smart menu "Quick links" items
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "CSS class" to "static-item-resources"
-    And I click on "Save changes" "button"
-    And I should see "Resources" in the "smartmenus_items" "table"
-    And the "class" attribute of "//div[@class='primary-navigation']//a[contains(normalize-space(.), 'Resources')]" "xpath_element" should contain "static-item-resources"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu     | Quick links           |
+      | title    | Resources             |
+      | itemtype | Static                |
+      | url      | http://moodle.org     |
+      | cssclass | static-item-resources |
+    When I am on the "Quick links" "theme_boost_union > Smart menu > Items" page logged in as "admin"
+    Then the "class" attribute of "//div[@class='primary-navigation']//a[contains(normalize-space(.), 'Resources')]" "xpath_element" should contain "static-item-resources"
     And the "class" attribute of "//div[contains(@class, 'carousel-item')]//a[contains(normalize-space(.), 'Resources')]" "xpath_element" should contain "static-item-resources"
     And the "class" attribute of "//nav[contains(@class, 'menubar')]//a[contains(normalize-space(.), 'Resources')]" "xpath_element" should contain "static-item-resources"
     And I change the viewport size to "740x900"
@@ -82,16 +78,22 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
 
   @javascript
   Scenario Outline: Smartmenus: Menu items: Presentation - Display the different fields as smart menu item title
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu         | Quick links       |
+      | title        | Available courses |
+      | itemtype     | Dynamic courses   |
+      | category     | 0                 |
+      | displayfield | <selectnamefield> |
+      | textcount    | <numberofwords>   |
     When I log in as "admin"
-    And I set "Quick links" smart menu items with the following fields to these values:
-      | Title                                     | Available courses |
-      | Menu item type                            | Dynamic courses   |
-      | Dynamic courses: Course category          | Category 1        |
-      | Dynamic courses: Course name presentation | <selectnamefield> |
-      | Dynamic courses: Number of words          | <numberofwords>   |
-    And I should see "Available courses" in the "smartmenus_items" "table"
-    And I should see smart menu "Quick links" item "<showntitle>" in location "Main, Menu, User, Bottom"
-    And I should not see smart menu "Quick links" item "<notshowntitle>" in location "Main, Menu, User, Bottom"
+    Then "<showntitle>" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "<showntitle>" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "<showntitle>" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "<showntitle>" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    And "<notshowntitle>" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "<notshowntitle>" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "<notshowntitle>" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "<notshowntitle>" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
 
     Examples:
       | selectnamefield   | numberofwords | showntitle             | notshowntitle          |

--- a/tests/behat/theme_boost_union_smartmenusettings_menuitems_rules.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menuitems_rules.feature
@@ -29,22 +29,15 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
       | student2 | CH1    |
       | student2 | CH2    |
       | teacher  | CH2    |
-    And I create smart menu with the following fields to these values:
-      | Title            | Quick links              |
-      | Menu location(s) | Main, Menu, User, Bottom |
-    And I set "Quick links" smart menu items with the following fields to these values:
-      | Title          | Resources          |
-      | Menu item type | Static             |
-      | URL            | https://moodle.org |
+    And the following "theme_boost_union > smart menu" exists:
+      | title    | Quick links                                      |
+      | location | Main navigation, Menu bar, User menu, Bottom bar |
     # Empty menus are hidden from view. To prevent that the whole menu is missing and the test fails,
     # a sample item is created.
-    And I set "Quick links" smart menu items with the following fields to these values:
-      | Title          | Info    |
-      | Menu item type | Heading |
-    And the following "language packs" exist:
-      | language |
-      | de       |
-      | fr       |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu     | Quick links |
+      | title    | Info        |
+      | itemtype | Heading     |
 
   @javascript
   Scenario Outline: Smartmenu: Menu items: Rules - Show smart menu item based on the user roles
@@ -61,265 +54,227 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
     And the following "roles" exist:
       | name    | shortname | description     |
       | Visitor | visitor   | My visitor role |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | roles       | <byrole>           |
+      | rolecontext | <context>          |
+    Given I am logged in as "admin"
     And I navigate to "Users > Permissions > User policies" in site administration
     And I set the field "Role for visitors" to "Visitor (visitor)"
     And I press "Save changes"
-    When I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I should see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "By role" to "<byrole>"
-    And I set the field "Context" to "<context>"
-    And I click on "Save changes" "button"
-    And I <adminshouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "coursemanager"
-    Then I <managershouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "student1"
-    Then I <student1shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "teacher"
-    Then I <teachershouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "systemmanager"
-    Then I <systemshouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log in as "guest"
-    Then I <guestshouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, Bottom"
-    And I log out
-    And I <visitorshouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, Bottom"
+    And "Resources" "theme_boost_union > Smart menu item" <adminshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <adminshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <adminshouldorshouldnot> exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <adminshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "coursemanager"
+    Then "Resources" "theme_boost_union > Smart menu item" <managershouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    When I am logged in as "student1"
+    Then "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    When I am logged in as "teacher"
+    Then "Resources" "theme_boost_union > Smart menu item" <teachershouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    When I am logged in as "systemmanager"
+    Then "Resources" "theme_boost_union > Smart menu item" <systemshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    When I am logged in as "guest"
+    Then "Resources" "theme_boost_union > Smart menu item" <guestshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    When I log out
+    Then "Resources" "theme_boost_union > Smart menu item" <visitorshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
 
     Examples:
-      | byrole                    | context | student1shouldorshouldnot | teachershouldorshouldnot | managershouldorshouldnot | guestshouldorshouldnot | adminshouldorshouldnot | systemshouldorshouldnot | visitorshouldorshouldnot |
-      | Manager                   | Any     | should not                | should not               | should                   | should not             | should not             | should                  | should not               |
-      | Manager, Student          | Any     | should                    | should not               | should                   | should not             | should not             | should                  | should not               |
-      | Manager, Student, Teacher | Any     | should                    | should                   | should                   | should not             | should not             | should                  | should not               |
-      | Manager, Student, Teacher | System  | should not                | should not               | should not               | should not             | should not             | should                  | should not               |
-      | Authenticated user        | Any     | should                    | should                   | should                   | should not             | should                 | should                  | should not               |
-      | Guest                     | Any     | should not                | should not               | should not               | should                 | should not             | should not              | should not               |
-      | Visitor                   | Any     | should not                | should not               | should not               | should not             | should not             | should not              | should                   |
+      | byrole                           | context | student1shouldorshouldnot | teachershouldorshouldnot | managershouldorshouldnot | guestshouldorshouldnot | adminshouldorshouldnot | systemshouldorshouldnot | visitorshouldorshouldnot |
+      | Manager                          | Any     | should not                | should not               | should                   | should not             | should not             | should                  | should not               |
+      | Manager, Student                 | Any     | should                    | should not               | should                   | should not             | should not             | should                  | should not               |
+      | Manager, Student, editingteacher | Any     | should                    | should                   | should                   | should not             | should not             | should                  | should not               |
+      | Manager, Student, editingteacher | System  | should not                | should not               | should not               | should not             | should not             | should                  | should not               |
+      | user                             | Any     | should                    | should                   | should                   | should not             | should                 | should                  | should not               |
+      | Guest                            | Any     | should not                | should not               | should not               | should                 | should not             | should not              | should not               |
+      | Visitor                          | Any     | should not                | should not               | should not               | should not             | should not             | should not              | should                   |
 
   @javascript
   Scenario Outline: Smartmenu: Menu items: Rules - Show smart menu item based on being site admin
-    When I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I should see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "Show to" to "<byadmin>"
-    And I click on "Save changes" "button"
-    And I <adminshouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "student1"
-    Then I <student1shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | byadmin     | <byadmin>          |
+    When I am logged in as "admin"
+    And "Resources" "theme_boost_union > Smart menu item" <adminshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <adminshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <adminshouldorshouldnot> exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <adminshouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "student1"
+    And "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
 
     Examples:
-      | byadmin | adminshouldorshouldnot | student1shouldorshouldnot |
-      | 0       | should                 | should                    |
-      | 1       | should                 | should not                |
-      | 2       | should not             | should                    |
+      | byadmin          | adminshouldorshouldnot | student1shouldorshouldnot |
+      | All users        | should                 | should                    |
+      | Site admins only | should                 | should not                |
+      | Non-admins only  | should not             | should                    |
 
   @javascript
   Scenario Outline: Smartmenu: Menu items: Rules - Show smart menu item based on the user assignment in single cohorts
-    When I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I should see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "By cohort" to "<bycohort>"
-    And I click on "Save changes" "button"
-    And I should not see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "student1"
-    Then I <student1shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "student2"
-    Then I <student2shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "teacher"
-    Then I <teachershouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | cohorts     | <bycohort>         |
+    When I am logged in as "admin"
+    And "Resources" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "student1"
+    Then "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "student2"
+    Then "Resources" "theme_boost_union > Smart menu item" <student2shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "teacher"
+    Then "Resources" "theme_boost_union > Smart menu item" <teachershouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
 
     Examples:
       | bycohort | student1shouldorshouldnot | student2shouldorshouldnot | teachershouldorshouldnot |
-      | Cohort 1 | should                    | should                    | should not               |
-      | Cohort 2 | should not                | should                    | should                   |
+      | CH1      | should                    | should                    | should not               |
+      | CH2      | should not                | should                    | should                   |
 
   @javascript
   Scenario Outline: Smartmenu: Menu items: Rules - Show smart menu item based on the user assignment in multiple cohorts
-    When I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I should see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "By cohort" to "<bycohorts>"
-    And I set the field "Operator" to "<operator>"
-    And I click on "Save changes" "button"
-    And I should not see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "student1"
-    Then I <student1shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "student2"
-    Then I <student2shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "teacher"
-    Then I <teachershouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | cohorts     | <bycohorts>        |
+      | operator    | <operator>         |
+    When I am logged in as "admin"
+    And "Resources" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "student1"
+    Then "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "student2"
+    Then "Resources" "theme_boost_union > Smart menu item" <student2shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "teacher"
+    Then "Resources" "theme_boost_union > Smart menu item" <teachershouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
 
     Examples:
-      | bycohorts          | operator | student1shouldorshouldnot | student2shouldorshouldnot | teachershouldorshouldnot |
-      | Cohort 1, Cohort 2 | Any      | should                    | should                    | should                   |
-      | Cohort 1, Cohort 2 | All      | should not                | should                    | should not               |
+      | bycohorts | operator | student1shouldorshouldnot | student2shouldorshouldnot | teachershouldorshouldnot |
+      | CH1, CH2  | Any      | should                    | should                    | should                   |
+      | CH1, CH2  | All      | should not                | should                    | should not               |
 
   @javascript
   Scenario Outline: Smartmenu: Menu items: Rules - Show smart menu item based on the user's prefered language
-    When I log in as "teacher"
-    And I follow "Preferences" in the user menu
-    And I click on "Preferred language" "link"
-    And I set the field "Preferred language" to "Deutsch ‎(de)‎"
-    And I press "Save changes"
-    And I log out
-    And I log in as "student1"
-    And I follow "Preferences" in the user menu
-    And I click on "Preferred language" "link"
-    And I set the field "Preferred language" to "English ‎(en)‎"
-    And I press "Save changes"
-    And I log out
-    And I log in as "student2"
-    And I follow "Preferences" in the user menu
-    And I click on "Preferred language" "link"
-    And I set the field "Preferred language" to "Français ‎(fr)‎"
-    And I press "Save changes"
-    And I log out
-    When I log in as "admin"
-    When I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I should see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "By language" to "<bylanguage>"
-    And I click on "Save changes" "button"
-    And I log out
-    And I log in as "student1"
-    And I <student1shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "student2"
-    And I <student2shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "teacher"
-    And I <teachershouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
+    Given the following "language packs" exist:
+      | language |
+      | de       |
+      | fr       |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | languages   | <bylanguage>       |
+    When I am logged in as "student1"
+    Then "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "student2"
+    And I follow "Language" in the user menu
+    And I click on "Français" "link"
+    Then "Resources" "theme_boost_union > Smart menu item" <student2shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "teacher"
+    And I follow "Language" in the user menu
+    And I click on "Deutsch" "link"
+    Then "Resources" "theme_boost_union > Smart menu item" <teachershouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
 
     Examples:
-      | bylanguage       | student1shouldorshouldnot | student2shouldorshouldnot | teachershouldorshouldnot |
-      | English          | should                    | should not                | should not               |
-      | English, Deutsch | should                    | should not                | should                   |
+      | bylanguage | student1shouldorshouldnot | student2shouldorshouldnot | teachershouldorshouldnot |
+      | en         | should                    | should not                | should not               |
+      | en, de     | should                    | should not                | should                   |
 
   @javascript
   Scenario Outline: Smartmenu: Menu items: Rules - Show smart menu item based on the custom date range
-    When I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I should see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the following fields to these values:
-      | id_start_date_enabled    | <startenabled> |
-      | id_end_date_enabled      | <endenabled>   |
-      | id_start_date_day        | <start_day>    |
-      | id_start_date_month      | <start_month>  |
-      | id_start_date_year       | <start_year>   |
-      | id_end_date_day          | <end_day>      |
-      | id_end_date_month        | <end_month>    |
-      | id_end_date_year         | <end_year>     |
-    And I click on "Save changes" "button"
-    And I <menushouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    Then I log out
-    And I log in as "student1"
-    And I <menushouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    When I log in as "teacher"
-    And I <menushouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | start_date  | <start_date>       |
+      | end_date    | <end_date>         |
+    When I am logged in as "admin"
+    Then "Resources" "theme_boost_union > Smart menu item" <menushouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <menushouldorshouldnot> exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <menushouldorshouldnot> exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <menushouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "student1"
+    Then "Resources" "theme_boost_union > Smart menu item" <menushouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    When I am logged in as "teacher"
+    Then "Resources" "theme_boost_union > Smart menu item" <menushouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
 
     Examples:
-      | startenabled |endenabled | start_day | start_month | start_year | end_day | end_month | end_year | menushouldorshouldnot |
-      | 1            | 1         | 1         | January     | 2023       | 1       | January   | 2050     | should                |
-      | 1            | 1         | 1         | January     | 2049       | 1       | January   | 2050     | should not            |
-      | 1            | 1         | 1         | January     | 2023       | 1       | December  | 2023     | should not            |
-      | 1            | 0         | 1         | January     | 2023       | 1       | 1         | 2023     | should                |
-      | 1            | 0         | 1         | January     | 2049       | 1       | 1         | 2023     | should not            |
-      | 0            | 1         | 1         | January     | 2023       | 1       | December  | 2050     | should                |
-      | 0            | 1         | 1         | January     | 2023       | 1       | December  | 2023     | should not            |
+      | start_date           | end_date              | menushouldorshouldnot |
+      | ## 1 January 2023 ## | ## 1 January 2050 ##  | should                |
+      | ## 1 January 2049 ## | ## 1 January 2050 ##  | should not            |
+      | ## 1 January 2023 ## | ## 1 December 2023 ## | should not            |
+      | ## 1 January 2023 ## |                       | should                |
+      | ## 1 January 2049 ## |                       | should not            |
+      |                      | ## 1 December 2050 ## | should                |
+      |                      | ## 1 December 2023 ## | should not            |
 
   @javascript
   Scenario Outline: Smartmenu: Menu items: Rules - Show smart menu item based on multiple conditions
-    When I log in as "teacher"
-    And I follow "Preferences" in the user menu
-    And I click on "Preferred language" "link"
-    And I set the field "Preferred language" to "Deutsch ‎(de)‎"
-    And I press "Save changes"
-    And I log out
-    And I log in as "student1"
-    And I follow "Preferences" in the user menu
-    And I click on "Preferred language" "link"
-    And I set the field "Preferred language" to "English ‎(en)‎"
-    And I press "Save changes"
-    And I log out
-    And I log in as "student2"
-    And I follow "Preferences" in the user menu
-    And I click on "Preferred language" "link"
-    And I set the field "Preferred language" to "Français ‎(fr)‎"
-    And I press "Save changes"
-    And I log out
-    When I log in as "admin"
-    And I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I should see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "By role" to "<byrole>"
-    And I set the field "By cohort" to "<bycohort>"
-    And I set the field "By language" to "<bylanguage>"
-    And I click on "Save changes" "button"
-    And I log out
-    And I log in as "student1"
-    Then I <student1shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "student2"
-    Then I <student2shouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
-    And I log out
-    And I log in as "teacher"
-    Then I <teachershouldorshouldnot> see smart menu "Quick links" item "Resources" in location "Main, Menu, User, Bottom"
+    Given the following "language packs" exist:
+      | language |
+      | de       |
+      | fr       |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | roles       | <byrole>           |
+      | cohorts     | <bycohort>         |
+      | languages   | <bylanguage>       |
+    When I am logged in as "student1"
+    Then "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Menu bar smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > User menu smart menu"
+    And "Resources" "theme_boost_union > Smart menu item" <student1shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "student2"
+    And I follow "Language" in the user menu
+    And I click on "Français" "link"
+    Then "Resources" "theme_boost_union > Smart menu item" <student2shouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
+    When I am logged in as "teacher"
+    And I follow "Language" in the user menu
+    And I click on "Deutsch" "link"
+    Then "Resources" "theme_boost_union > Smart menu item" <teachershouldorshouldnot> exist in the "Quick links" "theme_boost_union > Bottom bar smart menu"
 
     Examples:
-      | byrole                    | bycohort           | bylanguage       | student1shouldorshouldnot | student2shouldorshouldnot | teachershouldorshouldnot |
-      | Manager, Student          | Cohort 1           | English          | should                    | should not                | should not               |
-      | Manager, Student, Teacher | Cohort 1, Cohort 2 | English, Deutsch | should                    | should not                | should                   |
+      | byrole                           | bycohort | bylanguage | student1shouldorshouldnot | student2shouldorshouldnot | teachershouldorshouldnot |
+      | Manager, Student                 | CH1      | en         | should                    | should not                | should not               |
+      | Manager, Student, editingteacher | CH1, CH2 | en, de     | should                    | should not                | should                   |
 
   @javascript
   Scenario: Smartmenu: Menu items: Rules - Deleting a cohort used for a rule removes it from the rule
-    Given I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "By cohort" to "Cohort 1, Cohort 2"
-    And I set the field "Operator" to "Any"
-    And I click on "Save changes" "button"
+    Given the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | cohorts     | CH1, CH2           |
+    And I am on the "Quick links" "theme_boost_union > Smart menu > Items" page logged in as "admin"
     And I should see "Cohort 1" in the "Resources" "table_row"
     And I should see "Cohort 2" in the "Resources" "table_row"
     When I navigate to "Users > Cohorts" in site administration
     And I open the action menu in "Cohort 1" "table_row"
     And I choose "Delete" in the open action menu
     And I click on "Delete" "button" in the "Delete selected" "dialogue"
-    And I navigate to smart menus
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I should not see "Cohort 1" in the "Resources" "table_row"
+    And I am on the "Quick links" "theme_boost_union > Smart menu > Items" page
+    Then I should not see "Cohort 1" in the "Resources" "table_row"
     And I should see "Cohort 2" in the "Resources" "table_row"
 
   @javascript
@@ -328,20 +283,18 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
       | shortname | name        |
       | test1     | Test role 1 |
       | test2     | Test role 2 |
-    And I navigate to smart menus
-    And I should see "Quick links" in the "smartmenus" "table"
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I click on ".action-edit" "css_element" in the "Resources" "table_row"
-    And I expand all fieldsets
-    And I set the field "By role" to "Test role 1, Test role 2"
-    And I set the field "Operator" to "Any"
-    And I click on "Save changes" "button"
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu        | Quick links        |
+      | title       | Resources          |
+      | itemtype    | Static             |
+      | url         | https://moodle.org |
+      | roles       | test1, test2       |
+    And I am on the "Quick links" "theme_boost_union > Smart menu > Items" page logged in as "admin"
     And I should see "Test role 1" in the "Resources" "table_row"
     And I should see "Test role 2" in the "Resources" "table_row"
     When I navigate to "Users > Define roles" in site administration
     And I click on "Delete" "link" in the "Test role 1" "table_row"
     And I press "Yes"
-    And I navigate to smart menus
-    And I click on ".action-list-items" "css_element" in the "Quick links" "table_row"
-    And I should not see "Test role 1" in the "Resources" "table_row"
+    And I am on the "Quick links" "theme_boost_union > Smart menu > Items" page
+    Then I should not see "Test role 1" in the "Resources" "table_row"
     And I should see "Test role 2" in the "Resources" "table_row"

--- a/tests/generator/behat_theme_boost_union_generator.php
+++ b/tests/generator/behat_theme_boost_union_generator.php
@@ -1,0 +1,479 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+use theme_boost_union\smartmenu;
+use theme_boost_union\smartmenu_item;
+
+/**
+ * Behat generator for Boost Union
+ *
+ * @package   theme_boost_union
+ * @copyright 2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
+ * @author    Mark Johnson <mark.johnson@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_theme_boost_union_generator extends behat_generator_base {
+    /**
+     * Define entities that can be generated with the 'the following "x" exist(s):' steps.
+     *
+     * Currently supported entities:
+     * - "smart menus" - Requires a location, supports all options.
+     *   - Most properties can be specified as they appear on the editing form.
+     *   - "location", "roles", "cohorts" and "languages" support multiple values as a comma-separated list.
+     *   - "roles" are specified by shortname, "cohorts" are specified by idnumber and "languages" are specified by
+     *     short code (for example, en, de).
+     * - "smart menu items" - Requires a menu title, supports all options except file uploads.
+     *   - Most properties can be specified as they appear on the editing form.
+     *   - "menu" is the title of the Smart menu this item belongs to.
+     *   - "categories", "completionstatus", "daterange", "customfields", "roles", "cohorts" and "languages"
+     *     support multiple values as a comma-separated list.
+     *   - "roles" are specified by shortname, "cohorts" are specified by idnumber and "languages" are specified by
+     *     short code (for example, en, de).
+     *   - "customfields" are specified in `name: value` format, where name is the name or shortname of the custom field.
+     *
+     * @return array[]
+     */
+    protected function get_creatable_entities(): array {
+        return [
+            'smart menus' => [
+                'singular' => 'smart menu',
+                'datagenerator' => 'smartmenu',
+                'required' => ['location'],
+                'switchids' => [
+                    'location' => 'location',
+                    'showdescription' => 'showdescription',
+                    'type' => 'type',
+                    'mode' => 'mode',
+                    'moremenubehaviour' => 'moremenubehaviour',
+                    'cardform' => 'cardform',
+                    'cardsize' => 'cardsize',
+                    'cardoverflowbehaviour' => 'cardoverflowbehaviour',
+                    'roles' => 'roles',
+                    'rolecontext' => 'rolecontext',
+                    'cohorts' => 'cohorts',
+                    'operator' => 'operator',
+                    'languages' => 'languages',
+                ],
+            ],
+
+            'smart menu items' => [
+                'singular' => 'smart menu item',
+                'datagenerator' => 'smartmenu_item',
+                'required' => ['menu'],
+                'switchids' => [
+                    'menu' => 'menu',
+                    'itemtype' => 'type',
+                    'categories' => 'category',
+                    'enrolmentrole' => 'enrolmentrole',
+                    'completionstatus' => 'completionstatus',
+                    'daterange' => 'daterange',
+                    'customfields' => 'customfields',
+                    'listsort' => 'listsort',
+                    'displayfield' => 'displayfield',
+                    'itemmode' => 'mode',
+                    'display' => 'display',
+                    'target' => 'target',
+                    'textposition' => 'textposition',
+                    'roles' => 'roles',
+                    'rolecontext' => 'rolecontext',
+                    'cohorts' => 'cohorts',
+                    'operator' => 'operator',
+                    'languages' => 'languages',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Return the ID of an identifier from an array of ids => identifiers.
+     *
+     * If the identifier does not appear in the array, throw an exception with a list of allowed values.
+     *
+     * @param string $name
+     * @param string $identifier
+     * @param array $options A list of allowed options, keyed by ID.
+     * @return int
+     */
+    protected function option_id(string $name, string $identifier, array $options): int {
+        $id = array_search(trim($identifier), $options);
+        if ($id === false) {
+            throw new Exception("Invalid {$name}: '{$identifier}'. Allowed values are '" .
+                implode("', '", $options) . "'");
+        }
+        return $id;
+    }
+
+    /**
+     * Given a comma-separated list of location strings, return an array of location IDs.
+     *
+     * @param string $locations A comma-separated list of locations, must be strings from the smartmenu::get_locations() array.
+     * @return array
+     */
+    protected function get_location_id(string $locations): array {
+        $locationoptions = smartmenu::get_locations();
+        $locationids = [];
+        foreach (explode(',', $locations) as $location) {
+            $location = trim($location);
+            if (empty($location)) {
+                continue;
+            }
+            $locationid = array_search($location, $locationoptions);
+            if ($locationid === false) {
+                throw new Exception("Invalid location '{$location}'. Allowed locations are: " . implode(',', $locationoptions));
+            }
+            $locationids[] = $locationid;
+        }
+        return $locationids;
+    }
+
+    /**
+     * Return the ID for the given showdescription setting.
+     *
+     * @param string $showdescription
+     * @return int
+     * @throws Exception
+     */
+    protected function get_showdescription_id(string $showdescription): int {
+        return $this->option_id('showdescription', $showdescription, smartmenu::get_showdescription_options());
+    }
+
+    /**
+     * Return the ID for the given menu type.
+     *
+     * @param string $type
+     * @return int
+     * @throws Exception
+     */
+    protected function get_type_id(string $type): int {
+        return $this->option_id('type', $type, smartmenu::get_types());
+    }
+
+    /**
+     * Return the ID for the given menu mode.
+     *
+     * @param string $mode
+     * @return int
+     * @throws Exception
+     */
+    protected function get_mode_id(string $mode): int {
+        return $this->option_id('mode', $mode, smartmenu::get_mode_options());
+    }
+
+    /**
+     * Return the ID for the given moremenubehavriour setting.
+     *
+     * @param string $moremenu
+     * @return int
+     * @throws Exception
+     */
+    protected function get_moremenubehaviour_id(string $moremenu): int {
+        return $this->option_id('moremenu', $moremenu, smartmenu::get_moremenu_options());
+    }
+
+    /**
+     * Return the ID for the given cardsize setting.
+     *
+     * @param string $cardsize
+     * @return int
+     * @throws Exception
+     */
+    protected function get_cardsize_id(string $cardsize): int {
+        return $this->option_id('cardsize', $cardsize, smartmenu::get_cardsize_options());
+    }
+
+    /**
+     * Return the ID for the given cardform setting.
+     *
+     * @param string $cardform
+     * @return int
+     * @throws Exception
+     */
+    protected function get_cardform_id(string $cardform): int {
+        return $this->option_id('cardform', $cardform, smartmenu::get_cardform_options());
+    }
+
+    /**
+     * Return the ID for the given cardoverflowbehaviour setting.
+     *
+     * @param string $cardoverflowbehaviour
+     * @return int
+     * @throws Exception
+     */
+    protected function get_cardoverflowbehaviour_id(string $cardoverflowbehaviour): int {
+        return $this->option_id('cardoverflowbehaviour', $cardoverflowbehaviour, smartmenu::get_cardoverflowbehaviour_options());
+    }
+
+    /**
+     * Given a comma-separated list of role shortnames, return an array of role IDs.
+     *
+     * @param string $roles
+     * @return array
+     * @throws Exception
+     */
+    protected function get_roles_id(string $roles): array {
+        $roleids = [];
+        foreach (explode(',', $roles) as $shortname) {
+            $shortname = trim($shortname);
+            if (empty($shortname)) {
+                continue;
+            }
+            $roleids[] = $this->get_role_id(strtolower($shortname));
+        }
+        return $roleids;
+    }
+
+    /**
+     * Return the ID for the given rolecontext setting.
+     *
+     * @param string $rolecontext
+     * @return int
+     * @throws Exception
+     */
+    protected function get_rolecontext_id(string $rolecontext): int {
+        return $this->option_id('rolecontext', $rolecontext, smartmenu::get_rolecontext_options());
+    }
+
+    /**
+     * Given a comma-separated list of cohort idnumbers, return an array of the cohort IDs.
+     *
+     * @param string $cohorts
+     * @return array
+     * @throws dml_exception
+     */
+    protected function get_cohorts_id(string $cohorts): array {
+        global $DB;
+        $cohortids = [];
+        foreach (explode(',', $cohorts) as $idnumber) {
+            $idnumber = trim($idnumber);
+            if (empty($idnumber)) {
+                continue;
+            }
+            $cohortids[] = $DB->get_field('cohort', 'id', ['idnumber' => $idnumber]);
+        }
+        return $cohortids;
+    }
+
+    /**
+     * Return the ID for the given operator setting.
+     *
+     * @param string $operator
+     * @return int
+     * @throws Exception
+     */
+    protected function get_operator_id(string $operator): int {
+        return $this->option_id('operator', $operator, smartmenu::get_operator_options());
+    }
+
+    /**
+     * Given a comma-separated list of language short codes, return an array of each trimmed value.
+     *
+     * @param string $languages
+     * @return array
+     */
+    protected function get_languages_id(string $languages): array {
+        return array_map('trim', explode(',', $languages));
+    }
+
+    /**
+     * Given the title of an existing Smart menu, return the menu ID.
+     *
+     * @param string $title
+     * @return int
+     * @throws dml_exception
+     */
+    protected function get_menu_id(string $title): int {
+        global $DB;
+        $id = $DB->get_field('theme_boost_union_menus', 'id', ['title' => $title]);
+        if (!$id) {
+            throw new Exception('Menu not found with title ' . $title);
+        }
+        return $id;
+    }
+
+    /**
+     * Return the ID for a given smart menu item type.
+     *
+     * @param string $type
+     * @return int
+     * @throws Exception
+     */
+    protected function get_itemtype_id(string $type): int {
+        return $this->option_id('itemtype', $type, smartmenu_item::get_types());
+    }
+
+    /**
+     * Given a comma-separated list of course category ID numbers, return an array of the category IDs.
+     *
+     * @param string $categories
+     * @return array
+     * @throws dml_exception
+     */
+    protected function get_categories_id(string $categories): array {
+        global $DB;
+        $categories = explode(',', $categories);
+        $categoryids = [];
+        foreach ($categories as $idnumber) {
+            $idnumber = trim($idnumber);
+            if (empty($idnumber)) {
+                continue;
+            }
+            $categoryids[] = $DB->get_field('course_categories', 'id', ['idnumber' => $idnumber]);
+        }
+        return $categoryids;
+    }
+
+    /**
+     * Return role IDs for the enrolmentrole setting. {@see get_roles_id}
+     *
+     * @param string $roles
+     * @return array
+     * @throws Exception
+     */
+    protected function get_enrolmentrole_id(string $roles): array {
+        return $this->get_roles_id($roles);
+    }
+
+    /**
+     * Given a comma-separated list of completion status settings, return an array of completion status IDs.
+     *
+     * @param string $completionstatuses
+     * @return array
+     * @throws Exception
+     */
+    protected function get_completionstatus_id(string $completionstatuses): array {
+        $completionstatusids = [];
+        $statuses = smartmenu_item::get_completionstatus_options();
+        foreach (explode(',', $completionstatuses) as $completionstatus) {
+            $completionstatusids[] = $this->option_id('completionstatus', $completionstatus, $statuses);
+        }
+        return $completionstatusids;
+    }
+
+    /**
+     * Given a comma-separated list of date range settings, return an array of date range IDs.
+     *
+     * @param string $dateranges
+     * @return array
+     * @throws Exception
+     */
+    protected function get_daterange_id(string $dateranges): array {
+        $daterangeids = [];
+        $ranges = smartmenu_item::get_daterange_options();
+        foreach (explode(',', $dateranges) as $daterange) {
+            $daterangeids[] = $this->option_id('daterange', $daterange, $ranges);
+        }
+        return $daterangeids;
+    }
+
+    /**
+     * Return an array of custom field settings.
+     *
+     * Given a comma-separated list of `name: value` pairs for custom fields, return an array of [name => value].
+     *
+     * @param string $customfields
+     * @return array
+     * @throws dml_exception
+     */
+    protected function get_customfields_id(string $customfields): array {
+        global $DB;
+        $customfields = explode(',', $customfields);
+        $customfieldids = [];
+        foreach ($customfields as $customfield) {
+            if (empty(trim($customfield))) {
+                continue;
+            }
+            [$identifier, $value] = explode(':', $customfield);
+            $identifier = trim($identifier);
+            $shortname = $DB->get_field_select(
+                'customfield_field',
+                'shortname',
+                'name = ? OR shortname = ?',
+                [$identifier, $identifier]
+            );
+            if (!$shortname) {
+                throw new Exception('No custom field found with name or shortname ' . $identifier);
+            }
+            $customfieldids[$shortname] = trim($value);
+        }
+        return $customfieldids;
+    }
+
+    /**
+     * Return the ID of the given listsort option.
+     *
+     * @param string $listsort
+     * @return int
+     * @throws Exception
+     */
+    protected function get_listsort_id(string $listsort): int {
+        return $this->option_id('listsort', $listsort, smartmenu_item::get_listsort_options());
+    }
+
+    /**
+     * Return the ID of the given displayfield option.
+     *
+     * @param string $displayfield
+     * @return int
+     * @throws Exception
+     */
+    protected function get_displayfield_id(string $displayfield): int {
+        return $this->option_id('displayfield', $displayfield, smartmenu_item::get_displayfield_options());
+    }
+
+    /**
+     * Return the ID of the given Smart menu item mode setting.
+     *
+     * @param string $mode
+     * @return int
+     * @throws Exception
+     */
+    protected function get_itemmode_id(string $mode): int {
+        return $this->option_id('itemmode', $mode, smartmenu_item::get_mode_options());
+    }
+
+    /**
+     * Return the ID of the given display setting.
+     *
+     * @param string $display
+     * @return int
+     * @throws Exception
+     */
+    protected function get_display_id(string $display): int {
+        return $this->option_id('display', $display, smartmenu_item::get_display_options());
+    }
+
+    /**
+     * Return the ID of the given target setting.
+     *
+     * @param string $target
+     * @return int
+     * @throws Exception
+     */
+    protected function get_target_id(string $target): int {
+        return $this->option_id('target', $target, smartmenu_item::get_target_options());
+    }
+
+    /**
+     * Return the ID of the given textposition setting.
+     *
+     * @param string $textposition
+     * @return int
+     * @throws Exception
+     */
+    protected function get_textposition_id(string $textposition): int {
+        return $this->option_id('textposition', $textposition, smartmenu_item::get_textposition_options());
+    }
+}

--- a/tests/generator/behat_theme_boost_union_generator.php
+++ b/tests/generator/behat_theme_boost_union_generator.php
@@ -66,6 +66,7 @@ class behat_theme_boost_union_generator extends behat_generator_base {
                     'cohorts' => 'cohorts',
                     'operator' => 'operator',
                     'languages' => 'languages',
+                    'byadmin' => 'byadmin',
                 ],
             ],
 
@@ -92,6 +93,7 @@ class behat_theme_boost_union_generator extends behat_generator_base {
                     'cohorts' => 'cohorts',
                     'operator' => 'operator',
                     'languages' => 'languages',
+                    'byadmin' => 'byadmin',
                 ],
             ],
         ];
@@ -275,6 +277,17 @@ class behat_theme_boost_union_generator extends behat_generator_base {
      */
     protected function get_operator_id(string $operator): int {
         return $this->option_id('operator', $operator, smartmenu::get_operator_options());
+    }
+
+    /**
+     * Return the ID for the given byadmin setting.
+     *
+     * @param string $byadmin
+     * @return int
+     * @throws Exception
+     */
+    protected function get_byadmin_id(string $byadmin): int {
+        return $this->option_id('byadmin', $byadmin, smartmenu::get_byadmin_options());
     }
 
     /**

--- a/tests/generator/behat_theme_boost_union_generator.php
+++ b/tests/generator/behat_theme_boost_union_generator.php
@@ -18,12 +18,12 @@ use theme_boost_union\smartmenu;
 use theme_boost_union\smartmenu_item;
 
 /**
- * Behat generator for Boost Union
+ * Theme Boost Union - Behat generator.
  *
- * @package   theme_boost_union
- * @copyright 2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
- * @author    Mark Johnson <mark.johnson@catalyst-eu.net>
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    theme_boost_union
+ * @copyright  2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
+ * @author     Mark Johnson <mark.johnson@catalyst-eu.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_theme_boost_union_generator extends behat_generator_base {
     /**

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -1,0 +1,357 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+use theme_boost_union\smartmenu;
+use theme_boost_union\smartmenu_item;
+
+/**
+ * Boost Union test data generator
+ *
+ * @package   theme_boost_union
+ * @copyright 2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
+ * @author    Mark Johnson <mark.johnson@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class theme_boost_union_generator extends component_generator_base {
+    /**
+     * Generate a smart menu.
+     *
+     * An array of one or more locations are required, which must match the smartmenu:LOCATION_* constants.
+     * All other properties are optional.
+     *
+     * @param array $data
+     * @return stdClass
+     */
+    public function create_smartmenu(array $data): \stdClass {
+        global $DB;
+        $location = $data['location'] ?? [];
+        if (empty($location)) {
+            throw new Exception('A Smart menu location must be specified.');
+        }
+        $validlocations = [
+            smartmenu::LOCATION_MAIN,
+            smartmenu::LOCATION_MENU,
+            smartmenu::LOCATION_BOTTOM,
+            smartmenu::LOCATION_USER,
+        ];
+        if (!empty(array_diff($validlocations, $location))) {
+            throw new Exception('Invalid Smart menu location.');
+        }
+        $validdescriptions = [
+            smartmenu::DESC_NEVER,
+            smartmenu::DESC_ABOVE,
+            smartmenu::DESC_BELOW,
+            smartmenu::DESC_HELP,
+        ];
+        $showdescription = $data['showdescription'] ?? smartmenu::DESC_NEVER;
+        if (!in_array($showdescription, $validdescriptions)) {
+            throw new Exception('Invalid showdescription.');
+        }
+        $validtypes = [
+            smartmenu::TYPE_LIST,
+            smartmenu::TYPE_CARD,
+        ];
+        $type = $data['type'] ?? smartmenu::TYPE_LIST;
+        if (!in_array($type, $validtypes)) {
+            throw new Exception('Invalid showdescription.');
+        }
+        $validmodes = [
+            smartmenu::MODE_SUBMENU,
+            smartmenu::MODE_INLINE,
+        ];
+        $mode = $data['mode'] ?? smartmenu::MODE_SUBMENU;
+        if (!in_array($mode, $validmodes)) {
+            throw new Exception('Invalid mode.');
+        }
+        $validbehaviours = [
+            smartmenu::MOREMENU_DONOTCHANGE,
+            smartmenu::MOREMENU_INTO,
+            smartmenu::MOREMENU_OUTSIDE,
+        ];
+        $moremenubehaviour = $data['moremenubehaviour'] ?? smartmenu::MOREMENU_DONOTCHANGE;
+        if (!in_array($moremenubehaviour, $validbehaviours)) {
+            throw new Exception('Invalid moremenubehaviour.');
+        }
+
+        $cardsize = null;
+        $cardform = null;
+        $cardoverflowbehaviour = null;
+        if ($type === smartmenu::TYPE_CARD) {
+            $validcardsizes = [
+                smartmenu::CARDSIZE_TINY,
+                smartmenu::CARDSIZE_SMALL,
+                smartmenu::CARDSIZE_MEDIUM,
+                smartmenu::CARDSIZE_LARGE,
+            ];
+            $cardsize = $data['cardsize'] ?? smartmenu::CARDSIZE_SMALL;
+            if (!in_array($cardsize, $validcardsizes)) {
+                throw new Exception('Invalid cardsize.');
+            }
+            $validcardforms = [
+                smartmenu::CARDFORM_SQUARE,
+                smartmenu::CARDFORM_PORTRAIT,
+                smartmenu::CARDFORM_LANDSCAPE,
+                smartmenu::CARDFORM_FULLWIDTH,
+            ];
+            $cardform = $data['cardform'] ?? smartmenu::CARDFORM_SQUARE;
+            if (!in_array($cardform, $validcardforms)) {
+                throw new Exception('Invalid cardform.');
+            }
+            $validbehaviours = [
+                smartmenu::CARDOVERFLOWBEHAVIOUR_NOWRAP,
+                smartmenu::CARDOVERFLOWBEHAVIOUR_WRAP,
+            ];
+            $cardoverflowbehaviour = strtolower($data['cardoverflowbehaviour']) ?? smartmenu::CARDOVERFLOWBEHAVIOUR_NOWRAP;
+            if (!in_array($cardoverflowbehaviour, $validbehaviours)) {
+                throw new Exception('Invalid cardoverflowbehaviour.');
+            }
+        }
+        [
+            $roles,
+            $rolecontext,
+            $cohorts,
+            $operator,
+            $languages,
+            $startdate,
+            $enddate,
+        ] = $this->parse_restrictions($data);
+
+        $sortorder = $data['sortorder'] ?? $DB->count_records('theme_boost_union_menus') + 1;
+        $record = (object)[
+            'title' => $data['title'] ?? 'Smart menu ' . random_string(),
+            'description' => $data['description'] ?? 'Smart menu description ' . random_string(),
+            'description_format' => $data['description_format'] ?? FORMAT_HTML,
+            'showdescription' => $showdescription,
+            'sortorder' => $sortorder,
+            'location' => json_encode($location),
+            'type' => $type,
+            'mode' => $mode,
+            'cssclass' => $data['cssclass'] ?? null,
+            'moremenubehaviour' => $moremenubehaviour,
+            'cardsize' => $cardsize,
+            'cardform' => $cardform,
+            'cardoverflowbehaviour' => $cardoverflowbehaviour,
+            'roles' => $roles,
+            'rolecontext' => $rolecontext,
+            'cohorts' => $cohorts,
+            'operator' => $operator,
+            'languages' => $languages,
+            'start_date' => $startdate,
+            'end_date' => $enddate,
+            'visible' => $data['visible'] ?? 1,
+        ];
+        $record->id = $DB->insert_record('theme_boost_union_menus', $record);
+        return $record;
+    }
+
+    /**
+     * Generate a Smart menu item.
+     *
+     * The ID of the parent menu must be specified. All other properties are optional.
+     *
+     * @param array $data
+     * @return stdClass
+     */
+    public function create_smartmenu_item(array $data): \stdClass {
+        global $DB;
+
+        if (!$DB->record_exists('theme_boost_union_menus', ['id' => $data['menu']])) {
+            throw new Exception('Menu not found with id ' . $data['menu']);
+        }
+
+        $sortorder = $data['sortorder'] ?? $DB->count_records('theme_boost_union_menus') + 1;
+
+        $validtypes = [
+            smartmenu_item::TYPESTATIC,
+            smartmenu_item::TYPEHEADING,
+            smartmenu_item::TYPEDYNAMIC,
+        ];
+        $type = $data['type'] ?? smartmenu_item::TYPESTATIC;
+        if (!in_array($type, $validtypes)) {
+            throw new Exception('Invalid type.');
+        }
+
+        $url = null;
+        if ($type === smartmenu_item::TYPESTATIC) {
+            if (empty($data['url'])) {
+                throw new Exception('URL is required when type is static.');
+            }
+            $url = $data['url'];
+        }
+
+        $category = json_encode($data['category'] ?? []);
+        $categorysubcats = $data['category_subcats'] ?? false;
+        $enrolmentrole = json_encode($data['enrolmentrole'] ?? []);
+        $completionstatus = json_encode($data['completionstatus'] ?? []);
+        $daterange = json_encode($data['daterange'] ?? []);
+        $customfields = json_encode($data['customfields'] ?? new stdClass());
+        $listsort = null;
+        $displayfield = null;
+        $textcount = null;
+        if ($type == smartmenu_item::TYPEDYNAMIC) {
+            $validsorts = [
+                smartmenu_item::LISTSORT_FULLNAME_ASC,
+                smartmenu_item::LISTSORT_FULLNAME_DESC,
+                smartmenu_item::LISTSORT_SHORTNAME_ASC,
+                smartmenu_item::LISTSORT_SHORTNAME_DESC,
+                smartmenu_item::LISTSORT_COURSEID_ASC,
+                smartmenu_item::LISTSORT_COURSEID_DESC,
+                smartmenu_item::LISTSORT_COURSEIDNUMBER_ASC,
+                smartmenu_item::LISTSORT_COURSEIDNUMBER_DESC,
+            ];
+            $listsort = $data['listsort'] ?? smartmenu_item::LISTSORT_FULLNAME_ASC;
+            if (!in_array($listsort, $validsorts)) {
+                throw new Exception('Invalid listsort.');
+            }
+            $validdisplayfields = [
+                smartmenu_item::FIELD_FULLNAME,
+                smartmenu_item::FIELD_SHORTNAME,
+            ];
+            $displayfield = $data['displayfield'] ?? smartmenu_item::FIELD_FULLNAME;
+            if (!in_array($displayfield, $validdisplayfields)) {
+                throw new Exception('Invalid displayfield.');
+            }
+            $textcount = $data['textcount'] ?? null;
+        }
+
+        $validmodes = [
+            smartmenu_item::MODE_INLINE,
+            smartmenu_item::MODE_SUBMENU,
+        ];
+        $mode = $data['mode'] ?? smartmenu_item::MODE_INLINE;
+        if (!in_array($mode, $validmodes)) {
+            throw new Exception('Invalid mode.');
+        }
+
+        $validdisplays = [
+            smartmenu_item::DISPLAY_SHOWTITLEICON,
+            smartmenu_item::DISPLAY_HIDETITLE,
+            smartmenu_item::DISPLAY_HIDETITLEMOBILE,
+        ];
+        $display = $data['display'] ?? smartmenu_item::DISPLAY_SHOWTITLEICON;
+        if (!in_array($display, $validdisplays)) {
+            throw new Exception('Invalid display.');
+        }
+
+        $validtargets = [
+            smartmenu_item::TARGET_SAME,
+            smartmenu_item::TARGET_NEW,
+        ];
+        $target = $data['target'] ?? smartmenu_item::TARGET_SAME;
+        if (!in_array($target, $validtargets)) {
+            throw new Exception('Invalid target.');
+        }
+
+        $validtextpositions = [
+            smartmenu_item::POSITION_BELOW,
+            smartmenu_item::POSITION_OVERLAYTOP,
+            smartmenu_item::POSITION_OVERLAYBOTTOM,
+        ];
+        $textposition = $data['textposition'] ?? smartmenu_item::POSITION_BELOW;
+        if (!in_array($textposition, $validtextpositions)) {
+            throw new Exception('Invalid text position.');
+        }
+
+        [
+            $roles,
+            $rolecontext,
+            $cohorts,
+            $operator,
+            $languages,
+            $startdate,
+            $enddate,
+        ] = $this->parse_restrictions($data);
+
+        $record = (object)[
+            'title' => $data['title'] ?? 'Smart menu item ' . random_string(),
+            'menu' => $data['menu'],
+            'type' => $type,
+            'sortorder' => $sortorder,
+            'url' => $url,
+            'category' => $category,
+            'category_subcats' => $categorysubcats,
+            'enrolmentrole' => $enrolmentrole,
+            'completionstatus' => $completionstatus,
+            'daterange' => $daterange,
+            'customfields' => $customfields,
+            'listsort' => $listsort,
+            'displayfield' => $displayfield,
+            'textcount' => $textcount,
+            'mode' => $mode,
+            'menuicon' => $data['menuicon'] ?? null,
+            'display' => $display,
+            'tooltip' => $data['tooltip'] ?? null,
+            'target' => $target,
+            'cssclass' => $data['cssclass'] ?? null,
+            'textposition' => $textposition,
+            'textcolor' => $data['textcolor'] ?? null,
+            'backgroundcolor' => $data['backgroundcolor'] ?? null,
+            'desktop' => $data['desktop'] ?? 0,
+            'tablet' => $data['tablet'] ?? 0,
+            'mobile' => $data['mobile'] ?? 0,
+            'roles' => $roles,
+            'rolecontext' => $rolecontext,
+            'cohorts' => $cohorts,
+            'operator' => $operator,
+            'languages' => $languages,
+            'start_date' => $startdate,
+            'end_date' => $enddate,
+            'visible' => $data['visible'] ?? 1,
+        ];
+        $record->id = $DB->insert_record('theme_boost_union_menuitems', $record);
+        return $record;
+    }
+
+    /**
+     * Parse the provided restriction fields to ensure they are valid and appropriately encoded.
+     *
+     * @param array $data
+     * @return array
+     * @throws Exception
+     */
+    protected function parse_restrictions(array $data): array {
+        $roles = $data['roles'] ?? [];
+        $rolecontext = null;
+        if (!empty($roles)) {
+            $validcontexts = array_keys(smartmenu::get_rolecontext_options());
+            $rolecontext = $data['rolecontext'] ?? smartmenu::ANYCONTEXT;
+            if (!in_array($rolecontext, $validcontexts)) {
+                throw new Exception('Invalid rolecontext.');
+            }
+        }
+        $cohorts = $data['cohorts'] ?? [];
+        $operator = null;
+        if (!empty($cohorts)) {
+            $validoperators = array_keys(smartmenu::get_operator_options());
+            $operator = $data['operator'] ?? smartmenu::ANY;
+            if (!in_array($operator, $validoperators)) {
+                throw new Exception('Invalid operator.');
+            }
+        }
+        $languages = $data['languages'] ?? [];
+        $startdate = $data['start_date'] ?? 0;
+        $enddate = $data['end_date'] ?? 0;
+        return [
+            json_encode($roles),
+            $rolecontext,
+            json_encode($cohorts),
+            $operator,
+            json_encode($languages),
+            $startdate,
+            $enddate,
+        ];
+    }
+}

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -18,12 +18,12 @@ use theme_boost_union\smartmenu;
 use theme_boost_union\smartmenu_item;
 
 /**
- * Boost Union test data generator
+ * Theme Boost Union - Test data generator.
  *
- * @package   theme_boost_union
- * @copyright 2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
- * @author    Mark Johnson <mark.johnson@catalyst-eu.net>
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    theme_boost_union
+ * @copyright  2024 onwards Catalyst IT EU {@link https://catalyst-eu.net}
+ * @author     Mark Johnson <mark.johnson@catalyst-eu.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class theme_boost_union_generator extends component_generator_base {
     /**

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -41,46 +41,26 @@ class theme_boost_union_generator extends component_generator_base {
         if (empty($location)) {
             throw new Exception('A Smart menu location must be specified.');
         }
-        $validlocations = [
-            smartmenu::LOCATION_MAIN,
-            smartmenu::LOCATION_MENU,
-            smartmenu::LOCATION_BOTTOM,
-            smartmenu::LOCATION_USER,
-        ];
+        $validlocations = array_keys(smartmenu::get_locations());
         if (!empty(array_diff($validlocations, $location))) {
             throw new Exception('Invalid Smart menu location.');
         }
-        $validdescriptions = [
-            smartmenu::DESC_NEVER,
-            smartmenu::DESC_ABOVE,
-            smartmenu::DESC_BELOW,
-            smartmenu::DESC_HELP,
-        ];
+        $validdescriptions = array_keys(smartmenu::get_showdescription_options());
         $showdescription = $data['showdescription'] ?? smartmenu::DESC_NEVER;
         if (!in_array($showdescription, $validdescriptions)) {
             throw new Exception('Invalid showdescription.');
         }
-        $validtypes = [
-            smartmenu::TYPE_LIST,
-            smartmenu::TYPE_CARD,
-        ];
+        $validtypes = array_keys(smartmenu::get_types());
         $type = $data['type'] ?? smartmenu::TYPE_LIST;
         if (!in_array($type, $validtypes)) {
             throw new Exception('Invalid showdescription.');
         }
-        $validmodes = [
-            smartmenu::MODE_SUBMENU,
-            smartmenu::MODE_INLINE,
-        ];
+        $validmodes = array_keys(smartmenu::get_mode_options());
         $mode = $data['mode'] ?? smartmenu::MODE_SUBMENU;
         if (!in_array($mode, $validmodes)) {
             throw new Exception('Invalid mode.');
         }
-        $validbehaviours = [
-            smartmenu::MOREMENU_DONOTCHANGE,
-            smartmenu::MOREMENU_INTO,
-            smartmenu::MOREMENU_OUTSIDE,
-        ];
+        $validbehaviours = array_keys(smartmenu::get_moremenu_options());
         $moremenubehaviour = $data['moremenubehaviour'] ?? smartmenu::MOREMENU_DONOTCHANGE;
         if (!in_array($moremenubehaviour, $validbehaviours)) {
             throw new Exception('Invalid moremenubehaviour.');
@@ -90,30 +70,17 @@ class theme_boost_union_generator extends component_generator_base {
         $cardform = null;
         $cardoverflowbehaviour = null;
         if ($type === smartmenu::TYPE_CARD) {
-            $validcardsizes = [
-                smartmenu::CARDSIZE_TINY,
-                smartmenu::CARDSIZE_SMALL,
-                smartmenu::CARDSIZE_MEDIUM,
-                smartmenu::CARDSIZE_LARGE,
-            ];
+            $validcardsizes = array_keys(smartmenu::get_cardsize_options());
             $cardsize = $data['cardsize'] ?? smartmenu::CARDSIZE_SMALL;
             if (!in_array($cardsize, $validcardsizes)) {
                 throw new Exception('Invalid cardsize.');
             }
-            $validcardforms = [
-                smartmenu::CARDFORM_SQUARE,
-                smartmenu::CARDFORM_PORTRAIT,
-                smartmenu::CARDFORM_LANDSCAPE,
-                smartmenu::CARDFORM_FULLWIDTH,
-            ];
+            $validcardforms = array_keys(smartmenu::get_cardform_options());
             $cardform = $data['cardform'] ?? smartmenu::CARDFORM_SQUARE;
             if (!in_array($cardform, $validcardforms)) {
                 throw new Exception('Invalid cardform.');
             }
-            $validbehaviours = [
-                smartmenu::CARDOVERFLOWBEHAVIOUR_NOWRAP,
-                smartmenu::CARDOVERFLOWBEHAVIOUR_WRAP,
-            ];
+            $validbehaviours = array_keys(smartmenu::get_cardoverflowbehaviour_options());
             $cardoverflowbehaviour = strtolower($data['cardoverflowbehaviour']) ?? smartmenu::CARDOVERFLOWBEHAVIOUR_NOWRAP;
             if (!in_array($cardoverflowbehaviour, $validbehaviours)) {
                 throw new Exception('Invalid cardoverflowbehaviour.');
@@ -124,6 +91,7 @@ class theme_boost_union_generator extends component_generator_base {
             $rolecontext,
             $cohorts,
             $operator,
+            $byadmin,
             $languages,
             $startdate,
             $enddate,
@@ -148,6 +116,7 @@ class theme_boost_union_generator extends component_generator_base {
             'rolecontext' => $rolecontext,
             'cohorts' => $cohorts,
             'operator' => $operator,
+            'byadmin' => $byadmin,
             'languages' => $languages,
             'start_date' => $startdate,
             'end_date' => $enddate,
@@ -174,11 +143,7 @@ class theme_boost_union_generator extends component_generator_base {
 
         $sortorder = $data['sortorder'] ?? $DB->count_records('theme_boost_union_menus') + 1;
 
-        $validtypes = [
-            smartmenu_item::TYPESTATIC,
-            smartmenu_item::TYPEHEADING,
-            smartmenu_item::TYPEDYNAMIC,
-        ];
+        $validtypes = array_keys(smartmenu_item::get_types());
         $type = $data['type'] ?? smartmenu_item::TYPESTATIC;
         if (!in_array($type, $validtypes)) {
             throw new Exception('Invalid type.');
@@ -202,24 +167,12 @@ class theme_boost_union_generator extends component_generator_base {
         $displayfield = null;
         $textcount = null;
         if ($type == smartmenu_item::TYPEDYNAMIC) {
-            $validsorts = [
-                smartmenu_item::LISTSORT_FULLNAME_ASC,
-                smartmenu_item::LISTSORT_FULLNAME_DESC,
-                smartmenu_item::LISTSORT_SHORTNAME_ASC,
-                smartmenu_item::LISTSORT_SHORTNAME_DESC,
-                smartmenu_item::LISTSORT_COURSEID_ASC,
-                smartmenu_item::LISTSORT_COURSEID_DESC,
-                smartmenu_item::LISTSORT_COURSEIDNUMBER_ASC,
-                smartmenu_item::LISTSORT_COURSEIDNUMBER_DESC,
-            ];
+            $validsorts = array_keys(smartmenu_item::get_listsort_options());
             $listsort = $data['listsort'] ?? smartmenu_item::LISTSORT_FULLNAME_ASC;
             if (!in_array($listsort, $validsorts)) {
                 throw new Exception('Invalid listsort.');
             }
-            $validdisplayfields = [
-                smartmenu_item::FIELD_FULLNAME,
-                smartmenu_item::FIELD_SHORTNAME,
-            ];
+            $validdisplayfields = array_keys(smartmenu_item::get_displayfield_options());
             $displayfield = $data['displayfield'] ?? smartmenu_item::FIELD_FULLNAME;
             if (!in_array($displayfield, $validdisplayfields)) {
                 throw new Exception('Invalid displayfield.');
@@ -236,30 +189,19 @@ class theme_boost_union_generator extends component_generator_base {
             throw new Exception('Invalid mode.');
         }
 
-        $validdisplays = [
-            smartmenu_item::DISPLAY_SHOWTITLEICON,
-            smartmenu_item::DISPLAY_HIDETITLE,
-            smartmenu_item::DISPLAY_HIDETITLEMOBILE,
-        ];
+        $validdisplays = array_keys(smartmenu_item::get_display_options());
         $display = $data['display'] ?? smartmenu_item::DISPLAY_SHOWTITLEICON;
         if (!in_array($display, $validdisplays)) {
             throw new Exception('Invalid display.');
         }
 
-        $validtargets = [
-            smartmenu_item::TARGET_SAME,
-            smartmenu_item::TARGET_NEW,
-        ];
+        $validtargets = array_keys(smartmenu_item::get_target_options());
         $target = $data['target'] ?? smartmenu_item::TARGET_SAME;
         if (!in_array($target, $validtargets)) {
             throw new Exception('Invalid target.');
         }
 
-        $validtextpositions = [
-            smartmenu_item::POSITION_BELOW,
-            smartmenu_item::POSITION_OVERLAYTOP,
-            smartmenu_item::POSITION_OVERLAYBOTTOM,
-        ];
+        $validtextpositions = array_keys(smartmenu_item::get_textposition_options());
         $textposition = $data['textposition'] ?? smartmenu_item::POSITION_BELOW;
         if (!in_array($textposition, $validtextpositions)) {
             throw new Exception('Invalid text position.');
@@ -270,6 +212,7 @@ class theme_boost_union_generator extends component_generator_base {
             $rolecontext,
             $cohorts,
             $operator,
+            $byadmin,
             $languages,
             $startdate,
             $enddate,
@@ -304,6 +247,7 @@ class theme_boost_union_generator extends component_generator_base {
             'mobile' => $data['mobile'] ?? 0,
             'roles' => $roles,
             'rolecontext' => $rolecontext,
+            'byadmin' => $byadmin,
             'cohorts' => $cohorts,
             'operator' => $operator,
             'languages' => $languages,
@@ -341,6 +285,11 @@ class theme_boost_union_generator extends component_generator_base {
                 throw new Exception('Invalid operator.');
             }
         }
+        $validbyadmins = array_keys(smartmenu::get_byadmin_options());
+        $byadmin = $data['byadmin'] ?? smartmenu::BYADMIN_ALL;
+        if (!in_array($byadmin, $validbyadmins)) {
+            throw new Exception('Invalid byadmin.');
+        }
         $languages = $data['languages'] ?? [];
         $startdate = $data['start_date'] ?? 0;
         $enddate = $data['end_date'] ?? 0;
@@ -349,6 +298,7 @@ class theme_boost_union_generator extends component_generator_base {
             $rolecontext,
             json_encode($cohorts),
             $operator,
+            $byadmin,
             json_encode($languages),
             $startdate,
             $enddate,


### PR DESCRIPTION
This does a bunch of optimisations for the longest-running behat features. See the commit messages for details of what I've done. Further optimisations are possible, but I don't have time to work on this any further at the moment. Hopefully the groundwork of adding the `behat_theme_boost_union` and `behat_theme_boost_union_generator` classes will make it easy for others to make further improvements.

In [my first run of these changes](https://github.com/marxjohnson/moodle-theme_boost_union/actions/runs/11957413640) the tests completed in 2.5 hours, vs the 3.5-4 hours I was getting previously., 

[x] link your issue in the PR title, using the keyword 'resolves #ISSUE-NUMBER', e.g. 'Feature: Provide the ultimate user experience, resolves #42'
[x provide any further information that is relevant for peer review and not yet mentioned in the linked issue as a comment in the PR
[x] make sure that the 'Allow edits by maintainers' checkbox is checked when creating the PR. Otherwise, the peer reviewer would not be able to push any review changes to the PR and the communication overhead increases
[x] submit your PR in draft status to run the automated checks and review the results
[x] in case any checks fail solve the mentioned errors by pushing the corrected code to your PR-branch
[x] if all checks pass (or if you are unable to resolve the failing steps without any help of the review team), mark the PR as 'ready for review'