### PR TITLE
Enable title in activity header on secure layout, resolved #766

### DIFF
--- a/config.php
+++ b/config.php
@@ -168,7 +168,12 @@ $THEME->layouts = [
     'secure' => [
         'file' => 'secure.php',
         'regions' => ['side-pre'],
-        'defaultregion' => 'side-pre'
+        'defaultregion' => 'side-pre',
+        'options' => [
+            'activityheader' => [
+                'notitle' => false,
+            ],
+        ],
     ]
 ];
 


### PR DESCRIPTION
Once MDL-75610, this will allow Boost Union to display the activity name in the secure layout.

Testing:
```bash
php admin/tool/behat/cli/init.php -a
php admin/tool/behat/cli/run.php --suite=boost_union --feature="$(pwd)/mod/quiz/accessrule/seb/tests/behat/secure_layout_activity_heading.feature"
```


[x] link your issue in the PR title, using the keyword 'resolves #ISSUE-NUMBER', e.g. 'Feature: Provide the ultimate user experience, resolves #42'
[x] provide any further information that is relevant for peer review and not yet mentioned in the linked issue as a comment in the PR
[x] make sure that the 'Allow edits by maintainers' checkbox is checked when creating the PR. Otherwise, the peer reviewer would not be able to push any review changes to the PR and the communication overhead increases
[x] submit your PR in draft status to run the automated checks and review the results
[ ] in case any checks fail solve the mentioned errors by pushing the corrected code to your PR-branch
[ ] if all checks pass (or if you are unable to resolve the failing steps without any help of the review team), mark the PR as 'ready for review'
