### PR TITLE
 Enable title in activity header on secure layout, resolved #766 (405 backport)

### DIFF
--- a/config.php
+++ b/config.php
@@ -168,7 +168,12 @@ $THEME->layouts = [
     'secure' => [
         'file' => 'secure.php',
         'regions' => ['side-pre'],
-        'defaultregion' => 'side-pre'
+        'defaultregion' => 'side-pre',
+        'options' => [
+            'activityheader' => [
+                'notitle' => false,
+            ],
+        ],
     ]
 ];
 


### PR DESCRIPTION
Backport of #770 for the MOODLE_405_STABLE branch.