### PR TITLE
Enable title in activity header on secure layout, resolves #766 (404 backport)

### DIFF
--- a/config.php
+++ b/config.php
@@ -168,7 +168,12 @@ $THEME->layouts = [
     'secure' => [
         'file' => 'secure.php',
         'regions' => ['side-pre'],
-        'defaultregion' => 'side-pre'
+        'defaultregion' => 'side-pre',
+        'options' => [
+            'activityheader' => [
+                'notitle' => false,
+            ],
+        ],
     ]
 ];
 


### PR DESCRIPTION
Backport of #770 for the MOODLE_404_STABLE branch.