### PR TITLE
Distinguish behat tests who deal with footer and footnote.

### DIFF
--- a/tests/behat/theme_boost_union_contentsettings_footer.feature
+++ b/tests/behat/theme_boost_union_contentsettings_footer.feature
@@ -1,4 +1,4 @@
-@theme @theme_boost_union @theme_boost_union_contentsettings @theme_boost_union_contentsettings_footer
+@theme @theme_boost_union @theme_boost_union_contentsettings @theme_boost_union_contentsettings_footer @theme_boost_union_footer @theme_boost_union_footnote
 Feature: Configuring the theme_boost_union plugin for the "Footer" tab on the "Content" page
   In order to use the features
   As admin

--- a/tests/behat/theme_boost_union_contentsettings_staticpages.feature
+++ b/tests/behat/theme_boost_union_contentsettings_staticpages.feature
@@ -1,4 +1,4 @@
-@theme @theme_boost_union @theme_boost_union_contentsettings @theme_boost_union_contentsettings_staticpages
+@theme @theme_boost_union @theme_boost_union_contentsettings @theme_boost_union_contentsettings_staticpages @theme_boost_union_footer @theme_boost_union_footnote
 Feature: Configuring the theme_boost_union plugin for the "Static pages" tab on the "Content" page
   In order to use the features
   As admin

--- a/tests/behat/theme_boost_union_feelsettings_links.feature
+++ b/tests/behat/theme_boost_union_feelsettings_links.feature
@@ -1,4 +1,4 @@
-@theme @theme_boost_union @theme_boost_union_feelsettings @theme_boost_union_feelsettings_links
+@theme @theme_boost_union @theme_boost_union_feelsettings @theme_boost_union_feelsettings_links @theme_boost_union_footnote
 Feature: Configuring the theme_boost_union plugin for the "Links" tab on the "Feel" page
   In order to use the features
   As admin

--- a/tests/behat/theme_boost_union_feelsettings_navigation.feature
+++ b/tests/behat/theme_boost_union_feelsettings_navigation.feature
@@ -1,4 +1,4 @@
-@theme @theme_boost_union @theme_boost_union_feelsettings @theme_boost_union_feelsettings_navigation
+@theme @theme_boost_union @theme_boost_union_feelsettings @theme_boost_union_feelsettings_navigation @theme_boost_union_footer
 Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on the "Feel" page
   In order to use the features
   As admin

--- a/tests/behat/theme_boost_union_feelsettings_pagelayouts.feature
+++ b/tests/behat/theme_boost_union_feelsettings_pagelayouts.feature
@@ -1,4 +1,4 @@
-@theme @theme_boost_union @theme_boost_union_feelsettings @theme_boost_union_feelsettings_pagelayouts
+@theme @theme_boost_union @theme_boost_union_feelsettings @theme_boost_union_feelsettings_pagelayouts @theme_boost_union_footer
 Feature: Configuring the theme_boost_union plugin for the "Page layouts" tab on the "Feel" page
   In order to use the features
   As admin

--- a/tests/behat/theme_boost_union_goodiesfordesigners.feature
+++ b/tests/behat/theme_boost_union_goodiesfordesigners.feature
@@ -1,4 +1,4 @@
-@theme @theme_boost_union @theme_boost_union_goodiesfordesigners
+@theme @theme_boost_union @theme_boost_union_goodiesfordesigners @theme_boost_union_footnote
 Feature: Using the goodies for designers in the theme_boost_union plugin
   In order to use the features
   As designer


### PR DESCRIPTION
The aim of those two tags is to potentially exclude tests that deal with footer and footnote.
In my place, I modify the .mustache so that the footer and footnote are completely different.
In consequence, the Behat test fail. But in this way, I could exclude the adhering Behat test (by instructing @theme_boost_union&&\~@theme_boost_union_footer&&\~@theme_boost_union_footnote)