### PR TITLE
PR for multiple flavour and child-theme related issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-12-31 - Tests: Increase the test coverage for the background image setting, helps to resolve theme_boost_union_child/#5
 * 2024-12-31 - Bugfix: In flavours, not setting the brand color / bootstrap colors in a flavour did not result in the global brand color / bootstrap colors being served properly, resolves #790.
 * 2024-12-30 - Improvement: Add more flavour settings (Activity icon colors, navbar color, background image position), resolves #789.
 * 2024-12-25 - Documentation: Explain the SCSS stack order in the README.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-12-31 - Child theme support: Fully replicate Boost Union's extra SCSS if a Boost Union Child theme is the current theme, resolves #718, resolves theme_boost_union_child/#5.
 * 2024-12-31 - Bugfix / Child theme support: The theme_boost_union_get_pre_scss() and theme_boost_union_get_extra_scss() function used $theme->settings although they should not do that anymore, resolves #791
 * 2024-12-31 - Tests: Increase the test coverage for the background image setting, helps to resolve theme_boost_union_child/#5
 * 2024-12-31 - Bugfix: In flavours, not setting the brand color / bootstrap colors in a flavour did not result in the global brand color / bootstrap colors being served properly, resolves #790.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-12-30 - Improvement: Add more flavour settings (Activity icon colors, navbar color, background image position), resolves #789.
 * 2024-12-25 - Documentation: Explain the SCSS stack order in the README.
 * 2024-12-25 - Bugfix: Fix the order in which all the pre SCSS assets are added to the SCSS stack, resolves #788.
 * 2024-12-22 - Feature: Allow overwriting of brand colors and the usage of SCSS (instead of pure CSS) in flavours, resolves #155.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-12-31 - Bugfix: In flavours, not setting the brand color / bootstrap colors in a flavour did not result in the global brand color / bootstrap colors being served properly, resolves #790.
 * 2024-12-30 - Improvement: Add more flavour settings (Activity icon colors, navbar color, background image position), resolves #789.
 * 2024-12-25 - Documentation: Explain the SCSS stack order in the README.
 * 2024-12-25 - Bugfix: Fix the order in which all the pre SCSS assets are added to the SCSS stack, resolves #788.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2024-12-31 - Bugfix / Child theme support: The theme_boost_union_get_pre_scss() and theme_boost_union_get_extra_scss() function used $theme->settings although they should not do that anymore, resolves #791
 * 2024-12-31 - Tests: Increase the test coverage for the background image setting, helps to resolve theme_boost_union_child/#5
 * 2024-12-31 - Bugfix: In flavours, not setting the brand color / bootstrap colors in a flavour did not result in the global brand color / bootstrap colors being served properly, resolves #790.
 * 2024-12-30 - Improvement: Add more flavour settings (Activity icon colors, navbar color, background image position), resolves #789.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes
 * 2024-12-25 - Documentation: Explain the SCSS stack order in the README.
 * 2024-12-25 - Bugfix: Fix the order in which all the pre SCSS assets are added to the SCSS stack, resolves #788.
 * 2024-12-22 - Feature: Allow overwriting of brand colors and the usage of SCSS (instead of pure CSS) in flavours, resolves #155.
+               Child theme support: If you are running a Boost Union Child theme, please make sure to adapt your child theme to our latest boilerplate.
 * 2024-12-15 - Feature: Add declaration of accessibility page and accessibility support page, resolves #567.
 
 ### v4.5-r4

--- a/classes/form/flavour_edit_form.php
+++ b/classes/form/flavour_edit_form.php
@@ -164,6 +164,39 @@ class flavour_edit_form extends \moodleform {
                 ]);
         $mform->addHelpButton('flavours_look_backgroundimage', 'flavoursbackgroundimage', 'theme_boost_union');
 
+        // Add background image position select element.
+        $this->check_slasharguments_warning($mform);
+        $backgroundimagepositionoptions = [
+                THEME_BOOST_UNION_SETTING_SELECT_NOCHANGE =>
+                        get_string('nochange', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_CENTER,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_TOP =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_TOP,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_CENTER_BOTTOM,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_TOP =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_TOP,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_CENTER =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_CENTER,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_LEFT_BOTTOM,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_TOP =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_TOP,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_CENTER =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_CENTER,
+                THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_BOTTOM =>
+                        THEME_BOOST_UNION_SETTING_IMAGEPOSITION_RIGHT_BOTTOM, ];
+        $backgroundimagepositionselect = $mform->addElement(
+                'select',
+                'look_backgroundimageposition',
+                get_string('flavoursbackgroundimageposition', 'theme_boost_union'),
+                $backgroundimagepositionoptions,
+                );
+        $mform->setType('look_backgroundimageposition', PARAM_TEXT);
+        $backgroundimagepositionselect->setSelected([THEME_BOOST_UNION_SETTING_SELECT_NOCHANGE]);
+        $mform->addHelpButton('look_backgroundimageposition', 'flavoursbackgroundimageposition', 'theme_boost_union');
+
         // Add brand colors heading.
         $context = new \stdClass();
         $context->title = get_string('brandcolorsheading', 'theme_boost_union', null, true);
@@ -234,6 +267,67 @@ class flavour_edit_form extends \moodleform {
         $mform->setType('look_bootstrapcolordanger', PARAM_TEXT);
         $mform->addRule('look_bootstrapcolordanger', get_string('validateerror', 'admin'), 'theme_boost_union_colorpicker_rule');
         $mform->addHelpButton('look_bootstrapcolordanger', 'flavoursbootstrapcolordanger', 'theme_boost_union');
+
+        // Add activity icon colors heading.
+        $context = new \stdClass();
+        $context->title = get_string('activityiconcolorsheading', 'theme_boost_union', null, true);
+        $mform->addElement(
+                'html',
+                '<div id="adminsettings">'.$OUTPUT->render_from_template('core_admin/setting_heading', $context).'</div>'
+        );
+
+        // Define all activity icon purposes (without the 'other' purpose as this is not branded).
+        $purposes = [MOD_PURPOSE_ADMINISTRATION,
+                MOD_PURPOSE_ASSESSMENT,
+                MOD_PURPOSE_COLLABORATION,
+                MOD_PURPOSE_COMMUNICATION,
+                MOD_PURPOSE_CONTENT,
+                MOD_PURPOSE_INTERACTIVECONTENT,
+                MOD_PURPOSE_INTERFACE];
+        // Iterate over all purposes.
+        foreach ($purposes as $purpose) {
+            // Setting: Activity icon color.
+            $this->check_slasharguments_warning($mform);
+            $mform->addElement(
+                    'theme_boost_union_colorpicker',
+                    'look_activityiconcolor'.$purpose,
+                    get_string('flavoursactivityiconcolor'.$purpose, 'theme_boost_union'),
+                            ['id' => 'colourpicker-activityiconcolor'.$purpose]);
+            $mform->setType('look_activityiconcolor'.$purpose, PARAM_TEXT);
+            $mform->addRule('look_activityiconcolor'.$purpose, get_string('validateerror', 'admin'),
+                    'theme_boost_union_colorpicker_rule');
+            $mform->addHelpButton('look_activityiconcolor'.$purpose, 'flavoursactivityiconcolor'.$purpose, 'theme_boost_union');
+        }
+
+        // Add navbar heading.
+        $context = new \stdClass();
+        $context->title = get_string('navbarheading', 'theme_boost_union', null, true);
+        $mform->addElement(
+                'html',
+                '<div id="adminsettings">'.$OUTPUT->render_from_template('core_admin/setting_heading', $context).'</div>'
+        );
+
+        // Add navbar color select element.
+        $navbarcoloroptions = [
+                THEME_BOOST_UNION_SETTING_SELECT_NOCHANGE =>
+                        get_string('nochange', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_NAVBARCOLOR_LIGHT =>
+                        get_string('navbarcolorsetting_light', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_NAVBARCOLOR_DARK =>
+                        get_string('navbarcolorsetting_dark', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_NAVBARCOLOR_PRIMARYLIGHT =>
+                        get_string('navbarcolorsetting_primarylight', 'theme_boost_union'),
+                THEME_BOOST_UNION_SETTING_NAVBARCOLOR_PRIMARYDARK =>
+                        get_string('navbarcolorsetting_primarydark', 'theme_boost_union'), ];
+        $navbarcolorselect = $mform->addElement(
+                'select',
+                'look_navbarcolor',
+                get_string('flavoursnavbarcolor', 'theme_boost_union'),
+                $navbarcoloroptions,
+                );
+        $mform->setType('look_navbarcolor', PARAM_TEXT);
+        $navbarcolorselect->setSelected([THEME_BOOST_UNION_SETTING_SELECT_NOCHANGE]);
+        $mform->addHelpButton('look_navbarcolor', 'flavoursnavbarcolor', 'theme_boost_union');
 
         // Add SCSS heading.
         $context = new \stdClass();

--- a/db/install.xml
+++ b/db/install.xml
@@ -20,6 +20,7 @@
         <FIELD NAME="look_logocompact" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="look_favicon" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="look_backgroundimage" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_backgroundimageposition" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="look_rawscss" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="look_rawscsspre" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="look_brandcolor" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
@@ -27,6 +28,14 @@
         <FIELD NAME="look_bootstrapcolorinfo" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="look_bootstrapcolorwarning" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="look_bootstrapcolordanger" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_activityiconcoloradministration" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_activityiconcolorassessment" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_activityiconcolorcollaboration" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_activityiconcolorcommunication" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_activityiconcolorcontent" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_activityiconcolorinteractivecontent" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_activityiconcolorinterface" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="look_navbarcolor" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -405,5 +405,87 @@ function xmldb_theme_boost_union_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2024100706, 'theme', 'boost_union');
     }
 
+    if ($oldversion < 2024100707) {
+
+        // Define table theme_boost_union_flavours to be altered.
+        $table = new xmldb_table('theme_boost_union_flavours');
+
+        // Define field look_backgroundimageposition to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_backgroundimageposition', XMLDB_TYPE_CHAR, '32', null, null, null, null,
+                'look_backgroundimage');
+
+        // Conditionally launch add field look_backgroundimageposition.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field look_activityiconcoloradministration to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_activityiconcoloradministration', XMLDB_TYPE_CHAR, '32', null, null, null, null);
+
+        // Conditionally launch add field look_activityiconcoloradministration.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field look_activityiconcolorasessment to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_activityiconcolorasessment', XMLDB_TYPE_CHAR, '32', null, null, null, null);
+
+        // Conditionally launch add field look_activityiconcolorasessment.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field look_activityiconcolorcollaboration to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_activityiconcolorcollaboration', XMLDB_TYPE_CHAR, '32', null, null, null, null);
+
+        // Conditionally launch add field look_activityiconcolorcollaboration.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field look_activityiconcolorcommunication to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_activityiconcolorcommunication', XMLDB_TYPE_CHAR, '32', null, null, null, null);
+
+        // Conditionally launch add field look_activityiconcolorcommunication.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field look_activityiconcolorcontent to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_activityiconcolorcontent', XMLDB_TYPE_CHAR, '32', null, null, null, null);
+
+        // Conditionally launch add field look_activityiconcolorcontent.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field look_activityiconcolorinteractivecontent to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_activityiconcolorinteractivecontent', XMLDB_TYPE_CHAR, '32', null, null, null, null);
+
+        // Conditionally launch add field look_activityiconcolorinteractivecontent.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field look_activityiconcolorinterface to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_activityiconcolorinterface', XMLDB_TYPE_CHAR, '32', null, null, null, null);
+
+        // Conditionally launch add field look_activityiconcolorinterface.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field look_navbarcolor to be added to theme_boost_union_flavours.
+        $field = new xmldb_field('look_navbarcolor', XMLDB_TYPE_CHAR, '32', null, null, null, null);
+
+        // Conditionally launch add field look_navbarcolor.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Boost_union savepoint reached.
+        upgrade_plugin_savepoint(true, 2024100707, 'theme', 'boost_union');
+    }
+
     return true;
 }

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -37,6 +37,7 @@ $string['githubissueslink'] = '<a href="https://github.com/moodle-an-hochschulen
 // General select options.
 $string['never'] = 'Never';
 $string['always'] = 'Always';
+$string['nochange'] = 'No change';
 $string['forguestsonly'] = 'Only for guests and non-logged-in users';
 
 // Settings: General strings.
@@ -1158,6 +1159,20 @@ $string['accessibilitysupportrecaptcha_desc'] = 'With this setting, you control 
 
 // Settings: Flavours page.
 $string['configtitleflavours'] = 'Flavours';
+$string['flavoursactivityiconcoloradministration'] = 'Activity icon color for "Administration"';
+$string['flavoursactivityiconcoloradministration_help'] = 'With this setting, the flavour will override the activity icon "Administration" color which is configured in Boost Union\'s look settings.';
+$string['flavoursactivityiconcolorassessment'] = 'Activity icon color for "Assessment"';
+$string['flavoursactivityiconcolorassessment_help'] = 'With this setting, the flavour will override the activity icon "Assessment" color which is configured in Boost Union\'s look settings.';
+$string['flavoursactivityiconcolorcollaboration'] = 'Activity icon color for "Collaboration"';
+$string['flavoursactivityiconcolorcollaboration_help'] = 'With this setting, the flavour will override the activity icon "Collaboration" color which is configured in Boost Union\'s look settings.';
+$string['flavoursactivityiconcolorcommunication'] = 'Activity icon color for "Communication"';
+$string['flavoursactivityiconcolorcommunication_help'] = 'With this setting, the flavour will override the activity icon "Communication" color which is configured in Boost Union\'s look settings.';
+$string['flavoursactivityiconcolorcontent'] = 'Activity icon color for "Content"';
+$string['flavoursactivityiconcolorcontent_help'] = 'With this setting, the flavour will override the activity icon "Content" color which is configured in Boost Union\'s look settings.';
+$string['flavoursactivityiconcolorinteractivecontent'] = 'Activity icon color for "Interactive content"';
+$string['flavoursactivityiconcolorinteractivecontent_help'] = 'With this setting, the flavour will override the activity icon "Interactive content" color which is configured in Boost Union\'s look settings.';
+$string['flavoursactivityiconcolorinterface'] = 'Activity icon color for "Interface"';
+$string['flavoursactivityiconcolorinterface_help'] = 'With this setting, the flavour will override the activity icon "Interface" color which is configured in Boost Union\'s look settings.';
 $string['flavoursappliesto'] = 'Applies to';
 $string['flavoursapplytocategories'] = 'Apply to course categories';
 $string['flavoursapplytocategories_help'] = 'Here, you define if this flavour should be applied to course categories.';
@@ -1169,6 +1184,8 @@ $string['flavoursapplytocohorts_ids'] = 'Cohorts';
 $string['flavoursapplytocohorts_ids_help'] = 'Here, you define one or more particular cohorts which this flavour should be applied to. As soon as the user is a member of one of the configured cohorts, the flavour is applied.<br /><br />Please note that, if you define more than one cohorts, there is no need for the user to be a member of all of them at the same time.<br /><br />Please also note that at the current state of implementation category cohorts are treated just as if they were system cohorts.';
 $string['flavoursbackgroundimage'] = 'Background image';
 $string['flavoursbackgroundimage_help'] = 'With this setting, the flavour will override the background image which is configured in Boost Union\'s look settings.';
+$string['flavoursbackgroundimageposition'] = 'Background image position';
+$string['flavoursbackgroundimageposition_help'] = 'With this setting, the flavour will override the background image position which is configured in Boost Union\'s look settings.';
 $string['flavoursbacktooverview'] = 'Back to flavour overview';
 $string['flavoursbootstrapcolordanger'] = 'Bootstrap color for "Danger"';
 $string['flavoursbootstrapcolordanger_help'] = 'With this setting, the flavour will override the Bootstrap "danger" color which is configured in Boost Union\'s look settings.';
@@ -1202,6 +1219,8 @@ $string['flavourslogo'] = 'Logo';
 $string['flavourslogo_help'] = 'With this setting, the flavour will override the logo which is configured in Boost Union\'s look settings.';
 $string['flavourslogocompact'] = 'Compact logo';
 $string['flavourslogocompact_help'] = 'With this setting, the flavour will override the logo which is configured in Boost Union\'s look settings.';
+$string['flavoursnavbarcolor'] = 'Navbar color';
+$string['flavoursnavbarcolor_help'] = 'With this setting, the flavour will override the navbar color which is configured in Boost Union\'s look settings.';
 $string['flavoursnotificationcreated'] = 'The flavour was created successfully';
 $string['flavoursnotificationdeleted'] = 'The flavour was deleted successfully';
 $string['flavoursnotificationedited'] = 'The flavour was edited successfully';

--- a/layout/includes/navbar.php
+++ b/layout/includes/navbar.php
@@ -24,8 +24,23 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+// Require flavours library.
+require_once($CFG->dirroot . '/theme/boost_union/flavours/flavourslib.php');
+
+// Get the flavour which applies to this page.
+$flavour = theme_boost_union_get_flavour_which_applies();
+// If a flavour applies to this page and if a navbar color is set in the flavour.
+if ($flavour != null &&
+        isset($flavour->look_navbarcolor) && $flavour->look_navbarcolor != THEME_BOOST_UNION_SETTING_SELECT_NOCHANGE) {
+    // Pick the navbar color from the flavour.
+    $navbarcolorsetting = $flavour->look_navbarcolor;
+
+    // Otherwise.
+} else {
+    // Pick the navbar color from the global setting.
+    $navbarcolorsetting = get_config('theme_boost_union', 'navbarcolor');
+}
 // Compose the navbar color classes based on the navbarcolor setting.
-$navbarcolorsetting = get_config('theme_boost_union', 'navbarcolor');
 switch($navbarcolorsetting) {
     case THEME_BOOST_UNION_SETTING_NAVBARCOLOR_DARK:
         $templatecontext['navbarcolorclasses'] = 'navbar-dark bg-dark';

--- a/lib.php
+++ b/lib.php
@@ -468,6 +468,7 @@ function theme_boost_union_get_extra_scss($theme) {
             // And add it to the SCSS code, adhering the fact that we must not overwrite the login page background image again.
             $content .= 'body:not(.pagelayout-login) { ';
             $content .= 'background-image: url("'.$backgroundimageurl.'");';
+            $content .= "background-size: cover;";
             $content .= '}';
         }
         // And if a background image position is set in the flavour.

--- a/lib.php
+++ b/lib.php
@@ -237,7 +237,7 @@ function theme_boost_union_get_pre_scss($theme) {
     // Prepend variables first.
     foreach ($configurable as $configkey => $targets) {
         // Get the global config value for the given config key.
-        $value = isset($theme->settings->{$configkey}) ? $theme->settings->{$configkey} : null;
+        $value = get_config('theme_boost_union', $configkey);
 
         // If any flavour applies to this page.
         if ($flavourid != null) {

--- a/lib.php
+++ b/lib.php
@@ -248,12 +248,11 @@ function theme_boost_union_get_pre_scss($theme) {
             }
             // Get the flavour config value for the given flavour id.
             $flavourvalue = theme_boost_union_get_flavour_config_item_for_flavourid($flavourid, $flavourconfigkey);
-            // If the value is not set, continue.
-            if ($flavourvalue == null || empty($flavourvalue)) {
-                continue;
+            // If a flavour value is set.
+            if ($flavourvalue != null && !empty($flavourvalue)) {
+                // Override the global config value with the flavour value.
+                $value = $flavourvalue;
             }
-            // Otherwise, override the global config value with the flavour value.
-            $value = $flavourvalue;
         }
 
         // If the value is not set, continue.

--- a/lib.php
+++ b/lib.php
@@ -208,6 +208,13 @@ function theme_boost_union_get_pre_scss($theme) {
     // We have to accept this fact here and must not copy the code from theme_boost_get_pre_scss into this function.
     // Instead, we must only add additionally CSS code which is based on any Boost Union-only functionality.
 
+    // But, well, there is one exception: Boost Union Child themes.
+    // Due to the described call chain, Boost Union Child won't get all the necessary extra SCSS.
+    // Thus, we fetch Boost's extra SCSS if the current theme is not Union itself (i.e. a Boost Union Child theme is active).
+    if (theme_boost_union_is_active_childtheme() == true) {
+        $scss .= theme_boost_get_pre_scss(\core\output\theme_config::load('boost_union'));
+    }
+
     // Include pre.scss from Boost Union.
     $scss .= file_get_contents($CFG->dirroot . '/theme/boost_union/scss/boost_union/pre.scss');
 
@@ -408,7 +415,14 @@ function theme_boost_union_get_extra_scss($theme) {
     // We have to accept this fact here and must not copy the code from theme_boost_get_extra_scss into this function.
     // Instead, we must only add additionally CSS code which is based on any Boost Union-only functionality.
 
-    // In contrast to Boost core, Boost Union should add the login page background to the body element as well.
+    // But, well, there is one exception: Boost Union Child themes.
+    // Due to the described call chain, Boost Union Child won't get all the necessary extra SCSS.
+    // Thus, we fetch Boost's extra SCSS if the current theme is not Union itself (i.e. a Boost Union Child theme is active).
+    if (theme_boost_union_is_active_childtheme() == true) {
+        $content .= theme_boost_get_extra_scss(\core\output\theme_config::load('boost_union'));
+    }
+
+    // Now, in contrast to Boost core, Boost Union should add the login page background to the body element as well.
     // Thus, check if a login background image is set.
     $loginbackgroundimagepresent = get_config('theme_boost_union', 'loginbackgroundimage');
     if (!empty($loginbackgroundimagepresent)) {

--- a/lib.php
+++ b/lib.php
@@ -26,6 +26,8 @@
 define('THEME_BOOST_UNION_SETTING_SELECT_YES', 'yes');
 define('THEME_BOOST_UNION_SETTING_SELECT_NO', 'no');
 
+define('THEME_BOOST_UNION_SETTING_SELECT_NOCHANGE', 'nochange');
+
 define('THEME_BOOST_UNION_SETTING_STATICPAGELINKPOSITION_NONE', 'none');
 define('THEME_BOOST_UNION_SETTING_STATICPAGELINKPOSITION_FOOTNOTE', 'footnote');
 define('THEME_BOOST_UNION_SETTING_STATICPAGELINKPOSITION_FOOTER', 'footer');
@@ -298,8 +300,21 @@ function theme_boost_union_get_pre_scss($theme) {
             MOD_PURPOSE_INTERFACE];
     // Iterate over all purposes.
     foreach ($purposes as $purpose) {
-        // Get color setting.
+        // Get color setting from global settings.
         $activityiconcolor = get_config('theme_boost_union', 'activityiconcolor'.$purpose);
+
+        // If any flavour applies to this page.
+        if ($flavourid != null) {
+            // Get color setting from flavour.
+            $activityiconcolorflavour = theme_boost_union_get_flavour_config_item_for_flavourid($flavourid,
+                    'look_activityiconcolor'.$purpose);
+
+            // If a flavour color is set.
+            if (!empty($activityiconcolorflavour)) {
+                // Override the global color setting with the flavour color setting.
+                $activityiconcolor = $activityiconcolorflavour;
+            }
+        }
 
         // If a color is set.
         if (!empty($activityiconcolor)) {
@@ -440,7 +455,7 @@ function theme_boost_union_get_extra_scss($theme) {
     $content .= "background-attachment: fixed;";
     $content .= '}';
 
-    // One more thing: Boost Union is also capable of overriding the background image in its flavours.
+    // One more thing: Boost Union is also capable of overriding the background image and background image position in its flavours.
     // So, if any flavour applies to this page.
     if ($flavourid != null) {
         // And if the flavour has a background image.
@@ -454,6 +469,16 @@ function theme_boost_union_get_extra_scss($theme) {
             // And add it to the SCSS code, adhering the fact that we must not overwrite the login page background image again.
             $content .= 'body:not(.pagelayout-login) { ';
             $content .= 'background-image: url("'.$backgroundimageurl.'");';
+            $content .= '}';
+        }
+        // And if a background image position is set in the flavour.
+        $backgroundimageposition = theme_boost_union_get_flavour_config_item_for_flavourid($flavourid,
+                'look_backgroundimageposition');
+        if ($backgroundimageposition != null && $backgroundimageposition != THEME_BOOST_UNION_SETTING_SELECT_NOCHANGE) {
+            // Set the background position in the SCSS code, adhering the fact that we must not overwrite the login page
+            // background image position again.
+            $content .= 'body:not(.pagelayout-login) { ';
+            $content .= "background-position: ".$backgroundimageposition.";";
             $content .= '}';
         }
     }

--- a/locallib.php
+++ b/locallib.php
@@ -2522,3 +2522,19 @@ function theme_boost_union_is_active_theme() {
         return false;
     }
 }
+
+/**
+ * Helper function to check if a child theme of Boost Union (and _not_ Boost Union itself) is active.
+ * This is needed at multiple locations to improve child theme support in Boost Union already.
+ *
+ * @return bool
+ */
+function theme_boost_union_is_active_childtheme() {
+    global $PAGE;
+
+    if ($PAGE->theme->name != 'boost_union') {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/tests/behat/behat_theme_boost_union_base_general.php
+++ b/tests/behat/behat_theme_boost_union_base_general.php
@@ -82,6 +82,33 @@ class behat_theme_boost_union_base_general extends behat_base {
     }
 
     /**
+     * Checks if the given DOM element has a background image with the given file name.
+     *
+     * @copyright 2024 Alexander Bias <bias@alexanderbias.de>
+     * @Then DOM element :arg1 should have background image with file name :arg2
+     * @param string $selector
+     * @param string $filename
+     * @throws ExpectationException
+     */
+    public function dom_element_should_have_background_image($selector, $filename) {
+        $stylejs = "
+            return (
+                window.getComputedStyle(document.querySelector('$selector')).getPropertyValue('background-image')
+            )
+        ";
+        $computedstyle = $this->evaluate_script($stylejs);
+        $urlmatches = [];
+        preg_match('/url\(["\']?(.*?)["\']?\)/', $computedstyle, $urlmatches);
+        $urlfromjs = $urlmatches[1];
+        $basenamefromjs = basename($urlfromjs);
+        if ($basenamefromjs != $filename) {
+            throw new ExpectationException('The \''.$selector.'\' DOM element does not have a background image with the file '.
+                    'name \''.$filename.'\', it has the file name \''.$basenamefromjs.'\' instead.',
+                            $this->getSession());
+        }
+    }
+
+    /**
      * Checks if the given DOM element has a CSS filter which is close enough to the given hex color.
      *
      * @copyright 2024 Alexander Bias <bias@alexanderbias.de>

--- a/tests/behat/theme_boost_union_flavourssettings_look.feature
+++ b/tests/behat/theme_boost_union_flavourssettings_look.feature
@@ -4,6 +4,14 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   As admin
   I need to be able to configure the theme Boost Union plugin
 
+  Background:
+    Given the following "categories" exist:
+      | name   | category | idnumber |
+      | Cat 1  | 0        | CAT1     |
+    And the following "courses" exist:
+      | fullname  | shortname | category |
+      | Course 1  | C1        | CAT1     |
+
   # Unfortunately, this can't be tested with Behat yet as the full logo is not displayed anywhere outside the login page
   # Scenario: Flavours: Logo - Upload a logo (with a global logo not having been uploaded before)
 
@@ -128,14 +136,87 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
   # Unfortunately, this can't be tested with Behat yet as the background image is added via external CSS which can't be referenced with XPath
   # Scenario: Flavours: Background image - Do not upload a background image (with a global background image being served properly)
 
+  @javascript @_file_upload
+  Scenario Outline: Flavours: Background image - Define the background image position (with a global color not having been set before)
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.png" file to "Background image" filemanager
+    And I set the field "look_backgroundimageposition" to "<position>"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then DOM element "body" should have computed style "background-position" "<cssvalue>"
+
+    # We do not want to burn too much CPU time by testing all available options. We just test one non-default value.
+    Examples:
+      | position      | cssvalue |
+      | center center | 50% 50%  |
+
+  @javascript @_file_upload
+  Scenario Outline: Flavours: Background image - Define the background image position(with the global setting being overridden)
+    Given the following config values are set as admin:
+      | config                  | value            | plugin            |
+      | backgroundimageposition | <globalposition> | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.png" file to "Background image" filemanager
+    And I set the field "look_backgroundimageposition" to "<position>"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then DOM element "body" should have computed style "background-position" "<cssvalue>"
+    And DOM element "body" should not have computed style "background-position" "<shouldnotcssvalue>"
+
+    # We do not want to burn too much CPU time by testing all available options. We just test one non-default value.
+    Examples:
+      | globalposition | position      | cssvalue | shouldnotcssvalue |
+      | bottom right   | center center | 50% 50%  | 100% 100%         |
+
+  @javascript @_file_upload
+  Scenario Outline: Flavours: Background image - Do not define the background image position (with a global setting being served properly)
+    Given the following config values are set as admin:
+      | config                  | value      | plugin            |
+      | backgroundimageposition | <position> | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.png" file to "Background image" filemanager
+    And I set the field "look_backgroundimageposition" to "No change"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then DOM element "body" should have computed style "background-position" "<cssvalue>"
+
+    # We do not want to burn too much CPU time by testing all available options. We just test one non-default value.
+    Examples:
+      | position      | cssvalue |
+      | center center | 50% 50%  |
+
   @javascript
   Scenario: Flavours: Brand color - Set the brand color
-    Given the following "categories" exist:
-      | name   | category | idnumber |
-      | Cat 1  | 0        | CAT1     |
-    And the following "courses" exist:
-      | fullname  | shortname | category |
-      | Course 1  | C1        | CAT1     |
     When I log in as "admin"
     And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
@@ -158,12 +239,6 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
 
   @javascript
   Scenario Outline: Flavours: Bootstrap colors - Set the Bootstrap colors
-    Given the following "categories" exist:
-      | name   | category | idnumber |
-      | Cat 1  | 0        | CAT1     |
-    And the following "courses" exist:
-      | fullname  | shortname | category |
-      | Course 1  | C1        | CAT1     |
     When I log in as "admin"
     And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
@@ -190,6 +265,188 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
       | info    | #00FF00  | rgb(0, 255, 0)   |
       | warning | #0000FF  | rgb(0, 0, 255)   |
       | danger  | #FFFF00  | rgb(255, 255, 0) |
+
+  @javascript
+  Scenario Outline: Flavours: Activity icon colors - Setting the color (with a global color not having been set before)
+    Given the following config values are set as admin:
+      | config                    | value | plugin            |
+      | activityiconcolorfidelity | 500   | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I set the field "look_activityiconcolor<purposename>" to "<colorhex>"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I turn editing mode on
+    And I click on "Add an activity or resource" "button" in the "New section" "section"
+    # First, we test that the default filter is _not_ set anymore.
+    Then DOM element ".chooser-container .activityiconcontainer.modicon_<modname> img" should not have computed style "filter" "<originalfilter>"
+    # And then, as the hex color to CSS filter conversion results are not reproducible, we test if the applied filter is close enough to the hex color.
+    And DOM element ".chooser-container .activityiconcontainer.modicon_<modname> img" should have a CSS filter close enough to hex color "<colorhex>"
+
+    # Unfortunately, we can only test 4 out of 6 purpose types as Moodle does does not ship with any activity with the
+    # administration and interface types. But this should be an acceptable test coverage anyway.
+    Examples:
+      | purposename        | modname | colorhex | originalfilter                                                                              |
+      | assessment         | assign  | #FF0000  | invert(0.36) sepia(0.98) saturate(69.69) hue-rotate(315deg) brightness(0.9) contrast(1.19)  |
+      | collaboration      | data    | #00FF00  | invert(0.25) sepia(0.54) saturate(62.26) hue-rotate(245deg) brightness(1) contrast(1.02)    |
+      | communication      | choice  | #0000FF  | invert(0.48) sepia(0.74) saturate(48.87) hue-rotate(11deg) brightness(1.02) contrast(1.01)  |
+      | content            | book    | #FFFF00  | invert(0.49) sepia(0.52) saturate(46.75) hue-rotate(156deg) brightness(0.89) contrast(1.02) |
+      | interactivecontent | lesson  | #00FFFF  | invert(0.25) sepia(0.63) saturate(11.52) hue-rotate(344deg) brightness(0.94) contrast(0.91) |
+
+  @javascript
+  Scenario Outline: Flavours: Activity icon colors - Setting the color (with the global setting being overridden)
+    Given the following config values are set as admin:
+      | config                         | value   | plugin            |
+      | activityiconcolor<purposename> | #00FFFF | theme_boost_union |
+    And the following config values are set as admin:
+      | config                    | value | plugin            |
+      | activityiconcolorfidelity | 500   | theme_boost_union |
+    And the theme cache is purged and the theme is reloaded
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I set the field "look_activityiconcolor<purposename>" to "<colorhex>"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I turn editing mode on
+    And I click on "Add an activity or resource" "button" in the "New section" "section"
+    # First, we test that the default filter is _not_ set anymore.
+    Then DOM element ".chooser-container .activityiconcontainer.modicon_<modname> img" should not have computed style "filter" "<originalfilter>"
+    # And then, as the hex color to CSS filter conversion results are not reproducible, we test if the applied filter is close enough to the hex color.
+    And DOM element ".chooser-container .activityiconcontainer.modicon_<modname> img" should have a CSS filter close enough to hex color "<colorhex>"
+
+    # We only test 1 out of 6 purpose types as we have tested the rest already in the previous scenario.
+    Examples:
+      | purposename | modname | colorhex | originalfilter                                                                             |
+      | assessment  | assign  | #FF0000  | invert(0.36) sepia(0.98) saturate(69.69) hue-rotate(315deg) brightness(0.9) contrast(1.19) |
+
+  @javascript
+  Scenario Outline: Flavours: Activity icon colors - Do not set the color (with a global setting being served properly)
+    Given the following config values are set as admin:
+      | config                         | value      | plugin            |
+      | activityiconcolor<purposename> | <colorhex> | theme_boost_union |
+    And the following config values are set as admin:
+      | config                    | value | plugin            |
+      | activityiconcolorfidelity | 500   | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I turn editing mode on
+    And I click on "Add an activity or resource" "button" in the "New section" "section"
+    # First, we test that the default filter is _not_ set anymore.
+    Then DOM element ".chooser-container .activityiconcontainer.modicon_<modname> img" should not have computed style "filter" "<originalfilter>"
+    # And then, as the hex color to CSS filter conversion results are not reproducible, we test if the applied filter is close enough to the hex color.
+    And DOM element ".chooser-container .activityiconcontainer.modicon_<modname> img" should have a CSS filter close enough to hex color "<colorhex>"
+
+    # We only test 1 out of 6 purpose types as we have tested the rest already in the previous scenario.
+    Examples:
+      | purposename | modname | colorhex | originalfilter                                                                             |
+      | assessment  | assign  | #FF0000  | invert(0.36) sepia(0.98) saturate(69.69) hue-rotate(315deg) brightness(0.9) contrast(1.19) |
+
+  @javascript
+  Scenario Outline: Setting: Navbar color - Set the navbar color (with a global color not having been set before)
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I set the field "Navbar color" to "<setting>"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then the "class" attribute of ".navbar" "css_element" should contain "<classes>"
+
+    Examples:
+      | setting      | classes                 |
+      | light        | navbar-light bg-white   |
+      | dark         | navbar-dark bg-dark     |
+      | primarylight | navbar-light bg-primary |
+      | primarydark  | navbar-dark bg-primary  |
+
+  @javascript
+  Scenario Outline: Setting: Navbar color - Set the navbar color (with the global setting being overridden)
+    Given the following config values are set as admin:
+      | config      | value           | plugin            |
+      | navbarcolor | <globalsetting> | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I set the field "Navbar color" to "<setting>"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then the "class" attribute of ".navbar" "css_element" should contain "<classes>"
+    And the "class" attribute of ".navbar" "css_element" should not contain "<shouldnotclasses>"
+
+    # We only test 1 out of 4 color types as we have tested the rest already in the previous scenario.
+    Examples:
+      | globalsetting | setting | classes               | shouldnotclasses    |
+      | dark          | light   | navbar-light bg-white | navbar-dark bg-dark |
+
+  @javascript
+  Scenario Outline: Setting: Navbar color - Do not set the navbar color (with a global setting being served properly)
+    Given the following config values are set as admin:
+      | config      | value     | plugin            |
+      | navbarcolor | <setting> | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I set the field "Navbar color" to "No change"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then the "class" attribute of ".navbar" "css_element" should contain "<classes>"
+
+    # We only test 1 out of 4 color types as we have tested the rest already in the previous scenario.
+    Examples:
+      | setting | classes             |
+      | dark    | navbar-dark bg-dark |
 
   @javascript
   Scenario: Flavours: Raw (initial) SCSS - Add custom SCSS to the page

--- a/tests/behat/theme_boost_union_flavourssettings_look.feature
+++ b/tests/behat/theme_boost_union_flavourssettings_look.feature
@@ -216,7 +216,7 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
       | center center | 50% 50%  |
 
   @javascript
-  Scenario: Flavours: Brand color - Set the brand color
+  Scenario: Flavours: Brand color - Set the brand color (with a global color not having been set before)
     When I log in as "admin"
     And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
@@ -238,7 +238,56 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
     Then DOM element ".mytesttext" should have computed style "color" "rgb(255, 0, 0)"
 
   @javascript
-  Scenario Outline: Flavours: Bootstrap colors - Set the Bootstrap colors
+  Scenario: Flavours: Brand color - Set the brand color (with the global setting being overridden)
+    Given the following config values are set as admin:
+      | config     | value   | plugin            |
+      | brandcolor | #FFFFFF | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I set the field "look_brandcolor" to "#FF0000"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    And the following "activities" exist:
+      | activity | name      | intro                                                     | course |
+      | label    | Label one | <span class="mytesttext text-primary">My test text</span> | C1     |
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I should see "My test text"
+    Then DOM element ".mytesttext" should have computed style "color" "rgb(255, 0, 0)"
+
+  @javascript
+  Scenario: Flavours: Brand color - Do not set the brand color (with a global setting being served properly)
+    Given the following config values are set as admin:
+      | config     | value   | plugin            |
+      | brandcolor | #FF0000 | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    And the following "activities" exist:
+      | activity | name      | intro                                                     | course |
+      | label    | Label one | <span class="mytesttext text-primary">My test text</span> | C1     |
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I should see "My test text"
+    Then DOM element ".mytesttext" should have computed style "color" "rgb(255, 0, 0)"
+
+  @javascript
+  Scenario Outline: Flavours: Bootstrap colors - Set the Bootstrap colors (with a global color not having been set before)
     When I log in as "admin"
     And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And I click on "Create flavour" "button"
@@ -265,6 +314,65 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
       | info    | #00FF00  | rgb(0, 255, 0)   |
       | warning | #0000FF  | rgb(0, 0, 255)   |
       | danger  | #FFFF00  | rgb(255, 255, 0) |
+
+  @javascript
+  Scenario Outline: Flavours: Bootstrap colors - Set the Bootstrap colors (with the global setting being overridden)
+    Given the following config values are set as admin:
+      | config               | value   | plugin            |
+      | bootstrapcolor<type> | #FFFFFF | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I set the field "look_bootstrapcolor<type>" to "<colorhex>"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    And the following "activities" exist:
+      | activity | name      | intro                                                    | course |
+      | label    | Label one | <span class="mytesttext text-<type>">My test text</span> | C1     |
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I should see "My test text"
+    Then DOM element ".mytesttext" should have computed style "color" "<colorrgb>"
+
+    # We only test 1 out of 4 color types as we have tested the rest already in the previous scenario.
+    Examples:
+      | type    | colorhex | colorrgb       |
+      | success | #FF0000  | rgb(255, 0, 0) |
+
+  @javascript
+  Scenario Outline: Flavours: Bootstrap colors - Do not set the Bootstrap colors (with a global setting being served properly)
+    Given the following config values are set as admin:
+      | config               | value      | plugin            |
+      | bootstrapcolor<type> | <colorhex> | theme_boost_union |
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    And the following "activities" exist:
+      | activity | name      | intro                                                    | course |
+      | label    | Label one | <span class="mytesttext text-<type>">My test text</span> | C1     |
+    When I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I should see "My test text"
+    Then DOM element ".mytesttext" should have computed style "color" "<colorrgb>"
+
+    # We only test 1 out of 4 color types as we have tested the rest already in the previous scenario.
+    Examples:
+      | type    | colorhex | colorrgb       |
+      | success | #FF0000  | rgb(255, 0, 0) |
 
   @javascript
   Scenario Outline: Flavours: Activity icon colors - Setting the color (with a global color not having been set before)

--- a/tests/behat/theme_boost_union_flavourssettings_look.feature
+++ b/tests/behat/theme_boost_union_flavourssettings_look.feature
@@ -127,14 +127,73 @@ Feature: Configuring the theme_boost_union plugin on the "Flavours" page, applyi
     # We can't check the uploaded image file visually, but we can verify that the favicon is shipped from the theme_boost_union global favicon filearea.
     Then "//head//link[contains(@rel, 'shortcut')][contains(@href, 'pluginfile.php/1/theme_boost_union/favicon')][contains(@href, 'favicon.ico')]" "xpath_element" should exist
 
-  # Unfortunately, this can't be tested with Behat yet as the background image is added via external CSS which can't be referenced with XPath
-  # Scenario: Flavours: Background image - Upload a background image (with a global background image not having been uploaded before)
+  @javascript @_file_upload
+  Scenario: Flavours: Background image - Upload a background image (with a global background image not having been uploaded before)
+    When I log in as "admin"
+    And I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I upload "theme/boost_union/tests/fixtures/login_bg2.png" file to "Background image" filemanager
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    And I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then DOM element "body" should have computed style "background-size" "cover"
+    And DOM element "body" should have background image with file name "login_bg2.png"
 
-  # Unfortunately, this can't be tested with Behat yet as the background image is added via external CSS which can't be referenced with XPath
-  # Scenario: Flavours: Background image - Upload a background image (with a global background image being overridden)
+  @javascript @_file_upload
+  Scenario: Flavours: Background image - Upload a background image (with a global background image being overridden)
+    Given I log in as "admin"
+    And Behat debugging is disabled
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Site branding" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.png" file to "Background image" filemanager
+    And I press "Save changes"
+    And Behat debugging is enabled
+    When I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I upload "theme/boost_union/tests/fixtures/login_bg2.png" file to "Background image" filemanager
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    And I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then DOM element "body" should have computed style "background-size" "cover"
+    And DOM element "body" should have background image with file name "login_bg2.png"
 
-  # Unfortunately, this can't be tested with Behat yet as the background image is added via external CSS which can't be referenced with XPath
-  # Scenario: Flavours: Background image - Do not upload a background image (with a global background image being served properly)
+  @javascript @_file_upload
+  Scenario: Flavours: Background image - Do not upload a background image (with a global background image being served properly)
+    Given I log in as "admin"
+    And Behat debugging is disabled
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Site branding" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.png" file to "Background image" filemanager
+    And I press "Save changes"
+    And Behat debugging is enabled
+    When I navigate to "Appearance > Boost Union > Flavours" in site administration
+    And I click on "Create flavour" "button"
+    And I should see "Create flavour" in the "#page-header h1" "css_element"
+    And I expand all fieldsets
+    And I set the field "Title" to "My shiny new flavour"
+    And I select "Yes" from the "Apply to course categories" singleselect
+    And I click on ".form-autocomplete-downarrow" "css_element" in the "#fitem_id_applytocategories_ids" "css_element"
+    And I click on "Cat 1" item in the autocomplete list
+    And I press the escape key
+    And I click on "Save changes" "button"
+    And I log in as "admin"
+    And I am on "Course 1" course homepage
+    Then DOM element "body" should have computed style "background-size" "cover"
+    And DOM element "body" should have background image with file name "login_bg1.png"
 
   @javascript @_file_upload
   Scenario Outline: Flavours: Background image - Define the background image position (with a global color not having been set before)

--- a/tests/behat/theme_boost_union_looksettings_loginpage.feature
+++ b/tests/behat/theme_boost_union_looksettings_loginpage.feature
@@ -4,12 +4,14 @@ Feature: Configuring the theme_boost_union plugin for the "Login page" tab on th
   As admin
   I need to be able to configure the theme Boost Union plugin
 
+  @javascript
   Scenario: Setting: Login page background images - Do not upload any login background image
     When I am on site homepage
     And I click on "Log in" "link" in the ".logininfo" "css_element"
     Then the "class" attribute of "body" "css_element" should contain "path-login"
     And the "class" attribute of "body" "css_element" should not contain "loginbackgroundimage"
     And the "class" attribute of "body" "css_element" should not contain "loginbackgroundimage1"
+    And DOM element "body" should have computed style "background-image" "none"
 
   @javascript @_file_upload
   Scenario: Setting: Login page background images - Upload one custom login background image
@@ -25,6 +27,8 @@ Feature: Configuring the theme_boost_union plugin for the "Login page" tab on th
     Then the "class" attribute of "body" "css_element" should contain "path-login"
     And the "class" attribute of "body" "css_element" should contain "loginbackgroundimage"
     And the "class" attribute of "body" "css_element" should contain "loginbackgroundimage1"
+    And DOM element "body" should have computed style "background-size" "cover"
+    And DOM element "body" should have background image with file name "login_bg1.png"
 
   @javascript @_file_upload
   Scenario: Setting: Login page background images - Upload multiple custom login background image (and have one picked randomly)
@@ -45,6 +49,8 @@ Feature: Configuring the theme_boost_union plugin for the "Login page" tab on th
     # However, the random image picking function is designed to detect Behat runs and will then always ship the
     # image matching the number of uploaded images (i.e. if you upload 3 images, you will get the third).
     And the "class" attribute of "body" "css_element" should contain "loginbackgroundimage3"
+    And DOM element "body" should have computed style "background-size" "cover"
+    And DOM element "body" should have background image with file name "login_bg3.png"
 
   @javascript @_file_upload
   Scenario Outline: Setting: Login page background images - Define the background image position.

--- a/tests/behat/theme_boost_union_looksettings_sitebranding.feature
+++ b/tests/behat/theme_boost_union_looksettings_sitebranding.feature
@@ -153,6 +153,25 @@ Feature: Configuring the theme_boost_union plugin for the "Site branding" tab on
     And "//head//link[contains(@rel, 'shortcut')][contains(@href, 'pluginfile.php/1/theme_boost_union/favicon')][contains(@href, 'favicon.ico')]" "xpath_element" should not exist
 
   @javascript @_file_upload
+  Scenario: Setting: Background image - Upload a background image.
+    When I log in as "admin"
+    And Behat debugging is disabled
+    And I navigate to "Appearance > Boost Union > Look" in site administration
+    And I click on "Site branding" "link" in the "#adminsettings .nav-tabs" "css_element"
+    And I upload "theme/boost_union/tests/fixtures/login_bg1.png" file to "Background image" filemanager
+    And I press "Save changes"
+    And Behat debugging is enabled
+    And I am on site homepage
+    Then DOM element "body" should have computed style "background-size" "cover"
+    And DOM element "body" should have background image with file name "login_bg1.png"
+
+  @javascript
+  Scenario: Setting: Background image - Do not upload a background image (countercheck).
+    When I log in as "admin"
+    And I am on site homepage
+    Then DOM element "body" should have computed style "background-image" "none"
+
+  @javascript @_file_upload
   Scenario Outline: Setting: Background image - Define the background image position.
     Given the following config values are set as admin:
       | config                  | value      | plugin            |

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2024100706;
+$plugin->version = 2024100707;
 $plugin->release = 'v4.5-r4';
 $plugin->requires = 2024100700;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
This PR fixes multiple flavour and child-theme related issues:

```
* 2024-12-31 - Child theme support: Fully replicate Boost Union's extra SCSS if a Boost Union Child theme is the current theme, resolves #718, resolves theme_boost_union_child/#5.
* 2024-12-31 - Bugfix / Child theme support: The theme_boost_union_get_pre_scss() and theme_boost_union_get_extra_scss() function used $theme->settings although they should not do that anymore, resolves #791
* 2024-12-31 - Tests: Increase the test coverage for the background image setting, helps to resolve theme_boost_union_child/#5
* 2024-12-31 - Bugfix: In flavours, not setting the brand color / bootstrap colors in a flavour did not result in the global brand color / bootstrap colors being served properly, resolves #790.
* 2024-12-30 - Improvement: Add more flavour settings (Activity icon colors, navbar color, background image position), resolves #789.
```