### PR TITLE
Bugfix: Fix dynamic course items not updating properly based on course role assignments. resolves #749.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,9 @@ moodle-theme_boost_union
 
 Changes
 -------
-
 ### Unreleased
 
+* 2025-02-04 - Bugfix: Fix smart menu dynamic course items not updating properly based on course role assignments, resolves #749.
 * 2025-02-04 - Bugfix: Smart menu item pointing to external site gets highlighted as active by mistake, resolves #758.
 * 2025-02-04 - Improvement: Allow changing of home URL on small devices as well, resolves #802.
 * 2025-01-31 - Improvement: Add option to include alt text for item image in smart menu cards, resolves #752.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ moodle-theme_boost_union
 
 Changes
 -------
+
 ### Unreleased
 
 * 2025-02-04 - Bugfix: Fix smart menu dynamic course items not updating properly based on course role assignments, resolves #749.

--- a/classes/eventobservers.php
+++ b/classes/eventobservers.php
@@ -129,6 +129,8 @@ class eventobservers {
 
         // Purge the cached menus for the user with the assigned role.
         smartmenu_helper::purge_cache_session_roles($event->objectid, $event->relateduserid);
+        // Purge the related user cache.
+        smartmenu_helper::set_user_purgecache($event->relateduserid);
     }
 
     /**
@@ -144,6 +146,8 @@ class eventobservers {
 
         // Purge the cached menus for the user with the unassigned role.
         smartmenu_helper::purge_cache_session_roles($event->objectid, $event->relateduserid);
+        // Purge the related user cache.
+        smartmenu_helper::set_user_purgecache($event->relateduserid);
     }
 
     /**
@@ -159,6 +163,8 @@ class eventobservers {
 
         // Purge the cached menus for all users with the deleted role.
         smartmenu_helper::purge_cache_deleted_roles($event->objectid);
+        // Purge all the dynamic course items cache.
+        smartmenu_helper::purge_cache_dynamic_courseitems();
     }
 
     /**

--- a/tests/behat/theme_boost_union_smartmenusettings_menuitems_dynamiccourses.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menuitems_dynamiccourses.feature
@@ -323,17 +323,15 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
       | title    | Future Courses Menu                              |
       | location | Main navigation, Menu bar, User menu, Bottom bar |
     And the following "theme_boost_union > smart menu item" exists:
-      | menu             | Future Courses Menu |
-      | title            | Future Courses      |
-      | itemtype         | Dynamic courses     |
-      | daterange        | Future              |
-      | enrolmentrole    | student             |
-    And I am logged in as "admin"
-    And I am on the "Future Courses Menu > Future Courses" "theme_boost_union > smart menu item" page
+      | menu          | Future Courses Menu |
+      | title         | Future Courses      |
+      | itemtype      | Dynamic courses     |
+      | daterange     | Future              |
+      | enrolmentrole | student             |
     And the following "courses" exist:
-      | fullname  | shortname | category | enablecompletion | startdate     | enddate         |
-      | Future 01 | F1        | CAT1     | 1                | ## +10 days ##| ## +20 days ##  |
-      | Future 02 | F2        | CAT1     | 1                | ## +15 days ##| ## +25 days ##  |
+      | fullname  | shortname | category | enablecompletion | startdate      | enddate        |
+      | Future 01 | F1        | CAT1     | 1                | ## +10 days ## | ## +20 days ## |
+      | Future 02 | F2        | CAT1     | 1                | ## +15 days ## | ## +25 days ## |
     And the following "course enrolments" exist:
       | user     | course | role    |
       | student1 | F1     | student |
@@ -343,9 +341,12 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
     And the following "course enrolments" exist:
       | user     | course | role    |
       | student1 | F2     | student |
-    And I log in as "student1"
+    And I reload the page
+    Then "Future 01" "theme_boost_union > Smart menu item" should exist in the "Future Courses Menu" "theme_boost_union > Main menu smart menu"
     And "Future 02" "theme_boost_union > Smart menu item" should exist in the "Future Courses Menu" "theme_boost_union > Main menu smart menu"
-    Then I am on the "Future 02" "enrolled users" page logged in as "admin"
+    And I log out
+    And I log in as "admin"
+    And I am on the "Future 02" "enrolled users" page
     And I click on "Unenrol" "icon" in the "student1" "table_row"
     And I click on "Unenrol" "button" in the "Unenrol" "dialogue"
     And I log out

--- a/tests/behat/theme_boost_union_smartmenusettings_menuitems_dynamiccourses.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menuitems_dynamiccourses.feature
@@ -316,3 +316,39 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, usi
       | teacher, editingteacher | teacher  | should      | Course 01 | Inline   | smart menu item |
       | student                 | student1 | should      | Course 01 | Inline   | smart menu item |
       | student                 | teacher  | should not  | Course 01 | Inline   | smart menu item |
+
+  @javascript
+  Scenario: Smartmenus: Menu items: Dynamic courses - User role assignments in future courses
+    Given the following "theme_boost_union > smart menu" exists:
+      | title    | Future Courses Menu                              |
+      | location | Main navigation, Menu bar, User menu, Bottom bar |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu             | Future Courses Menu |
+      | title            | Future Courses      |
+      | itemtype         | Dynamic courses     |
+      | daterange        | Future              |
+      | enrolmentrole    | student             |
+    And I am logged in as "admin"
+    And I am on the "Future Courses Menu > Future Courses" "theme_boost_union > smart menu item" page
+    And the following "courses" exist:
+      | fullname  | shortname | category | enablecompletion | startdate     | enddate         |
+      | Future 01 | F1        | CAT1     | 1                | ## +10 days ##| ## +20 days ##  |
+      | Future 02 | F2        | CAT1     | 1                | ## +15 days ##| ## +25 days ##  |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | F1     | student |
+    When I log in as "student1"
+    Then "Future 01" "theme_boost_union > Smart menu item" should exist in the "Future Courses Menu" "theme_boost_union > Main menu smart menu"
+    And "Future 02" "theme_boost_union > Smart menu item" should not exist in the "Future Courses Menu" "theme_boost_union > Main menu smart menu"
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | F2     | student |
+    And I log in as "student1"
+    And "Future 02" "theme_boost_union > Smart menu item" should exist in the "Future Courses Menu" "theme_boost_union > Main menu smart menu"
+    Then I am on the "Future 02" "enrolled users" page logged in as "admin"
+    And I click on "Unenrol" "icon" in the "student1" "table_row"
+    And I click on "Unenrol" "button" in the "Unenrol" "dialogue"
+    And I log out
+    When I log in as "student1"
+    Then "Future 01" "theme_boost_union > Smart menu item" should exist in the "Future Courses Menu" "theme_boost_union > Main menu smart menu"
+    And "Future 02" "theme_boost_union > Smart menu item" should not exist in the "Future Courses Menu" "theme_boost_union > Main menu smart menu"

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2024100709;
+$plugin->version = 2024100710;
 $plugin->release = 'v4.5-r5';
 $plugin->requires = 2024100700;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
Fixed the issue where course enrollment and unenrollment now properly update the dynamic course items for users.