### PR TITLE
Correct activity icon colors, resolves #831

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2025-02-18 - Bugfix: Correct activity icon colors, resolves #831
 * 2025-02-17 - Bugfix: Remove the possibility to set the activity purpose for subsections to avoid that activities within subsections get tinted with the wrong color, resolves #823.
 * 2025-02-12 - Bugfix: Accessibility page link in description differed from real location, resolves #818.
 

--- a/lib.php
+++ b/lib.php
@@ -331,7 +331,7 @@ function theme_boost_union_get_pre_scss($theme) {
             // Set the activity-icon-*-filter variable which holds the CSS filters for the activity icon colors now.
             $solver = new \theme_boost_union\lib\hextocssfilter\solver($activityiconcolor);
             $cssfilterresult = $solver->solve();
-            $scss .= '$activity-icon-'.$purpose.'-filter: '.$cssfilterresult['filter'].";\n";
+            $scss .= '$activity-icon-'.$purpose.'-filter: brightness(0) saturate(100%) '.$cssfilterresult['filter'].";\n";
         }
     }
 


### PR DESCRIPTION
Make activity icons black before applying color filters for final color.

See #832. That is the pull request for Moodle 4.4, this is the one for Moodle 4.5.