### PR TITLE
Remove assumtion that syscontext->id = 1, resolves #627

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2025-03-29 - Bugfix: Remove assumtion that syscontext->id = 1, resolves #627
 * 2025-03-28 - Improvement: Add resizing to flavour logo and compact logo, resolves #212.
 * 2025-03-27 - Improvement: Add admin main navigation to smart menu items page as well, resolves #882.
 * 2025-03-27 - Improvement: Add tertiary navigation to Boost Union admin settings pages to allow jumping from one settings page to another, resolves #876.

--- a/locallib.php
+++ b/locallib.php
@@ -801,9 +801,11 @@ function theme_boost_union_get_additionalresources_templatecontext() {
         // Iterate over the files and fill the templatecontext of the file list.
         $filesforcontext = [];
         foreach ($files as $af) {
-            $urlpersistent = new core\url('/pluginfile.php/1/theme_boost_union/additionalresources/0/'.$af->get_filename());
-            $urlrevisioned = new core\url('/pluginfile.php/1/theme_boost_union/additionalresources/'.theme_get_revision().
-                    '/'.$af->get_filename());
+            $urlpersistent = new moodle_url('/pluginfile.php/' . $systemcontext->id .
+                '/theme_boost_union/additionalresources/0/' . $af->get_filename());
+                $urlrevisioned = new moodle_url('/pluginfile.php/' . $systemcontext->id .
+                '/theme_boost_union/additionalresources/' . theme_get_revision().
+                '/' . $af->get_filename());
             $filesforcontext[] = ['filename' => $af->get_filename(),
                                         'filetype' => $af->get_mimetype(),
                                         'filesize' => display_size($af->get_filesize()),
@@ -860,7 +862,8 @@ function theme_boost_union_get_customfonts_templatecontext() {
             }
 
             // Otherwise, fill the templatecontext of the file list.
-            $urlpersistent = new core\url('/pluginfile.php/1/theme_boost_union/customfonts/0/'.$filename);
+            $urlpersistent = new core\url('/pluginfile.php/'. $systemcontext->id .
+                '/theme_boost_union/customfonts/0/' . $filename);
             $filesforcontext[] = ['filename' => $filename,
                     'fileurlpersistent' => $urlpersistent->out(), ];
         }
@@ -1929,7 +1932,8 @@ function theme_boost_union_get_touchicons_html_for_page() {
             // If the file exists (i.e. it has been uploaded).
             if ($file->exists == true) {
                 // Build the file URL.
-                $fileurl = new core\url('/pluginfile.php/1/theme_boost_union/touchiconsios/' .
+                $systemcontext = \context_system::instance();
+                $fileurl = new core\url('/pluginfile.php/' . $systemcontext->id . '/theme_boost_union/touchiconsios/' .
                     theme_get_revision().'/'.$file->filename);
 
                 // Compose and append the HTML tag.


### PR DESCRIPTION
See #627. Essentially only replaces the '1' in the URL string with the correct systemcontextid where applicable. Behat tests should not be changed as fresh installs always for the tests should have $systemcontext -> id = 1. 