### PR TITLE
 Bugfix: Unset width restrictions for dropdowns in custommenu and smartmenu, resolves #883

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2025-04-02 - Bugfix: Unset width restrictions for dropdowns in custommenu and smartmenu, resolves #883.
+
 ### v4.5-r12
 
 * 2025-03-29 - Bugfix: Remove assumption that syscontext->id = 1, resolves #627

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -2471,6 +2471,12 @@ body.theme_boost-union-footerbuttonnone.jsenabled {
                 text-decoration: none;
             }
         }
+        &.dropdown {
+            .boost-union-moremenu.dropdown-menu {
+                max-width: unset;
+                width: max-content;
+            }
+        }
     }
     /* Dropdown carousel more menu*/
     .dropdownmoremenu {


### PR DESCRIPTION
See #883

This unsets the width restrictions from earlier smartmenu works.

With the new css core costummenus, but also dropdowns from smartmenus are rendered without any wrapping.

