### PR TITLE
Improvement: Improve wrapping of the outside-left and outside-right regions, resolves #255

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2025-04-17 - Improvement: Improve wrapping of the outside-left and outside-right regions, resolves #255.
+
 ### v4.5-r13
 
 * 2025-04-06 - Bugfix: Enrol page used modified course listing renderer from category index / site home as well, resolves #895.

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -662,6 +662,9 @@ $string['outsideregionsplacement'] = 'Outside regions horizontal placement';
 $string['outsideregionsplacement_desc'] = 'With this setting, you can control if, on larger screens, the \'Outside (left)\' and \'Outside (right)\' block regions should be placed near the main content area or rather near the window edges.';
 $string['outsideregionsplacementnextmaincontent'] = 'Display \'Outside (left)\' and \'Outside (right)\' regions next to the main content area';
 $string['outsideregionsplacementnearwindowedges'] = 'Display \'Outside (left)\' and \'Outside (right)\' regions near the window edges';
+// ... ... Setting: Wrap outside left and right regions below main content.
+$string['outsideregionswrap'] = 'Wrap outside left and right regions below main content';
+$string['outsideregionswrap_desc'] = 'With this setting, you can control if the \'Outside (left)\' and \'Outside (right)\' block regions should be wrapped below the main content area on smaller screens.';
 // ... Section: Site home right-hand block drawer behaviour.
 $string['sitehomerighthandblockdrawerbehaviour'] = 'Site home right-hand block drawer';
 // ... ... Setting: Show right-hand block drawer of site home on visit.

--- a/layout/includes/blockregions.php
+++ b/layout/includes/blockregions.php
@@ -112,6 +112,13 @@ class additionalregions {
             $maininnerwrapperclass = 'main-inner-outside-none';
         }
 
+        // If outside-regions wrap below main content is enabled.
+        $outsideregionswrap = get_config('theme_boost_union', 'blockregionoutsidewrap');
+        if ($outsideregionswrap == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            // Include class in main inner wrapper to wrap the outside regions below main content.
+            $maininnerwrapperclass .= ' left-region-nextmaincontent ';
+        }
+
         return $maininnerwrapperclass;
     }
 

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -1157,6 +1157,29 @@ body.theme-boost-union-commincourse {
     }
 }
 
+/* And on larger screens and below. */
+@include media-breakpoint-down(md) {
+    /* Wrap the left and right outside regions below the main content. */
+    body.limitedwidth {
+        .left-region-nextmaincontent {
+            &.main-inner-outside-left-right.main-inner-outside-nextmaincontent,
+            &.main-inner-outside-left.main-inner-outside-nextmaincontent,
+            &.main-inner-outside-right.main-inner-outside-nextmaincontent,
+            &.main-inner-outside-left-right.main-inner-outside-nearwindowedges,
+            &.main-inner-outside-left.main-inner-outside-nearwindowedges,
+            &.main-inner-outside-right.main-inner-outside-nearwindowedges {
+                display: grid;
+                #theme-block-region-outside-left {
+                    order: 1;
+                }
+                #theme-block-region-outside-right {
+                    order: 2;
+                }
+            }
+        }
+    }
+}
+
 /* And on smaller screens. */
 @include media-breakpoint-down(sm) {
     /* Change the outside-left and outside-right blocks to full width (with some horizontal space). */

--- a/settings.php
+++ b/settings.php
@@ -1899,6 +1899,13 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
                 THEME_BOOST_UNION_SETTING_OUTSIDEREGIONSPLACEMENT_NEXTMAINCONTENT, $outsideregionsplacementoptions);
         $tab->add($setting);
 
+        // Setting: Wrap outside left and right regions below maincontent (on mobile).
+        $name = 'theme_boost_union/blockregionoutsidewrap';
+        $title = get_string('outsideregionswrap', 'theme_boost_union', null, true);
+        $description = get_string('outsideregionswrap_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
         // Create site home right-hand blocks drawer behaviour heading.
         $name = 'theme_boost_union/sitehomerighthandblockdrawerbehaviour';
         $title = get_string('sitehomerighthandblockdrawerbehaviour', 'theme_boost_union', null, true);

--- a/tests/behat/behat_theme_boost_union_behat_blocks.php
+++ b/tests/behat/behat_theme_boost_union_behat_blocks.php
@@ -39,4 +39,46 @@ use Behat\Mink\Exception\ElementNotFoundException as ElementNotFoundException;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_theme_boost_union_behat_blocks extends behat_blocks {
+
+    /**
+     * Checks the order of elements before or after.
+     *
+     * @Then :arg1 :arg2 should display :arg3 :arg4 :arg5
+     *
+     * @param string $selector1 The first element selector.
+     * @param string $type1 The type of the first element selector.
+     * @param string $order The expected order (before or after).
+     * @param string $selector2 The second element selector.
+     * @param string $type2 The type of the second element selector.
+     */
+    public function assert_element_order($selector1, $type1, $order, $selector2, $type2) {
+        $element1 = $this->find($type1, $selector1);
+        $element2 = $this->find($type2, $selector2);
+
+        if (!$element1) {
+            throw new ElementNotFoundException($this->getSession(), 'element', $type1, $selector1);
+        }
+
+        if (!$element2) {
+            throw new ElementNotFoundException($this->getSession(), 'element', $type2, $selector2);
+        }
+
+        $script = "
+            return (function() {
+                const el1 = document.querySelector('$selector1');
+                const el2 = document.querySelector('$selector2');
+                const order1 = parseInt(window.getComputedStyle(el1).order);
+                const order2 = parseInt(window.getComputedStyle(el2).order);
+                return order1 < order2 ? true : false;
+            })();";
+
+        $result = $this->evaluate_script($script);
+
+        if (($order === 'before' && $result == false) || ($order === 'after' && $result == true)) {
+            throw new Exception(sprintf(
+                'The element "%s" (%s) is not displayed %s the element "%s" (%s).',
+                $selector1, $type1, $order, $selector2, $type2
+            ));
+        }
+    }
 }

--- a/tests/behat/theme_boost_union_feelsettings_blocks.feature
+++ b/tests/behat/theme_boost_union_feelsettings_blocks.feature
@@ -486,3 +486,24 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | setting | shouldcontain      |
       | yes     | should contain     |
       | no      | should not contain |
+
+  @javascript
+  Scenario Outline: Setting: Wrap outside regions below main content
+    Given the following config values are set as admin:
+      | config                 | value     | plugin            |
+      | blockregionoutsidewrap | <setting> | theme_boost_union |
+      | blockregionsforcourse  | outside-left,outside-right | theme_boost_union |
+    And the following "blocks" exist:
+      | blockname    | contextlevel | reference | pagetypepattern | defaultregion |
+      | online_users | Course       | C1        | course-view-*   | outside-left  |
+      | myprofile    | Course       | C1        | course-view-*   | outside-right |
+    When I am on the "Course 1" "Course" page logged in as "student1"
+
+    Then the "class" attribute of ".main-inner-wrapper" "css_element" <shouldcontain> "left-region-nextmaincontent"
+    And I change window size to "mobile"
+    Then ".main-inner#topofscroll" "css_element" should display <beforeafter> "#theme-block-region-outside-left" "css_element"
+
+    Examples:
+      | setting | shouldcontain      | beforeafter |
+      | yes     | should contain     | before      |
+      | no      | should not contain | after       |

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2024100728;
+$plugin->version = 2024100729;
 $plugin->release = 'v4.5-r13';
 $plugin->requires = 2024100702;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
Added a new admin setting under the Blocks section: "**Wrap outside left and right regions below main content**".

This setting allows the outside-left and outside-right block regions to stack vertically below the main content on smaller screens, improving responsive layout and accessibility.