### PR TITLE
Regression: Course search page did not use the improved course listings anymore, resolves #930

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2025-05-06 - Regression: Course search page did not use the improved course listings anymore, resolves #930
 * 2025-05-02 - Bugfix: On mobile devices, the course listing combo box produced horizontal scroll bars, resolves #926.
 * 2025-04-30 - Bugfix: Modified smart menu transition time had an impact on the slider, resolves #922.
 * 2025-04-30 - Bugfix: Fix a HTML nesting glitch for the course lists on site home, resolves #919.

--- a/classes/output/core/course_renderer.php
+++ b/classes/output/core/course_renderer.php
@@ -865,6 +865,7 @@ class course_renderer extends \core_course_renderer {
         // List of other page URLs where the modification is allowed.
         $pageswithboostunionmodification = [
               '/course/index.php',
+              '/course/search.php',
         ];
 
         // Iterate over these pages.

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -555,6 +555,21 @@
     }
 }
 
+/* The search page 'show all' button, if the search page has modified course listings. */
+#page-course-search {
+    .paging:has(+ .theme_boost_union-courselisting-wrapper),
+    .theme_boost_union-courselisting-wrapper ~ .paging {
+        @extend .text-end;
+
+        a {
+            @extend .btn;
+            @extend .btn-secondary;
+            @extend .btn-sm;
+            @extend .mb-3;
+        }
+    }
+}
+
 
 /*=======================================
  * Settings: Look -> Course

--- a/tests/behat/theme_boost_union_looksettings_categoryindexsitehome.feature
+++ b/tests/behat/theme_boost_union_looksettings_categoryindexsitehome.feature
@@ -879,3 +879,21 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     And I am on site homepage
     Then I should see "Category C"
     And I should not see "Kategorie C"
+
+  @javascript
+  Scenario Outline: Setting: Course listing presentation: Set the setting (and check that the course search page as special page is styled as well)
+    Given the following config values are set as admin:
+      | config                    | value          | plugin            |
+      | courselistingpresentation | <settingvalue> | theme_boost_union |
+    When I log in as "student1"
+    And I am on course index
+    And I set the field "Search courses" to "Course"
+    And I press "Search courses"
+    Then ".theme_boost_union-courselisting-<cssclass1>" "css_element" <shouldornot1> exist in the ".course-search-result" "css_element"
+    And ".theme_boost_union-courselisting-<cssclass2>" "css_element" <shouldornot2> exist in the ".course-search-result" "css_element"
+
+    Examples:
+      | settingvalue | cssclass1 | shouldornot1 | cssclass2 | shouldornot2 |
+      | nochange     | card      | should not   | list      | should not   |
+      | cards        | card      | should       | list      | should not   |
+      | list         | list      | should       | card      | should not   |


### PR DESCRIPTION
This PR fixes the regression of #930 and styles the button on the search page.