### PR TITLE
Bugfix: Smart menu: menu bar displayed although there are no items to display, resolves #849.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2025-08-01 - Bugfix: Smart menu: menu bar was displayed although there were no items to display, resolves #849.
 * 2025-07-31 - Bugfix: Uninitialized $overflow might have caused the smart menu item icon picker to fail, resolves #1035
 * 2025-07-28 - Bugfix: Reposition Boost Union footer buttons correctly if sticky footer is shown, resolves #1033
 * 2025-07-28 - Improvement: Query SCSS snippets table during theme refresh only if the table exists, resolves #1024

--- a/classes/output/navigation/primary.php
+++ b/classes/output/navigation/primary.php
@@ -122,9 +122,35 @@ class primary extends \core\navigation\output\primary {
         // Convert the children menu items into submenus.
         // Removed the menu nodes from menubar, each item will be displayed as menu in menubar.
         if (!empty($locationmenubarmenu)) {
+
+            // Set the visibility of the menu bar for mobile, tablet, and desktop based on its child items.
+            $hidedesktop = $hidemobile = $hidetablet = 1;
+            foreach ($locationmenubarmenu as $key => $menu) {
+                // Check if the menu has any children to be displayed on desktop.
+                if (!isset($menu->desktop) || empty($menu->desktop)) {
+                    $hidedesktop = 0;
+                }
+                // Check if the menu has any children to be displayed on tablets.
+                if (!isset($menu->tablet) || empty($menu->tablet)) {
+                    $hidetablet = 0;
+                }
+                // Check if the menu has any children to be displayed on mobiles.
+                if (!isset($menu->mobile) || empty($menu->mobile)) {
+                    $hidemobile = 0;
+                }
+            }
+
             $locationmenubarmenuconverted = $this->convert_submenus($locationmenubarmenu);
             $menubarmoremenu = new \core\navigation\output\more_menu((object) $locationmenubarmenuconverted,
                     'navbar-nav-menu-bar', false);
+            $menubartemplatedata = $menubarmoremenu->export_for_template($output);
+
+            // Define the visibility classes for the menubar.
+            $menubarclasses[] = $hidedesktop ? 'd-lg-none' : 'd-lg-flex';
+            $menubarclasses[] = $hidetablet ? 'd-md-none' : 'd-md-flex';
+            $menubarclasses[] = $hidemobile ? 'd-none' : 'd-flex';
+            $menubartemplatedata['classes'] = implode(' ', $menubarclasses);
+
         }
 
         // Bottom bar.
@@ -166,7 +192,7 @@ class primary extends \core\navigation\output\primary {
         return [
             'mobileprimarynav' => $mobileprimarynav,
             'moremenu' => $moremenu->export_for_template($output),
-            'menubar' => isset($menubarmoremenu) ? $menubarmoremenu->export_for_template($output) : false,
+            'menubar' => $menubartemplatedata ?? false,
             'lang' => !isloggedin() || isguestuser() ? $languagemenu->export_for_template($output) : [],
             'user' => $usermenu ?? [],
             'bottombar' => $bottombardata ?? false,

--- a/classes/smartmenu.php
+++ b/classes/smartmenu.php
@@ -679,6 +679,28 @@ class smartmenu {
                 // Setup the childrens to parent menu node.
                 $nodes->haschildren = (count($builditems) > 0) ? true : false;
                 $nodes->children = $builditems;
+
+                // Set the visibility of the menu node for mobile, tablet, and desktop based on its child items.
+                foreach ($builditems as $key => $item) {
+                    // If any of the items are visible on the desktop, the menu node should also be visible on the desktop.
+                    if (!isset($item['desktop']) || empty($item['desktop'])) {
+                        $hidemenudesktop = 0;
+                    }
+                    // If any of the items are visible on the tablet, the menu node should also be visible on the tablet.
+                    if (!isset($item['tablet']) || empty($item['tablet'])) {
+                        $hidemenutablet = 0;
+                    }
+                    // If any of the items are visible on the mobile, the menu node should also be visible on the mobile.
+                    if (!isset($item['mobile']) || empty($item['mobile'])) {
+                        $hidemenumobile = 0;
+                    }
+                }
+
+                // Include the menu node visibility based on its child items.
+                $nodes->desktop = $hidemenudesktop ?? true;
+                $nodes->tablet = $hidemenutablet ?? true;
+                $nodes->mobile = $hidemenumobile ?? true;
+
             } else {
                 // If menu is inline mode, then it items are displayed directly in menus.
                 // Set the menuitems as separate menu node in cache.

--- a/classes/smartmenu_item.php
+++ b/classes/smartmenu_item.php
@@ -1375,6 +1375,9 @@ class smartmenu_item {
             'sort' => uniqid(), // Support third level menu.
             'sortdata' => $sortdata,
             'imagealt' => $imagealt ?? $title,
+            'desktop' => $this->item->desktop,
+            'tablet' => $this->item->tablet,
+            'mobile' => $this->item->mobile,
         ];
 
         if ($haschildren && !empty($children)) {

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -1789,10 +1789,6 @@ body.theme_boost-union-footerbuttonnone.jsenabled {
                 ~ .drawer.drawer-right {
                     top: calc(#{$navbar-height} + #{$bu-smartmenu-menubar-height} + 1px);
                 }
-                /* The position of the main page has been adjusted slightly below to accommodate the top header. */
-                ~ #page.drawers {
-                    margin-top: calc(#{$navbar-height} + #{$bu-smartmenu-menubar-height});
-                }
                 .moremenu {
                     height: $bu-smartmenu-menubar-height;
 
@@ -1846,16 +1842,16 @@ body.theme_boost-union-footerbuttonnone.jsenabled {
                        header. */
                     &.fixed-top {
                         margin-top: $bu-smartmenu-menubar-height;
-                        /* The position of the card dropdown block has been set to static,
-                        so it will always appear under the card menu link. */
-                        .moremenu .dropdown.card-dropdown {
-                            position: static;
-                            .dropdown-menu {
-                                overflow-y: auto;
-                            }
-                            &:not(.card-overflow-no-wrap) .dropdown-menu {
-                                max-height: calc(100vh - 300px);
-                            }
+                    }
+                    /* The position of the card dropdown block has been set to static,
+                    so it will always appear under the card menu link. */
+                    .moremenu .dropdown.card-dropdown {
+                        position: static;
+                        .dropdown-menu {
+                            overflow-y: auto;
+                        }
+                        &:not(.card-overflow-no-wrap) .dropdown-menu {
+                            max-height: calc(100vh - 300px);
                         }
                     }
                 }
@@ -2609,6 +2605,32 @@ body.theme_boost-union-footerbuttonnone.jsenabled {
     }
 }
 
+@include media-breakpoint-up(lg) {
+    .theme-boost-union-smartmenu .navbar.fixed-top.boost-union-menubar.d-lg-none {
+        /* Margin top has been added to the Header block to ensure that it does not conflict with the top header. */
+        + .navbar.fixed-top {
+            margin-top: 0;
+        }
+        ~ #page.drawers {
+            /* The position has been adjusted to prevent the message drawer from being hidden behind the primary header. */
+            margin-top: $bu-smartmenu-menubar-height;
+        }
+    }
+}
+
+@include media-breakpoint-only(md) {
+    .theme-boost-union-smartmenu .navbar.fixed-top.boost-union-menubar.d-md-none {
+        /* Margin top has been added to the Header block to ensure that it does not conflict with the top header. */
+        + .navbar.fixed-top {
+            margin-top: 0;
+        }
+        ~ #page.drawers {
+            /* The position has been adjusted to prevent the message drawer from being hidden behind the primary header. */
+            margin-top: $bu-smartmenu-menubar-height;
+        }
+    }
+}
+
 /* The nav drawer position to the top in the responsive alignment */
 @include media-breakpoint-down(lg) {
     .navbar.fixed-top.boost-union-menubar ~ .drawer {
@@ -2674,8 +2696,20 @@ body.theme_boost-union-footerbuttonnone.jsenabled {
         }
     }
     /* The card menu of the drodown item margin right is removed when the card dropdown menu is inside the "More" menu */
-    .theme-boost-union-smartmenu .navbar .moremenu .dropdown.card-dropdown .dropdown-menu .card-block-wrapper .card-block {
-        margin-right: 0;
+    .theme-boost-union-smartmenu .navbar {
+        .moremenu .dropdown.card-dropdown .dropdown-menu .card-block-wrapper .card-block {
+            margin-right: 0;
+        }
+        &.fixed-top.boost-union-menubar.d-none {
+            /* Margin top has been added to the Header block to ensure that it does not conflict with the top header. */
+            + .navbar.fixed-top {
+                margin-top: 0;
+            }
+            ~ #page.drawers {
+                /* The position has been adjusted to prevent the message drawer from being hidden behind the primary header. */
+                margin-top: $bu-smartmenu-menubar-height;
+            }
+        }
     }
 }
 

--- a/templates/theme_boost/navbar.mustache
+++ b/templates/theme_boost/navbar.mustache
@@ -68,7 +68,7 @@
 }}
 
 {{#menubar}}
-<nav class="menubar fixed-top boost-union-menubar navbar navbar-expand {{#bottombar.drawer}} smartmenu-bottom-navigation {{/bottombar.drawer}}">
+<nav class="menubar fixed-top boost-union-menubar navbar navbar-expand {{#bottombar.drawer}} smartmenu-bottom-navigation {{/bottombar.drawer}} {{{menubar.classes}}}">
     {{> core/moremenu}}
 </nav>
 {{/menubar}}

--- a/tests/behat/theme_boost_union_smartmenusettings_menuitems_presentation.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menuitems_presentation.feature
@@ -169,31 +169,93 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
     And "Demo item 02" "text" should appear after "Demo item 03" "text"
     And "Demo item 01" "text" should appear after "Demo item 02" "text"
 
+  # The following "Smartmenus: Menu items: Presentation - Display the menu items in different viewports" scenarios look like they
+  # could be combined into a single scenario outline, but they are not because with the scenario outline approach, the test
+  # would attempt to open menus that were hidden due to having no items.
+
   @javascript
-  Scenario Outline: Smartmenus: Menu items: Presentation - Display the menu items in different viewports
+  Scenario: Smartmenus: Menu items: Presentation - Display the menu items in different viewports - hide the menu items on mobile devices
     When I log in as "admin"
     And I set "Quick links" smart menu items with the following fields to these values:
       | Title          | Resources          |
       | Menu item type | Static             |
       | Menu item URL  | https://moodle.org |
-      | desktop        | <hidedesktop>      |
-      | tablet         | <hidetablet>       |
-      | mobile         | <hidemobile>       |
-    Then I <desktopshouldornot> see smart menu "Quick links" item "Resources" in location "Menu, Main, User"
+      | desktop        | 0                  |
+      | tablet         | 0                  |
+      | mobile         | 1                  |
+    Then I should see smart menu "Quick links" item "Resources" in location "Menu, Main, User"
     And I change viewport size to "tablet"
-    Then I <tabletshouldornot> see smart menu "Quick links" item "Resources" in location "User, Menu"
+    Then I should see smart menu "Quick links" item "Resources" in location "User, Menu"
     And I click on "More" "link" in the ".primary-navigation" "css_element"
-    Then I <tabletshouldornot> see smart menu "Quick links" item "Resources" in location "Main"
+    Then I should see smart menu "Quick links" item "Resources" in location "Main"
     And I change viewport size to "mobile"
-    Then I <mobileshouldornot> see smart menu "Quick links" item "Resources" in location "Menu, User"
-    And I <mobileshouldornot> see smart menu "Quick links" item "Resources" in location "Bottom"
+    Then "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Menu bar smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > User menu smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Bottom bar smart menu" should not be visible
 
-    Examples:
-      | hidedesktop | hidetablet | hidemobile | desktopshouldornot | tabletshouldornot | mobileshouldornot |
-      | 0           | 0          | 1          | should             | should            | should not        |
-      | 0           | 1          | 1          | should             | should not        | should not        |
-      | 1           | 0          | 0          | should not         | should            | should            |
-      | 1           | 0          | 1          | should not         | should            | should not        |
+  @javascript
+  Scenario: Smartmenus: Menu items: Presentation - Display the menu items in different viewports - hide the menu items on tablet and mobile devices
+    When I log in as "admin"
+    And I set "Quick links" smart menu items with the following fields to these values:
+      | Title          | Resources          |
+      | Menu item type | Static             |
+      | Menu item URL  | https://moodle.org |
+      | desktop        | 0                  |
+      | tablet         | 1                  |
+      | mobile         | 1                  |
+    Then I should see smart menu "Quick links" item "Resources" in location "Menu, Main, User"
+    And I change viewport size to "tablet"
+    Then "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Menu bar smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > User menu smart menu" should not be visible
+    And I click on "More" "link" in the ".primary-navigation" "css_element"
+    Then "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Main menu smart menu" should not be visible
+    And I change viewport size to "mobile"
+    Then "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Menu bar smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > User menu smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Bottom bar smart menu" should not be visible
+
+  @javascript
+  Scenario: Smartmenus: Menu items: Presentation - Display the menu items in different viewports - hide the menu items on desktop devices
+    When I log in as "admin"
+    And I set "Quick links" smart menu items with the following fields to these values:
+      | Title          | Resources          |
+      | Menu item type | Static             |
+      | Menu item URL  | https://moodle.org |
+      | desktop        | 1                  |
+      | tablet         | 0                  |
+      | mobile         | 0                  |
+    Then "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Main menu smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Menu bar smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > User menu smart menu" should not be visible
+    And I change viewport size to "tablet"
+    Then I should see smart menu "Quick links" item "Resources" in location "User, Menu"
+    And I click on "More" "link" in the ".primary-navigation" "css_element"
+    Then I should see smart menu "Quick links" item "Resources" in location "Main"
+    And I change viewport size to "mobile"
+    Then I should see smart menu "Quick links" item "Resources" in location "Menu, User"
+    And I should see smart menu "Quick links" item "Resources" in location "Bottom"
+
+  @javascript
+  Scenario: Smartmenus: Menu items: Presentation - Display the menu items in different viewports - hide the menu items on desktop and mobile devices
+    When I log in as "admin"
+    And I set "Quick links" smart menu items with the following fields to these values:
+      | Title          | Resources          |
+      | Menu item type | Static             |
+      | Menu item URL  | https://moodle.org |
+      | desktop        | 1                  |
+      | tablet         | 0                  |
+      | mobile         | 1                  |
+    Then "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Main menu smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Menu bar smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > User menu smart menu" should not be visible
+    And I change viewport size to "tablet"
+    Then I should see smart menu "Quick links" item "Resources" in location "User, Menu"
+    And I click on "More" "link" in the ".primary-navigation" "css_element"
+    Then I should see smart menu "Quick links" item "Resources" in location "Main"
+    And I change viewport size to "mobile"
+    Then "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Menu bar smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > User menu smart menu" should not be visible
+    And "Resources" "theme_boost_union > Smart menu item" in the "Quick links" "theme_boost_union > Bottom bar smart menu" should not be visible
 
   @javascript
   Scenario: Smartmenus: Menu items: Presentation - Select an existing icon from the icon autocomplete list

--- a/tests/behat/theme_boost_union_smartmenusettings_menus_presentation.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menus_presentation.feature
@@ -491,3 +491,43 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
     And the "class" attribute of ".primary-navigation .nav-item:nth-child(5) a" "css_element" should contain "active"
     And "//a[@aria-current = 'true']" "xpath" should not exist in the ".primary-navigation [data-key='home']" "css_element"
     And "//a[@aria-current = 'true']" "xpath" should exist in the ".primary-navigation .nav-item:nth-child(5)" "css_element"
+
+  @javascript
+  Scenario Outline: Smartmenu: Menus: Presentation - Ensure the menu bar is not displayed when no menus are present
+    Given the following "theme_boost_union > smart menu" exists:
+      | title    | Menu bar links |
+      | location | Menu bar       |
+      | mode     | Inline         |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu     | Menu bar links    |
+      | title    | Moodle org        |
+      | itemtype | Static            |
+      | url      | http://moodle.org |
+      | itemmode | Inline            |
+      | desktop  | <item1desk>       |
+      | tablet   | <item1tab>        |
+      | mobile   | <item1mob>        |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu     | Menu bar links              |
+      | title    | Moodle Plugins              |
+      | itemtype | Static                      |
+      | url      | https://moodle.org/plugins/ |
+      | itemmode | Inline                      |
+      | desktop  | <item2desk>                 |
+      | tablet   | <item2tab>                  |
+      | mobile   | <item2mob>                  |
+    When I am on site homepage
+    And I change the viewport size to "large"
+    And ".boost-union-menubar" "css_element" <menubarshouldornot> be visible
+    And I change the viewport size to "tablet"
+    And ".boost-union-menubar" "css_element" <menubartabshouldornot> be visible
+    And I change the viewport size to "mobile"
+    And ".boost-union-menubar" "css_element" <menubarmobshouldornot> be visible
+
+    Examples:
+      | item1desk | item1tab | item1mob | item2desk | item2tab | item2mob | menubarshouldornot | menubartabshouldornot | menubarmobshouldornot |
+      | 1         | 1        | 1        | 1         | 1        | 1        | should not         | should not            | should not            |
+      | 0         | 1        | 1        | 1         | 1        | 1        | should             | should not            | should not            |
+      | 1         | 0        | 1        | 1         | 1        | 1        | should not         | should                | should not            |
+      | 1         | 1        | 0        | 1         | 1        | 0        | should not         | should not            | should                |
+      | 0         | 0        | 1        | 0         | 0        | 1        | should             | should                | should not            |

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2025041421;
+$plugin->version = 2025041422;
 $plugin->release = 'v5.0-r7';
 $plugin->requires = 2025041401;
 $plugin->supported = [500, 500];


### PR DESCRIPTION
Included bootstrap responsive utility classes (d-md-none, d-md-flex, etc.) to control the visibility of the smart menu menubar based on the presence of child items.