### PR TITLE
Bugfix: Smart menu 'Visibility by language' restriction was not applied correctly after changes of the current language, resolves #697.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2025-05-21 - Bugfix: Smart menu "Visibility by language" restriction was not applied correctly after changes of the current language, resolves #697.
 * 2025-05-20 - Release: Set the Boost Union logo and tagline as screenshot for the theme overview page, resolves #925
 
 ### v4.5-r16

--- a/classes/smartmenu.php
+++ b/classes/smartmenu.php
@@ -1096,12 +1096,12 @@ class smartmenu {
      * @return array An array of SmartMenu nodes.
      */
     public static function build_smartmenu() {
-        global $USER;
+        global $SESSION, $USER;
 
         $nodes = [];
 
-        // Verify the language changes in user session, if changed than purge the menus and items cache for the user session.
-        self::verify_lang_session_changes();
+        // Detect language changes in user session - if changed then purge the menus and items cache for the user session.
+        self::detect_lang_session_change();
 
         $cache = cache::make('theme_boost_union', 'smartmenus');
         // Fetch the list of menus from cache.
@@ -1118,7 +1118,19 @@ class smartmenu {
         }
 
         // Test the flag to purge the cache is set for this user.
-        $removecache = (get_user_preferences('theme_boost_union_menu_purgesessioncache', false) == true);
+        // If the user is a guest.
+        if (!isloggedin() || isguestuser()) {
+            if (isset ($SESSION->theme_boost_union_menu_purgesessioncache) &&
+                    $SESSION->theme_boost_union_menu_purgesessioncache == true) {
+                $removecache = true;
+            } else {
+                $removecache = false;
+            }
+
+            // Otherwise.
+        } else {
+            $removecache = (get_user_preferences('theme_boost_union_menu_purgesessioncache', false) == true);
+        }
 
         foreach ($topmenus as $menu) {
             // Need to purge the menus for user, remove the cache before build.
@@ -1145,20 +1157,24 @@ class smartmenu {
 
     /**
      * Verifies and handles changes in the session language.
-     * Clears cached smart menus and items when the user changes the language using the language menu.
+     * Clears cached smart menus and items especially when the user changes the language using the language menu or if the language
+     * gets changed by a forced language in a course.
      *
      * @return void
      */
-    protected static function verify_lang_session_changes() {
+    protected static function detect_lang_session_change() {
         global $SESSION, $USER;
-        // Make sure the lang is updated for the session.
-        if ($lang = optional_param('lang', '', PARAM_SAFEDIR)) {
-            // Confirm the cache is not already purged for this language change. To avoid multiple purge.
-            if (!isset($SESSION->prevlang) || $SESSION->prevlang != $lang) {
-                // Set the purge cache preference for this session user. Cache will purged in the build_smartmenu method.
-                smartmenu_helper::set_user_purgecache($USER->id);
-                $SESSION->prevlang = $lang; // Save this lang for verification.
-            }
+
+        // Get the current language.
+        $lang = current_language();
+
+        // If the language does not match the language of the previous smart menu build or if we did not have a previous build yet.
+        if (!isset($SESSION->theme_boost_union_prevlang) || $SESSION->theme_boost_union_prevlang != $lang) {
+            // Set the purge cache preference for this session user. Cache will purged in the build_smartmenu method.
+            smartmenu_helper::set_user_purgecache($USER->id);
+
+            // And save this language for verification in the next build.
+            $SESSION->theme_boost_union_prevlang = $lang;
         }
     }
 }

--- a/smartmenus/menulib.php
+++ b/smartmenus/menulib.php
@@ -652,8 +652,18 @@ class smartmenu_helper {
      * @return void
      */
     public static function set_user_purgecache($userid) {
-        // Clear all the menu and item caches for this user.
-        set_user_preference('theme_boost_union_menu_purgesessioncache', true, $userid);
+        global $SESSION;
+
+        // If the user is a guest.
+        if (!isloggedin() || isguestuser($userid)) {
+            // Store the flag to clear the menu cache for this user in the session as guests do not have user preferences.
+            $SESSION->theme_boost_union_menu_purgesessioncache = true;
+
+            // Otherwise.
+        } else {
+            // Store a user preference to clear all the menu and item caches for this user.
+            set_user_preference('theme_boost_union_menu_purgesessioncache', true, $userid);
+        }
     }
 
     /**
@@ -661,8 +671,18 @@ class smartmenu_helper {
      * @return void
      */
     public static function clear_user_cachepreferencemenu() {
-        global $USER;
-        set_user_preference('theme_boost_union_menu_purgesessioncache', false, $USER);
+        global $SESSION, $USER;
+
+        // If the user is a guest.
+        if (!isloggedin() || isguestuser($USER)) {
+            // Remove the flag to clear the menu cache.
+            unset($SESSION->theme_boost_union_menu_purgesessioncache);
+
+            // Otherwise.
+        } else {
+            // Remove the user preference to clear all the menu and item caches.
+            set_user_preference('theme_boost_union_menu_purgesessioncache', false, $USER);
+        }
     }
 
     /**

--- a/tests/behat/theme_boost_union_smartmenusettings_menuitems_rules.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menuitems_rules.feature
@@ -197,6 +197,100 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
       | en, de     | should                    | should not                | should                   |
 
   @javascript
+  Scenario: Smartmenu: Menu items: Rules - Rules - Show smart menu item based on the user's prefered language - Handle the case of forced language courses
+    Given the following "language packs" exist:
+      | language |
+      | de       |
+      | fr       |
+    And the following "courses" exist:
+      | fullname           | shortname | category |
+      | Forced Language de | FL1       | 0        |
+      | Forced Language fr | FL2       | 0        |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu      | Quick links      |
+      | title     | Language menu de |
+      | itemtype  | Static           |
+      | url       | /bar             |
+      | languages | de               |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu      | Quick links      |
+      | title     | Language menu fr |
+      | itemtype  | Static           |
+      | url       | /bar             |
+      | languages | fr               |
+    And I am on "Forced Language fr" course homepage with editing mode on
+    And I follow "Settings"
+    And I set the following fields to these values:
+      | id_lang | fr |
+    And I press "Save and display"
+    And I am on "Forced Language de" course homepage with editing mode on
+    And I follow "Settings"
+    And I set the following fields to these values:
+      | id_lang | de |
+    And I press "Save and display"
+    And I log out
+    And I log in as "student1"
+    And I am on "Forced Language de" course homepage
+    Then "Language menu de" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Language menu fr" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And I am on "Forced Language fr" course homepage
+    Then "Language menu de" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Language menu fr" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And I am on "Test" course homepage
+    Then "Language menu de" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Language menu fr" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+
+  @javascript
+  Scenario: Smartmenu: Menu items: Rules - Rules - Show smart menu item based on the user's prefered language - Handle the case of guests changing their language
+    Given the following "language packs" exist:
+      | language |
+      | de       |
+      | fr       |
+    And the following config values are set as admin:
+      | name             | value |
+      | guestloginbutton | 1     |
+      | autologinguests  | 1     |
+      | forcelogin       | 1     |
+    And the following "courses" exist:
+      | fullname           | shortname | category |
+      | Forced Language de | FL1       | 0        |
+      | Forced Language fr | FL2       | 0        |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu      | Quick links      |
+      | title     | Language menu de |
+      | itemtype  | Static           |
+      | url       | /bar             |
+      | languages | de               |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu      | Quick links      |
+      | title     | Language menu fr |
+      | itemtype  | Static           |
+      | url       | /bar             |
+      | languages | fr               |
+    And I am on "Forced Language fr" course homepage with editing mode on
+    And I follow "Settings"
+    And I set the following fields to these values:
+      | id_lang | fr |
+    And I press "Save and display"
+    And I am on "Forced Language de" course homepage with editing mode on
+    And I follow "Settings"
+    And I set the following fields to these values:
+      | id_lang | de |
+    And I press "Save and display"
+    And I log out
+    And I should see "You are currently using guest access"
+    Then "Language menu de" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Language menu fr" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And I click on "#lang-menu-toggle" "css_element"
+    And I click on "Deutsch ‎(de)‎" "link" in the "#lang-action-menu" "css_element"
+    Then "Language menu de" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Language menu fr" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And I click on "#lang-menu-toggle" "css_element"
+    And I click on "Français ‎(fr)‎" "link" in the "#lang-action-menu" "css_element"
+    Then "Language menu de" "theme_boost_union > Smart menu item" should not exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+    And "Language menu fr" "theme_boost_union > Smart menu item" should exist in the "Quick links" "theme_boost_union > Main menu smart menu"
+
+  @javascript
   Scenario Outline: Smartmenu: Menu items: Rules - Show smart menu item based on the custom date range
     Given the following "theme_boost_union > smart menu item" exists:
       | menu        | Quick links        |

--- a/tests/behat/theme_boost_union_smartmenusettings_menus_rules.feature
+++ b/tests/behat/theme_boost_union_smartmenusettings_menus_rules.feature
@@ -36,10 +36,6 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
       | Title          | Resources          |
       | Menu item type | Static             |
       | URL            | https://moodle.org |
-    And the following "language packs" exist:
-      | language |
-      | de       |
-      | fr       |
 
   @javascript
   Scenario Outline: Smartmenu: Menus: Rules - Show smart menu based on the user roles
@@ -169,6 +165,10 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
 
   @javascript
   Scenario Outline: Smartmenu: Menus: Rules - Show smart menu based on the user's prefered language
+    Given the following "language packs" exist:
+      | language |
+      | de       |
+      | fr       |
     When I log in as "teacher"
     And I follow "Preferences" in the user menu
     And I click on "Preferred language" "link"
@@ -211,6 +211,128 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
       | English, Deutsch | should                    | should not                | should                   |
 
   @javascript
+  Scenario: Smartmenu: Menus: Rules - Show smart menu based on the user's prefered language - Handle the case of forced language courses
+    Given the following "language packs" exist:
+      | language |
+      | de       |
+      | fr       |
+    And the following "courses" exist:
+      | fullname           | shortname | category |
+      | Forced Language de | FL1       | 0        |
+      | Forced Language fr | FL2       | 0        |
+    And the following "theme_boost_union > smart menu" exists:
+      | title    | Language de     |
+      | location | Main navigation |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu     | Language de          |
+      | title    | Language menu node 1 |
+      | itemtype | Static               |
+      | url      | /bar                 |
+    And the following "theme_boost_union > smart menu" exists:
+      | title    | Language fr     |
+      | location | Main navigation |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu     | Language fr          |
+      | title    | Language menu node 2 |
+      | itemtype | Static               |
+      | url      | /bar                 |
+    And I am on "Forced Language fr" course homepage with editing mode on
+    And I follow "Settings"
+    And I set the following fields to these values:
+      | id_lang | fr |
+    And I press "Save and display"
+    And I am on "Forced Language de" course homepage with editing mode on
+    And I follow "Settings"
+    And I set the following fields to these values:
+      | id_lang | de |
+    And I press "Save and display"
+    And I click on "Website-Administration" "link"
+    And I navigate to smart menus
+    And I click on ".action-edit" "css_element" in the "Language de" "table_row"
+    And I expand all fieldsets
+    And I set the field "By language" to "Deutsch"
+    And I click on "Save and return" "button"
+    And I click on ".action-edit" "css_element" in the "Language fr" "table_row"
+    And I expand all fieldsets
+    And I set the field "By language" to "Français"
+    And I click on "Save and return" "button"
+    And I log out
+    And I log in as "student1"
+    And I am on "Forced Language de" course homepage
+    Then I should see smart menu "Language de" in location "Main"
+    And I should not see smart menu "Language fr" in location "Main"
+    And I am on "Forced Language fr" course homepage
+    Then I should not see smart menu "Language de" in location "Main"
+    And I should see smart menu "Language fr" in location "Main"
+    And I am on "Test" course homepage
+    Then I should not see smart menu "Language de" in location "Main"
+    And I should not see smart menu "Language fr" in location "Main"
+
+  @javascript
+  Scenario: Smartmenu: Menus: Rules - Show smart menu based on the user's prefered language - Handle the case of guests changing their language
+    Given the following "language packs" exist:
+      | language |
+      | de       |
+      | fr       |
+    And the following config values are set as admin:
+      | name             | value |
+      | guestloginbutton | 1     |
+      | autologinguests  | 1     |
+      | forcelogin       | 1     |
+    And the following "courses" exist:
+      | fullname           | shortname | category |
+      | Forced Language de | FL1       | 0        |
+      | Forced Language fr | FL2       | 0        |
+    And the following "theme_boost_union > smart menu" exists:
+      | title    | Language de     |
+      | location | Main navigation |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu     | Language de          |
+      | title    | Language menu node 1 |
+      | itemtype | Static               |
+      | url      | /bar                 |
+    And the following "theme_boost_union > smart menu" exists:
+      | title    | Language fr     |
+      | location | Main navigation |
+    And the following "theme_boost_union > smart menu item" exists:
+      | menu     | Language fr          |
+      | title    | Language menu node 2 |
+      | itemtype | Static               |
+      | url      | /bar                 |
+    And I am on "Forced Language fr" course homepage with editing mode on
+    And I follow "Settings"
+    And I set the following fields to these values:
+      | id_lang | fr |
+    And I press "Save and display"
+    And I am on "Forced Language de" course homepage with editing mode on
+    And I follow "Settings"
+    And I set the following fields to these values:
+      | id_lang | de |
+    And I press "Save and display"
+    And I click on "Website-Administration" "link"
+    And I navigate to smart menus
+    And I click on ".action-edit" "css_element" in the "Language de" "table_row"
+    And I expand all fieldsets
+    And I set the field "By language" to "Deutsch"
+    And I click on "Save and return" "button"
+    And I click on ".action-edit" "css_element" in the "Language fr" "table_row"
+    And I expand all fieldsets
+    And I set the field "By language" to "Français"
+    And I click on "Save and return" "button"
+    And I log out
+    And I should see "You are currently using guest access"
+    Then I should not see smart menu "Language de" in location "Main"
+    And I should not see smart menu "Language fr" in location "Main"
+    And I click on "#lang-menu-toggle" "css_element"
+    And I click on "Deutsch ‎(de)‎" "link" in the "#lang-action-menu" "css_element"
+    Then I should see smart menu "Language de" in location "Main"
+    And I should not see smart menu "Language fr" in location "Main"
+    And I click on "#lang-menu-toggle" "css_element"
+    And I click on "Français ‎(fr)‎" "link" in the "#lang-action-menu" "css_element"
+    Then I should not see smart menu "Language de" in location "Main"
+    And I should see smart menu "Language fr" in location "Main"
+
+  @javascript
   Scenario Outline: Smartmenu: Menus: Rules - Show the menus based on the custom date range
     When I navigate to smart menus
     And I should see "Quick links" in the "smartmenus" "table"
@@ -247,7 +369,11 @@ Feature: Configuring the theme_boost_union plugin on the "Smart menus" page, app
 
   @javascript
   Scenario Outline: Smartmenu: Menus: Rules - Show smart menu based on multiple conditions
-    Given I log in as "teacher"
+    Given the following "language packs" exist:
+      | language |
+      | de       |
+      | fr       |
+    And I log in as "teacher"
     And I follow "Preferences" in the user menu
     And I click on "Preferred language" "link"
     And I set the field "Preferred language" to "Deutsch ‎(de)‎"


### PR DESCRIPTION
This is a replacement of #911. See the discussion there.