### PR TITLE
Feature: Add color picker settings for calendar branding, resolves #434.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2025-06-06 - Feature: Add color picker settings for calendar branding, resolves #434.
 * 2025-06-30 - Regression: Flavour favicon images were not working, resolves #942
 * 2025-06-30 - Regression: Flavour background images were not working, resolves #942
 * 2025-06-30 - Improvement: Allow the "guest access" hint for teachers to be shown as well if a guest password is set, resolves #984

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ With these settings, you can override the activity icon background color which i
 
 With this setting, you can modify the icons for activities and resources which are used by Moodle on the course pages and in the activity chooser. You can upload custom icons for all or only some activity modules installed in this Moodle instance.
 
+#### Tab "Calendar Branding"
+
+##### Calendar event types
+
+With these settings, you can override the main colors and border colors of individual calendar entry types.
+
+##### General calendar branding
+
+With these settings, you can set additional colors for the calendar views.
+
 #### Tab "Login page"
 
 ##### Login page background images

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -252,6 +252,29 @@ $string['modiconversion'] = 'Icon version';
 $string['modicongtmoodle4'] = 'Moodle 4 icon';
 $string['modiconltmoodle311'] = 'Moodle 3 legacy icon';
 
+// Settings: Calendar branding tab.
+$string['calendarbrandingtab'] = 'Calendar branding';
+// Placeholders: Calendar event types.
+$string['calendareventtypecategory'] = 'Category';
+$string['calendareventtypecourse'] = 'Course';
+$string['calendareventtypegroup'] = 'Group';
+$string['calendareventtypeother'] = 'Other';
+$string['calendareventtypesite'] = 'Site';
+$string['calendareventtypeuser'] = 'User';
+// ... Section: Event types.
+$string['calendareventcolorsheading'] = 'Calendar event type: {$a}';
+// ... ... Setting: Main color of the calendar event.
+$string['calendareventcolormainsetting'] = 'Main color of the calendar event type "{$a}"';
+$string['calendareventcolormainsetting_desc'] = 'The main color of the calendar event type "{$a}" which is used for icons and backgrounds.';
+// ... ... Setting: Border color of the calendar event.
+$string['calendareventcolorbordersetting'] = 'Border color of the calendar event type "{$a}"';
+$string['calendareventcolorbordersetting_desc'] = 'The color of the calendar event type "{$a}" which is used for borders.';
+// ... Section: General calendar branding.
+$string['calendarbrandingheading'] = 'General calendar branding';
+// ... ... Setting: Calendar icon colors.
+$string['calendariconscolorsetting'] = 'Calendar icon colors';
+$string['calendariconscolorsetting_desc'] = 'The color of some icons which are used in the calendar views. The default color is blue, but this might clash with the calendar branding colors which you might set above.';
+
 // Settings: Login page tab.
 $string['loginpagetab'] = 'Login page';
 // ... Section: Login page background images.

--- a/lib.php
+++ b/lib.php
@@ -241,6 +241,19 @@ function theme_boost_union_get_pre_scss($theme) {
         'bootstrapcolorinfo' => ['info'],
         'bootstrapcolorwarning' => ['warning'],
         'bootstrapcolordanger' => ['danger'],
+        'calendareventcolormaincategory' => ['calendarEventCategoryColor'],
+        'calendareventcolorbordercategory' => ['calendarEventCategoryBorderColor'],
+        'calendareventcolormaincourse' => ['calendarEventCourseColor'],
+        'calendareventcolorbordercourse' => ['calendarEventCourseBorderColor'],
+        'calendareventcolormaingroup' => ['calendarEventGroupColor'],
+        'calendareventcolorbordergroup' => ['calendarEventGroupBorderColor'],
+        'calendareventcolormainsite' => ['calendarEventGlobalColor'],
+        'calendareventcolorbordersite' => ['calendarEventGlobalBorderColor'],
+        'calendareventcolormainuser' => ['calendarEventUserColor'],
+        'calendareventcolorborderuser' => ['calendarEventUserBorderColor'],
+        'calendareventcolormainother' => ['calendarEventOtherColor'],
+        'calendareventcolorborderother' => ['calendarEventOtherBorderColor'],
+        'calendariconscolor' => ['calendarEventColor'],
     ];
 
     // Define the configurables which can be overridden by flavours.

--- a/settings.php
+++ b/settings.php
@@ -680,6 +680,60 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $page->add($tab);
 
 
+        // Create calendar branding tab.
+        $tab = new admin_settingpage('theme_boost_union_look_calendarbranding',
+            get_string('calendarbrandingtab', 'theme_boost_union', null, true));
+
+        // Define supported calendar event types.
+        $calendareventtypes = ['category', 'course', 'group', 'user', 'site', 'other'];
+        // Iterate over all event types.
+        foreach ($calendareventtypes as $type) {
+            // Create Calendar event type heading.
+            $name = 'theme_boost_union/calendareventcolorsheading'.$type;
+            $title = get_string('calendareventcolorsheading', 'theme_boost_union',
+                    get_string('calendareventtype'.$type, 'theme_boost_union', null, true), true);
+            $setting = new admin_setting_heading($name, $title, null);
+            $tab->add($setting);
+
+            // Setting: Main color of the calendar event type.
+            $name = 'theme_boost_union/calendareventcolormain'.$type;
+            $title = get_string('calendareventcolormainsetting', 'theme_boost_union',
+                    get_string('calendareventtype'.$type, 'theme_boost_union', null, true), true);
+            $description = get_string('calendareventcolormainsetting_desc', 'theme_boost_union',
+                    get_string('calendareventtype'.$type, 'theme_boost_union', null, true), true);
+            $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+            $setting->set_updatedcallback('theme_reset_all_caches');
+            $tab->add($setting);
+
+            // Setting: Border color of the calendar event type.
+            $name = 'theme_boost_union/calendareventcolorborder'.$type;
+            $title = get_string('calendareventcolorbordersetting', 'theme_boost_union',
+                    get_string('calendareventtype'.$type, 'theme_boost_union', null, true), true);
+            $description = get_string('calendareventcolorbordersetting_desc', 'theme_boost_union',
+                    get_string('calendareventtype'.$type, 'theme_boost_union', null, true), true);
+            $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+            $setting->set_updatedcallback('theme_reset_all_caches');
+            $tab->add($setting);
+        }
+
+        // Create calendarbrandingheading heading.
+        $name = 'theme_boost_union/calendarbrandingheading';
+        $title = get_string('calendarbrandingheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Calendar icon colors.
+        $name = 'theme_boost_union/calendariconscolor';
+        $title = get_string('calendariconscolorsetting', 'theme_boost_union', null, true);
+        $description = get_string('calendariconscolorsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configcolourpicker($name, $title, $description, '');
+        $setting->set_updatedcallback('theme_reset_all_caches');
+        $tab->add($setting);
+
+        // Add tab to settings page.
+        $page->add($tab);
+
+
         // Create login page tab.
         $tab = new admin_settingpage('theme_boost_union_look_loginpage',
                 get_string('loginpagetab', 'theme_boost_union', null, true));

--- a/tests/behat/theme_boost_union_looksettings_calendarbranding.feature
+++ b/tests/behat/theme_boost_union_looksettings_calendarbranding.feature
@@ -1,0 +1,136 @@
+@theme @theme_boost_union @theme_boost_union_looksettings @theme_boost_union_looksettings_calendarbranding
+Feature: Configuring the theme_boost_union plugin for the "Calendar branding" tab on the "Look" page
+  In order to use the features
+  As admin
+  I need to be able to configure the theme Boost Union plugin
+
+  Background:
+    Given the following "categories" exist:
+      | name          | category | idnumber |
+      | My category 1 | 0        | CAT1     |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | CAT1     |
+    And the following "course enrolments" exist:
+      | user  | course | role           |
+      | admin | C1     | editingteacher |
+    And the following "blocks" exist:
+      | blockname      | contextlevel | reference | pagetypepattern | defaultregion |
+      | calendar_month | System       | 1         | my-index        | content       |
+
+  @javascript
+  Scenario: Setting: Calendar event colors - Setting the color for event type "Category"
+    Given the following config values are set as admin:
+      | config                           | value   | plugin            |
+      | calendareventcolormaincategory   | #ffc8ff | theme_boost_union |
+      | calendareventcolorbordercategory | #ff00ff | theme_boost_union |
+    And the theme cache is purged and the theme is reloaded
+    When I log in as "admin"
+    And I create a calendar event with form data:
+      | Type of event | Category         |
+      | Category      | My category 1    |
+      | Event title   | Category 1 Event |
+    And I follow "Dashboard"
+    Then DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_category" should have computed style "background-color" "rgb(255, 200, 255)"
+    # Now we have to test each border property for one particular border side individually as the Behat step would handle border or even border-with as shorthand notation which is untestable currently.
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_category" should have computed style "border-top-width" "2px"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_category" should have computed style "border-top-style" "solid"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_category" should have computed style "border-top-color" "rgb(255, 0, 255)"
+
+  @javascript
+  Scenario: Setting: Calendar event colors - Setting the color for event type "Course"
+    Given the following config values are set as admin:
+      | config                         | value   | plugin            |
+      | calendareventcolormaincourse   | #ffc8ff | theme_boost_union |
+      | calendareventcolorbordercourse | #ff00ff | theme_boost_union |
+    And the theme cache is purged and the theme is reloaded
+    When I log in as "admin"
+    And I create a calendar event with form data:
+      | Type of event | Course         |
+      | Course        | Course 1       |
+      | Event title   | Course 1 Event |
+    And I follow "Dashboard"
+    Then DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_course" should have computed style "background-color" "rgb(255, 200, 255)"
+    # Now we have to test each border property for one particular border side individually as the Behat step would handle border or even border-with as shorthand notation which is untestable currently.
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_course" should have computed style "border-top-width" "2px"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_course" should have computed style "border-top-style" "solid"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_course" should have computed style "border-top-color" "rgb(255, 0, 255)"
+
+  @javascript
+  Scenario: Setting: Calendar event colors - Setting the color for event type "Group"
+    Given the following config values are set as admin:
+      | config                        | value   | plugin            |
+      | calendareventcolormaingroup   | #ffc8ff | theme_boost_union |
+      | calendareventcolorbordergroup | #ff00ff | theme_boost_union |
+    And the theme cache is purged and the theme is reloaded
+    And the following "groups" exist:
+      | name    | course | idnumber |
+      | Group 1 | C1     | G1       |
+    And the following "group members" exist:
+      | user  | group |
+      | admin | G1    |
+    When I log in as "admin"
+    And I set the field "course" in the ".block_calendar_month" "css_element" to "Course 1"
+    And I create a calendar event:
+      | Type of event | Group         |
+      | Group         | Group 1       |
+      | Event title   | Group 1 Event |
+    And I follow "Dashboard"
+    Then DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_group" should have computed style "background-color" "rgb(255, 200, 255)"
+    # Now we have to test each border property for one particular border side individually as the Behat step would handle border or even border-with as shorthand notation which is untestable currently.
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_group" should have computed style "border-top-width" "2px"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_group" should have computed style "border-top-style" "solid"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_group" should have computed style "border-top-color" "rgb(255, 0, 255)"
+
+  @javascript
+  Scenario: Setting: Calendar event colors - Setting the color for event type "User"
+    Given the following config values are set as admin:
+      | config                       | value   | plugin            |
+      | calendareventcolormainuser   | #ffc8ff | theme_boost_union |
+      | calendareventcolorborderuser | #ff00ff | theme_boost_union |
+    And the theme cache is purged and the theme is reloaded
+    When I log in as "admin"
+    And I create a calendar event with form data:
+      | Type of event | User       |
+      | Event title   | User Event |
+    And I follow "Dashboard"
+    Then DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_user" should have computed style "background-color" "rgb(255, 200, 255)"
+    # Now we have to test each border property for one particular border side individually as the Behat step would handle border or even border-with as shorthand notation which is untestable currently.
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_user" should have computed style "border-top-width" "2px"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_user" should have computed style "border-top-style" "solid"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_user" should have computed style "border-top-color" "rgb(255, 0, 255)"
+
+  @javascript
+  Scenario: Setting: Calendar event colors - Setting the color for event type "Site"
+    Given the following config values are set as admin:
+      | config                       | value   | plugin            |
+      | calendareventcolormainsite   | #ffc8ff | theme_boost_union |
+      | calendareventcolorbordersite | #ff00ff | theme_boost_union |
+    And the theme cache is purged and the theme is reloaded
+    When I log in as "admin"
+    And I create a calendar event with form data:
+      | Type of event | Site       |
+      | Event title   | Site Event |
+    And I follow "Dashboard"
+    Then DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_site" should have computed style "background-color" "rgb(255, 200, 255)"
+    # Now we have to test each border property for one particular border side individually as the Behat step would handle border or even border-with as shorthand notation which is untestable currently.
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_site" should have computed style "border-top-width" "2px"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_site" should have computed style "border-top-style" "solid"
+    And DOM element ".maincalendar .calendarmonth ul li .calendar-circle.calendar_event_site" should have computed style "border-top-color" "rgb(255, 0, 255)"
+
+  # Unfortunately, this can't be tested with Behat as the event type is not displayed as an option when creating a new event
+  # Scenario: Setting: Calendar event colors - Setting the color for event type "Other"
+
+  @javascript
+  Scenario: Setting: General calendar branding - Setting the color for calendar icons
+    Given the following config values are set as admin:
+      | config             | value   | plugin            |
+      | calendariconscolor | #022973 | theme_boost_union |
+    And the theme cache is purged and the theme is reloaded
+    When I log in as "admin"
+    And I create a calendar event with form data:
+      | Type of event | User       |
+      | Event title   | User Event |
+    And I follow "Dashboard"
+    And I click on "Full calendar" "link"
+    Then DOM element ".block .calendar_filters li span i" should have computed style "color" "rgb(2, 41, 115)"

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2025041410;
+$plugin->version = 2025041411;
 $plugin->release = 'v5.0-r4';
 $plugin->requires = 2025041401;
 $plugin->supported = [500, 500];


### PR DESCRIPTION
This feature was initially built by @wa-bea in https://github.com/wa-bea/moodle-theme_boost_union/commit/4e87ec1a07f9269f8cd8b8026fade773336e6899, I have just adopted and polished it