### PR TITLE
 Bugfix: Text and media elements (aka. labels) were shown in the course index also in non edit mode, resolves #637

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2025-07-25 - Bugfix: Text and media elements (aka. labels) were shown in the course index also in non edit mode - which should not happen until Moodle 4.2 and which was caused by a wrong feature backport in Boost Union, resolves #637
+
 ### v4.1-r46
 
 * 2025-06-30 - Regression: Flavour favicon images were not working, resolves #942

--- a/templates/core_courseformat/local/courseindex/cm.mustache
+++ b/templates/core_courseformat/local/courseindex/cm.mustache
@@ -45,7 +45,7 @@
         {{#isactive}}active{{/isactive}}
         {{#hascmrestrictions}}restrictions{{/hascmrestrictions}}
         {{^accessvisible}}dimmed{{/accessvisible}}
-        d-flex
+        {{#url}} d-flex {{/url}} {{^url}} d-flex-noedit {{/url}}
         {{#indent}} indented {{/indent}}"
     id="course-index-cm-{{id}}"
     data-for="cm"
@@ -61,21 +61,23 @@
             </span>
         </span>
     </span>
-    {{#uservisible}}
-    <a
-        class="courseindex-link text-truncate"
-        {{#url}} href="{{{url}}}" {{/url}}{{^url}} href="#{{{anchor}}}" data-anchor="true" {{/url}}
-        data-for="cm_name"
-        tabindex="-1"
-    >
+    {{#url}}
+        {{#uservisible}}
+            <a class="courseindex-link text-truncate" href="{{{url}}}" data-for="cm_name" tabindex="-1">
+                {{{name}}}
+            </a>
+        {{/uservisible}}
+        {{^uservisible}}
+            <a class="courseindex-link text-truncate" href="#{{{anchor}}}" data-for="cm_name" tabindex="-1" data-anchor="true">
+                {{{name}}}
+            </a>
+        {{/uservisible}}
+    {{/url}}
+    {{^url}}
+    <span class="courseindex-name text-truncate" data-for="cm_name">
         {{{name}}}
-    </a>
-    {{/uservisible}}
-    {{^uservisible}}
-    <a class="courseindex-link text-truncate" href="#{{{anchor}}}" data-for="cm_name" tabindex="-1" data-anchor="true">
-        {{{name}}}
-    </a>
-    {{/uservisible}}
+    </span>
+    {{/url}}
     <span class="courseindex-locked ml-1" data-for="cm_name">
         {{#pix}} t/locked, core {{/pix}}
     </span>

--- a/templates/core_courseformat/local/courseindex/cm.mustache.upstream
+++ b/templates/core_courseformat/local/courseindex/cm.mustache.upstream
@@ -36,7 +36,7 @@
         {{#isactive}}active{{/isactive}}
         {{#hascmrestrictions}}restrictions{{/hascmrestrictions}}
         {{^accessvisible}}dimmed{{/accessvisible}}
-        d-flex
+        {{#url}} d-flex {{/url}} {{^url}} d-flex-noedit {{/url}}
         {{#indent}} indented {{/indent}}"
     id="course-index-cm-{{id}}"
     data-for="cm"
@@ -44,21 +44,23 @@
     role="treeitem"
 >
     <span class="completioninfo" data-for="cm_completion" data-value="NaN"></span>
-    {{#uservisible}}
-    <a
-        class="courseindex-link text-truncate"
-        {{#url}} href="{{{url}}}" {{/url}}{{^url}} href="#{{{anchor}}}" data-anchor="true" {{/url}}
-        data-for="cm_name"
-        tabindex="-1"
-    >
+    {{#url}}
+        {{#uservisible}}
+            <a class="courseindex-link text-truncate" href="{{{url}}}" data-for="cm_name" tabindex="-1">
+                {{{name}}}
+            </a>
+        {{/uservisible}}
+        {{^uservisible}}
+            <a class="courseindex-link text-truncate" href="#{{{anchor}}}" data-for="cm_name" tabindex="-1" data-anchor="true">
+                {{{name}}}
+            </a>
+        {{/uservisible}}
+    {{/url}}
+    {{^url}}
+    <span class="courseindex-name text-truncate" data-for="cm_name">
         {{{name}}}
-    </a>
-    {{/uservisible}}
-    {{^uservisible}}
-    <a class="courseindex-link text-truncate" href="#{{{anchor}}}" data-for="cm_name" tabindex="-1" data-anchor="true">
-        {{{name}}}
-    </a>
-    {{/uservisible}}
+    </span>
+    {{/url}}
     <span class="courseindex-locked ml-1" data-for="cm_name">
         {{#pix}} t/locked, core {{/pix}}
     </span>


### PR DESCRIPTION
This PR targets 401 only