### PR TITLE
Bugfix: Site support form success message is shown below blocks or advert tiles on frontpage, resolves #488

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2026-02-03 - Bugfix: Site support form success message was shown below blocks or advert tiles on frontpage, resolves #488
 * 2026-02-01 - Feature: Add dark variant setting for the slider, resolves #914
 * 2026-02-01 - Feature: Add individual carousel item interval setting for each slide, resolves #915
 * 2026-02-01 - Improvement: Replace smartmenu_item_edit_form.js with Moodle core solution for hiding headers, resolves #1028
@@ -54,7 +55,6 @@ Changes
 * 2025-11-03 - Glitch: upgrade.php did not match install.xml regarding the theme_boost_union_snippets table, resolves #1062
 * 2025-11-03 - Improvement: Use human-understandable values in the background position settings, resolves #1086
 * 2025-11-03 - Improvement: Make the outside-left and outside-right block regions fully responsive, finally moving them out of their experimental state, resolves #266.
-* 2025-10-24 - Bugfix: Site support form success message was shown below blocks or advert tiles on frontpage, resolves #488
 * 2025-10-23 - Feature: Add a type for smart menu item to use mailto links, resolves #702
 
 ### v5.0-r11

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -758,16 +758,17 @@ class core_renderer extends \theme_boost\output\core_renderer {
     }
 
     /**
-     * Returns just the notifications part of course_content_header.
+     * Returns course-specific information to be output immediately above content on any course page
+     * (for the current course)
      *
      * This renderer function is copied and modified from /lib/classes/output/core_renderer.php
      *
-     * It is based on the course_content_header() function but was split into two parts
-     * (for the notifications and the course content) to be requested individually in drawers.mustache
+     * It is based on the standard_end_of_body_html() function but was split into two parts
+     * (for the additionalhtmlfooter and the unique endtoken) to be requested individually in footer.mustache
      * in Boost Union.
      *
      * @param bool $onlyifnotcalledbefore output content only if it has not been output before
-     * @return string HTML fragment containing notifications.
+     * @return string
      */
     public function course_content_header_notifications($onlyifnotcalledbefore = false) {
         static $functioncalled = false;
@@ -775,7 +776,6 @@ class core_renderer extends \theme_boost\output\core_renderer {
             // We have already output the notifications.
             return '';
         }
-        $functioncalled = true;
 
         // Output any session notification.
         $notifications = \core\notification::fetch();
@@ -790,20 +790,23 @@ class core_renderer extends \theme_boost\output\core_renderer {
 
         $output = html_writer::span($bodynotifications, 'notifications', ['id' => 'user-notifications']);
 
+        $functioncalled = true;
+
         return $output;
     }
 
     /**
-     * Returns just the course content header part of course_content_header.
+     * Returns course-specific information to be output immediately above content on any course page
+     * (for the current course)
      *
      * This renderer function is copied and modified from /lib/classes/output/core_renderer.php
      *
-     * It is based on the course_content_header() function but was split into two parts
-     * (for the notifications and the course content) to be requested individually in drawers.mustache
+     * It is based on the standard_end_of_body_html() function but was split into two parts
+     * (for the additionalhtmlfooter and the unique endtoken) to be requested individually in footer.mustache
      * in Boost Union.
      *
      * @param bool $onlyifnotcalledbefore output content only if it has not been output before
-     * @return string HTML fragment containing course content header.
+     * @return string
      */
     public function course_content_header_coursecontent($onlyifnotcalledbefore = false) {
         global $CFG;
@@ -813,20 +816,21 @@ class core_renderer extends \theme_boost\output\core_renderer {
             // We have already output the course content header.
             return '';
         }
-        $functioncalled = true;
 
-        // If we are on the site homepage, there is no course content header.
+        $output = '';
+
         if ($this->page->course->id == SITEID) {
-            return '';
+            // Return immediately and do not include /course/lib.php if not necessary.
+            return $output;
         }
 
         require_once($CFG->dirroot . '/course/lib.php');
+        $functioncalled = true;
         $courseformat = course_get_format($this->page->course);
         if (($obj = $courseformat->course_content_header()) !== null) {
-            return html_writer::div($courseformat->get_renderer($this->page)->render($obj), 'course-content-header');
+            $output .= html_writer::div($courseformat->get_renderer($this->page)->render($obj), 'course-content-header');
         }
-
-        return '';
+        return $output;
     }
 
     /**

--- a/templates/theme_boost/drawers.mustache
+++ b/templates/theme_boost/drawers.mustache
@@ -61,6 +61,9 @@
     * Include theme_boost_union/advertisementtiles template
     * Include theme_boost_union/slider template
     * Added additional block regions (including JS for offcanvas region)
+      During this implementation, course_content_header was split into two functions
+        course_content_header_notifications and course_content_header_coursecontent to be able to show the notifications
+        before the blocks in the contentupper region.
     * Added smartmenu js to support third level submenus.
     * Added blockregions JS to support vertical alignment of outside regions. Included alignmentspacers for the outside left and right regions.
 }}

--- a/tests/behat/theme_boost_union_feelsettings_blocks.feature
+++ b/tests/behat/theme_boost_union_feelsettings_blocks.feature
@@ -560,7 +560,7 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
       | 0       | should not contain | after       |
 
   @javascript
-  Scenario: Support form success notification is shown before content-upper blocks on the homepage
+  Scenario: Notifications are shown before content-upper blocks on the homepage
     Given the following config values are set as admin:
       | config                     | value         | plugin            |
       | defaulthomepage            | Home          |                   |
@@ -577,4 +577,3 @@ Feature: Configuring the theme_boost_union plugin for the "Blocks" tab on the "F
     And I click on "Submit" "button"
     And I wait until the page is ready
     Then "Your accessibility support request was sent" "text" should appear before ".block_online_users" "css_element"
-


### PR DESCRIPTION
…t tiles on frontpage, resolves #488

On behalf of the Boost Union Team: 🎉 Thank you for contributing! 🎉

**Please note: There must be a GitHub issue for every pull request (PR)**

We kindly ask you to [create a github issue now](https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues/new/choose) if you haven't already done so.

Please make sure to follow these steps to ease the review process for the peer review team:

[ ] link your issue in the PR title, using the keyword 'resolves #ISSUE-NUMBER', e.g. 'Feature: Provide the ultimate user experience, resolves #42'
[ ] provide any further information that is relevant for peer review and not yet mentioned in the linked issue as a comment in the PR
[ ] make sure that the 'Allow edits by maintainers' checkbox is checked when creating the PR. Otherwise, the peer reviewer would not be able to push any review changes to the PR and the communication overhead increases
[ ] submit your PR in draft status to run the automated checks and review the results
[ ] in case any checks fail solve the mentioned errors by pushing the corrected code to your PR-branch
[ ] if all checks pass (or if you are unable to resolve the failing steps without any help of the review team), mark the PR as 'ready for review'

Thank you again for your contribution, we will start reviewing your PR as soon as we are able to.

In the meantime, please check our [wiki page for creating pull requests](https://github.com/moodle-an-hochschulen/moodle-plugin-maintaining/wiki/Forking-a-plugin,-creating-a-pull-request-and-keeping-your-plugin-fork-repo-up-to-date-(correctly)) and our [wiki page for reviewing pull requests](https://github.com/moodle-an-hochschulen/moodle-plugin-maintaining/wiki/Check-list-for-peer-reviewing-patches-and-pull-requests) for further infomation about our contribution and review process.
