### PR TITLE
Improvement: Add a test to view a user tour

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2026-04-07 - Tests: Add a test to view a user tour
 * 2026-04-03 - Improvement: Add CLI script to validate the SCSS compilation and to see SCSS compilation errors, resolves #1217
 * 2026-03-31 - Improvement: Allow the footnote text to be set in flavours as well, resolves #1216
 * 2026-03-31 - Internal change: Prefix all custom Boost Union SCSS variables which are set by Boost Union settings with 'bu-' for the sake of consistency

--- a/tests/behat/theme_boost_union_contentsettings_footer.feature
+++ b/tests/behat/theme_boost_union_contentsettings_footer.feature
@@ -383,3 +383,14 @@ Feature: Configuring the theme_boost_union plugin for the "Footer" tab on the "C
       | value | shouldornot |
       | no    | should      |
       | yes   | should not  |
+
+  @javascript
+  Scenario: View a user tour under Boost Union
+    Given I log in as "admin"
+    And I navigate to "Appearance > User tours" in site administration
+    And I click on "Enable" "link" in the "Course editing" "table_row"
+    And I click on "//a[@title=\"Edit\"]" "xpath_element" in the "Course editing" "table_row"
+    And I set the field "id_filter_theme" to "Boost Union"
+    And I press "Save changes"
+    When I am on the "C1" "Course" page logged in as "teacher1"
+    Then I should see "Reset user tour on this page"


### PR DESCRIPTION
This helps avoid situations as in #1209 when a user isn't sure any more that user tours work properly in Boost Union.