### PR TITLE
Tests: Drop 'And Behat debugging is (en|dis)abled' steps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2026-05-01 - Tests: Drop 'And Behat debugging is (en|dis)abled' steps, resolves #1242
 * 2026-04-30 - Cleanup: Drop overwritten templates/theme_boost/drawer.mustache, resolves #1246
 
 ### v5.1-r11

--- a/tests/behat/behat_theme_boost_union_base_general.php
+++ b/tests/behat/behat_theme_boost_union_base_general.php
@@ -475,6 +475,28 @@ class behat_theme_boost_union_base_general extends behat_base {
     }
 
     /**
+     * Disables debugging in Behat.
+     *
+     * We might need to deactivate debugging for a while when Behat steps fail due debugging message which can't be avoided.
+     *
+     * @Given /^Behat debugging is disabled$/
+     */
+    public function disable_behat_debugging() {
+        set_config('debug', 0);
+        set_config('debugdisplay', 0);
+    }
+
+    /**
+     * Re-enables debugging in Behat.
+     *
+     * @Given /^Behat debugging is enabled$/
+     */
+    public function enable_behat_debugging() {
+        set_config('debug', 32767);
+        set_config('debugdisplay', 1);
+    }
+
+    /**
      * Open the login page.
      *
      * @Given /^I am on login page$/

--- a/tests/behat/behat_theme_boost_union_base_general.php
+++ b/tests/behat/behat_theme_boost_union_base_general.php
@@ -475,30 +475,6 @@ class behat_theme_boost_union_base_general extends behat_base {
     }
 
     /**
-     * Disables debugging in Behat.
-     *
-     * We sometimes need to deactivate debugging for a while as Behat steps would otherwise fail due to the
-     * stupid 'Too much data passed as arguments to js_call_amd' debugging message which can't be avoided
-     * on Boost Union settings pages as we simply use too much hide_if() there.
-     *
-     * @Given /^Behat debugging is disabled$/
-     */
-    public function disable_behat_debugging() {
-        set_config('debug', 0);
-        set_config('debugdisplay', 0);
-    }
-
-    /**
-     * Re-enables debugging in Behat.
-     *
-     * @Given /^Behat debugging is enabled$/
-     */
-    public function enable_behat_debugging() {
-        set_config('debug', 32767);
-        set_config('debugdisplay', 1);
-    }
-
-    /**
      * Open the login page.
      *
      * @Given /^I am on login page$/

--- a/tests/behat/theme_boost_union_contentsettings_advertisementtiles.feature
+++ b/tests/behat/theme_boost_union_contentsettings_advertisementtiles.feature
@@ -232,7 +232,6 @@ Feature: Configuring the theme_boost_union plugin for the "Advertisement tiles" 
       | config       | value | plugin            |
       | tile1enabled | yes   | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Content" in site administration
     And I click on "Advertisement tiles" "link" in the "#adminsettings .nav-tabs" "css_element"
     Then "#admin-tile1title" "css_element" should be visible

--- a/tests/behat/theme_boost_union_contentsettings_infobanners.feature
+++ b/tests/behat/theme_boost_union_contentsettings_infobanners.feature
@@ -193,7 +193,6 @@ Feature: Configuring the theme_boost_union plugin for the "Information banners" 
     And I should not see "This is a test content"
     And I log out
     When I log in as "admin"
-    And Behat debugging is disabled
     # Navigating to the content settings may fail with an initialization error of the core_sms\manager for unknown reasons.
     # Purging the caches before navigating to the content area fixed the Behat failure for the same unknown reasons.
     # We accept this fix as the error seems not to happen in production.
@@ -204,7 +203,6 @@ Feature: Configuring the theme_boost_union plugin for the "Information banners" 
     And I click on "Reset visibility of info banner 1" "link"
     And I click on "Confirm" "link"
     Then I should see "The visibility of info banner 1 has been reset"
-    And Behat debugging is enabled
     And I log out
     When I log in as "teacher1"
     And I follow "Dashboard"

--- a/tests/behat/theme_boost_union_contentsettings_slider.feature
+++ b/tests/behat/theme_boost_union_contentsettings_slider.feature
@@ -338,7 +338,6 @@ Feature: Configuring the theme_boost_union plugin for the "Slider" tab on the "C
       | config        | value | plugin            |
       | slide1enabled | yes   | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Content" in site administration
     And I click on "Slider" "link" in the "#adminsettings .nav-tabs" "css_element"
     Then "#admin-slide1backgroundimage" "css_element" should be visible

--- a/tests/behat/theme_boost_union_general.feature
+++ b/tests/behat/theme_boost_union_general.feature
@@ -25,7 +25,6 @@ Feature: Configuring the theme_boost_union plugin as admin
       | itemtype    | Static             |
       | url         | https://moodle.org |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     Then "body#page-admin-setting-theme_boost_union_look" "css_element" should exist
     And ".admin_settingspage_tabs_with_tertiary" "css_element" should exist
@@ -39,7 +38,6 @@ Feature: Configuring the theme_boost_union plugin as admin
     And ".admin_settingspage_tabs_with_tertiary" "css_element" should be visible
     And I should see "Feel" in the ".admin_settingspage_tabs_with_tertiary .dropdown-toggle" "css_element"
     And "h2:has(+ .admin_settingspage_tabs_with_tertiary)" "css_element" should not be visible
-    And Behat debugging is enabled
     # However, we have to test the 'flavours' page as well as this is an external admin page.
     And I set the field "List of Boost Union settings pages" to "Flavours"
     Then "body#page-admin-theme-boost_union-flavours-overview" "css_element" should exist
@@ -69,7 +67,6 @@ Feature: Configuring the theme_boost_union plugin as admin
     And I should see "Smart menus" in the ".admin_settingspage_tabs_with_tertiary .dropdown-toggle" "css_element"
     And "h2:has(+ .admin_settingspage_tabs_with_tertiary)" "css_element" should not be visible
     # And we have to test the 'all settings on one page' page as well as this is an individual page.
-    And Behat debugging is disabled
     # The remaining steps cannot be executed on Github actions due to a timeout error due to the massive amount of Tiny editors
     # which load on this page. Increasing $CFG->behat_increasetimeout did not help anymore in the end.
     # So we commented these steps which should be okay as they just test jumping to a Moodle core page.
@@ -91,17 +88,13 @@ Feature: Configuring the theme_boost_union plugin as admin
     When I navigate to "Appearance > Boost Union > Settings overview" in site administration
     Then "Boost Union (or a child theme of Boost Union) is currently not the active theme" "text" should appear after "Boost Union settings overview" "text"
     # Look
-    When Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
-    And Behat debugging is enabled
     Then "Boost Union (or a child theme of Boost Union) is currently not the active theme" "text" should appear after ".admin_settingspage_tabs_with_tertiary" "css_element"
     # Feel
     When I navigate to "Appearance > Boost Union > Feel" in site administration
     Then "Boost Union (or a child theme of Boost Union) is currently not the active theme" "text" should appear after ".admin_settingspage_tabs_with_tertiary" "css_element"
     # Content
-    When Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Content" in site administration
-    And Behat debugging is enabled
     Then "Boost Union (or a child theme of Boost Union) is currently not the active theme" "text" should appear after ".admin_settingspage_tabs_with_tertiary" "css_element"
     # Functionality
     When I navigate to "Appearance > Boost Union > Functionality" in site administration
@@ -126,12 +119,10 @@ Feature: Configuring the theme_boost_union plugin as admin
   Scenario: Switch to the active Boost Union admin sub-tab after saving a setting and the following page reload
     When I log in as "admin"
     And I follow "Site administration"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Page" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "Course content max width" to "600px"
     And I click on "Save changes" "button"
-    And Behat debugging is enabled
     Then I should see "Course content max width" in the ".tab-content" "css_element"
     And "#theme_boost_union_look_page.tab-pane.active" "css_element" should exist
     And "#theme_boost_union_look_page.tab-pane:not(.active)" "css_element" should not exist

--- a/tests/behat/theme_boost_union_goodiesfordesigners.feature
+++ b/tests/behat/theme_boost_union_goodiesfordesigners.feature
@@ -27,7 +27,6 @@ Feature: Using the goodies for designers in the theme_boost_union plugin
   @javascript
   Scenario: Feature: Themerev as SCSS variable
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a small CSS snippet to the page which adds the themrev to the Dashboard header.
@@ -37,7 +36,6 @@ Feature: Using the goodies for designers in the theme_boost_union plugin
     #page-my-index h1:after { content: 'Themerev: #{$themerev}'; }
     """
     And I press "Save changes"
-    And Behat debugging is enabled
     And I follow "Dashboard"
     Then I should see "Dashboard" in the "#page-my-index h1" "css_element"
     And element "#page-my-index h1" pseudo-class "after" should contain "content": "Themerev"

--- a/tests/behat/theme_boost_union_looksettings_activitybranding.feature
+++ b/tests/behat/theme_boost_union_looksettings_activitybranding.feature
@@ -64,12 +64,10 @@ Feature: Configuring the theme_boost_union plugin for the "Activity branding" ta
   @javascript
   Scenario Outline: Setting: Activity icon purposes - Setting the purpose
     Given I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Activity branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I select "<purpose>" from the "<modname>" singleselect
     And I press "Save changes"
-    And Behat debugging is enabled
     When I am on "Course 1" course homepage
     And I turn editing mode on
     And I add a <mod> activity to course "Course 1" section "0" and I fill the form with:
@@ -94,12 +92,10 @@ Feature: Configuring the theme_boost_union plugin for the "Activity branding" ta
   @javascript
   Scenario: Setting: Activity icon purposes - Removing the purpose
     Given I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Activity branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I select "Other" from the "Assignment" singleselect
     And I press "Save changes"
-    And Behat debugging is enabled
     When I am on "Course 1" course homepage
     And I turn editing mode on
     And I add a assign activity to course "Course 1" section "0" and I fill the form with:
@@ -124,12 +120,10 @@ Feature: Configuring the theme_boost_union plugin for the "Activity branding" ta
       | subsection | Subsection1      	     | SC1    | sub      | 1       |
       | <mod>      | Activity in Subsection1 | SC1    | subact   | 4       |
     And I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Activity branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I select "<purpose>" from the "<modname>" singleselect
     And I press "Save changes"
-    And Behat debugging is enabled
     When I am on "Subsectioncourse 1" course homepage
     Then DOM element ".modtype_subsection .modtype_<mod> .activityicon" should have a CSS filter close enough to hex color "<colorhex>"
 
@@ -144,7 +138,6 @@ Feature: Configuring the theme_boost_union plugin for the "Activity branding" ta
       | config         | value | plugin            |
       | modiconsenable | yes   | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Activity branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I click on ".fa-folder-plus" "css_element" in the "#admin-modiconsfiles .fp-btn-mkdir" "css_element"
@@ -161,7 +154,6 @@ Feature: Configuring the theme_boost_union plugin for the "Activity branding" ta
     And I should see "Activity: <modclearname>" in the ".settings-modicons-filelist" "css_element"
     And I should see "Icon version: <iconversion>" in the ".settings-modicons-filelist" "css_element"
     # Unfortunately we can only test the result in the custom icons files list. We cannot distinguish the icons in the activity chooser visually
-    And Behat debugging is enabled
 
     Examples:
       | iconfile     | iconversion          | modtechname | modclearname |
@@ -173,9 +165,7 @@ Feature: Configuring the theme_boost_union plugin for the "Activity branding" ta
   @javascript
   Scenario: Setting: Custom icons files - Do not upload any file (countercheck)
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Activity branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     Then I should not see "Custom icons files list"
     And ".settings-modicons-filelist" "css_element" should not exist
-    And Behat debugging is enabled

--- a/tests/behat/theme_boost_union_looksettings_categoryindexsitehome.feature
+++ b/tests/behat/theme_boost_union_looksettings_categoryindexsitehome.feature
@@ -583,7 +583,6 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
       | Field 1 | Fieldcategory | text     | f1        | d1          |                       |
       | Field 2 | Fieldcategory | select   | f2        | d2          | {"options":"a\nb\nc"} |
     And I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Category index / Site home" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We must specify the container where to look for the fields as Behat would stumble otherwise as the same fields exist
@@ -591,7 +590,6 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     And I set the field "Field 1" in the "#admin-courselistingselectfields" "css_element" to "<field1value>"
     And I set the field "Field 2" in the "#admin-courselistingselectfields" "css_element" to "<field2value>"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     And I navigate to "Settings" in current page administration
     And I set the following fields to these values:
@@ -668,7 +666,6 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
       | Field 1 | Fieldcategory | text     | f1        | d1          |                       |
       | Field 2 | Fieldcategory | select   | f2        | d2          | {"options":"a\nb\nc"} |
     And I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Category index / Site home" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We must specify the container where to look for the fields as Behat would stumble otherwise as the same fields exist
@@ -717,11 +714,9 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
       | courselistingpresentation | <coursevalue>  | theme_boost_union |
       | courselistingshowfields   | <settingvalue> | theme_boost_union |
     And I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Category index / Site home" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I should see "There isn't any usable custom course field yet."
-    And Behat debugging is enabled
     And I log out
     When I log in as "student1"
     And I am on site homepage
@@ -958,13 +953,11 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
       | Field 1 | Fieldcategory | text     | f1        | d1          |                       |
       | Field 2 | Fieldcategory | select   | f2        | d2          | {"options":"a\nb\nc"} |
     And I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Category index / Site home" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "Field 1" to "1"
     And I set the field "Field 2" to "1"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     And I navigate to "Settings" in current page administration
     And I set the following fields to these values:

--- a/tests/behat/theme_boost_union_looksettings_course_courseheader.feature
+++ b/tests/behat/theme_boost_union_looksettings_course_courseheader.feature
@@ -695,7 +695,6 @@ Feature: Configuring the theme_boost_union plugin for the "Course header" sectio
       | Field 1 | Fieldcategory | text     | f1        | d1          |                       |
       | Field 2 | Fieldcategory | select   | f2        | d2          | {"options":"a\nb\nc"} |
     And I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Course" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We must specify the container where to look for the fields as Behat would stumble otherwise as the same fields exist
@@ -703,7 +702,6 @@ Feature: Configuring the theme_boost_union plugin for the "Course header" sectio
     And I set the field "Field 1" in the "#admin-courseheaderselectfields" "css_element" to "<field1value>"
     And I set the field "Field 2" in the "#admin-courseheaderselectfields" "css_element" to "<field2value>"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     And I navigate to "Settings" in current page administration
     And I set the following fields to these values:
@@ -741,7 +739,6 @@ Feature: Configuring the theme_boost_union plugin for the "Course header" sectio
       | Field 1 | Fieldcategory | text     | f1        | d1          |                       |
       | Field 2 | Fieldcategory | select   | f2        | d2          | {"options":"a\nb\nc"} |
     And I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Course" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We must specify the container where to look for the fields as Behat would stumble otherwise as the same fields exist
@@ -749,7 +746,6 @@ Feature: Configuring the theme_boost_union plugin for the "Course header" sectio
     And I set the field "Field 1" in the "#admin-courseheaderselectfields" "css_element" to "1"
     And I set the field "Field 2" in the "#admin-courseheaderselectfields" "css_element" to "1"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     And I navigate to "Settings" in current page administration
     And I set the following fields to these values:
@@ -780,11 +776,9 @@ Feature: Configuring the theme_boost_union plugin for the "Course header" sectio
       | filearea | courseheaderimageglobal                        |
       | filepath | theme/boost_union/tests/fixtures/login_bg1.png |
     And I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Course" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I should see "There isn't any usable custom course field yet."
-    And Behat debugging is enabled
     And I log out
     When I log in as "student1"
     And I am on "Course 1" course homepage
@@ -1183,12 +1177,10 @@ Feature: Configuring the theme_boost_union plugin for the "Course header" sectio
     And I am on "Course 1" course homepage
     And "#bucourseheader.headingabove" "css_element" should exist
     # Now change the global default (and change it within the GUI to trigger the updatecallback method).
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Course" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "Course header layout" to "Course title stacked on full surface course header image"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     Then "#bucourseheader.stacked" "css_element" should exist
     And "#bucourseheader.headingabove" "css_element" should not exist
@@ -1210,12 +1202,10 @@ Feature: Configuring the theme_boost_union plugin for the "Course header" sectio
     And I press "Save and display"
     And I am on "Course 1" course homepage
     And "#bucourseheader.headingabove" "css_element" should exist
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Course" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "Course header layout" to "Course title stacked on full surface course header image"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     And I navigate to "Settings" in current page administration
     Then the field "Course header layout" matches value "Course title above of full surface course header image"

--- a/tests/behat/theme_boost_union_looksettings_emailbranding.feature
+++ b/tests/behat/theme_boost_union_looksettings_emailbranding.feature
@@ -13,7 +13,6 @@ Feature: Configuring the theme_boost_union plugin for the "E-Mail branding" tab 
 #      | theme_boost_union | templateemailhtmlprefix | My HTML prefix |
 #      | theme_boost_union | templateemailhtmlsuffix | My HTML suffix |
 #    When I log in as "admin"
-#    And Behat debugging is disabled
 #    And I navigate to "Appearance > Boost Union > Look" in site administration
 #    And I click on "E-Mail branding" "link" in the "#adminsettings .nav-tabs" "css_element"
 #    Then I should not see "Up to now, the HTML E-Mails haven't been customized within this feature"
@@ -24,17 +23,14 @@ Feature: Configuring the theme_boost_union plugin for the "E-Mail branding" tab 
 #    And "Plaintext E-Mail preview" "text" should appear after "My HTML suffix" "text"
 #    And "My HTML prefix" "text" should appear before "Lorem ipsum dolor sit amet" "text"
 #    And "My HTML suffix" "text" should appear after "Lorem ipsum dolor sit amet" "text"
-#    And Behat debugging is enabled
 
   @javascript
   Scenario: Setting: HTML E-Mail branding (countercheck)
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "E-Mail branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     Then I should see "Up to now, the HTML E-Mails haven't been customized within this feature"
     And I should not see "This is a preview of a HTML E-Mail"
-    And Behat debugging is enabled
 
 #  Unfortunately, this can't be tested with Behat yet
 #  See https://github.com/moodle-an-hochschulen/moodle-theme_boost_union/issues/140 for details
@@ -45,7 +41,6 @@ Feature: Configuring the theme_boost_union plugin for the "E-Mail branding" tab 
 #      | theme_boost_union | templateemailtextprefix | My plaintext prefix |
 #      | theme_boost_union | templateemailtextsuffix | My plaintext suffix |
 #    When I log in as "admin"
-#    And Behat debugging is disabled
 #    And I navigate to "Appearance > Boost Union > Look" in site administration
 #    And I click on "E-Mail branding" "link" in the "#adminsettings .nav-tabs" "css_element"
 #    Then I should not see "Up to now, the plaintext E-Mails haven't been customized within this feature"
@@ -56,14 +51,11 @@ Feature: Configuring the theme_boost_union plugin for the "E-Mail branding" tab 
 #    And "HTML E-Mail preview" "text" should appear before "My HTML suffix" "text"
 #    And "My plaintext prefix" "text" should appear before "Lorem ipsum dolor sit amet" "text"
 #    And "My plaintext suffix" "text" should appear after "Lorem ipsum dolor sit amet" "text"
-#    And Behat debugging is enabled
 
   @javascript
   Scenario: Setting: Plaintext E-Mail branding (countercheck)
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "E-Mail branding" "link" in the "#adminsettings .nav-tabs" "css_element"
     Then I should see "Up to now, the plaintext E-Mails haven't been customized within this feature"
     And I should not see "This is a preview of a plaintext E-Mail"
-    And Behat debugging is enabled

--- a/tests/behat/theme_boost_union_looksettings_h5p.feature
+++ b/tests/behat/theme_boost_union_looksettings_h5p.feature
@@ -20,7 +20,6 @@ Feature: Configuring the theme_boost_union plugin for the "H5P" tab on the "Look
   @javascript
   Scenario: Setting: Raw CSS for H5P - Add custom SCSS to a mod_h5p content type
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "H5P" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a small CSS snippet to the page which makes the H5P content red.
@@ -32,7 +31,6 @@ Feature: Configuring the theme_boost_union plugin for the "H5P" tab on the "Look
     }
     """
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage with editing mode on
     Given the following "activity" exists:
       | activity        | h5pactivity                   |

--- a/tests/behat/theme_boost_union_looksettings_mobile.feature
+++ b/tests/behat/theme_boost_union_looksettings_mobile.feature
@@ -11,7 +11,6 @@ Feature: Configuring the theme_boost_union plugin for the "Mobile" tab on the "L
 
   Scenario: Setting: Additional CSS for Mobile app - Insert CSS code and test that the mobilecssurl URL is set correctly.
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Mobile" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "Additional CSS for Mobile app" to multiline:
@@ -19,7 +18,6 @@ Feature: Configuring the theme_boost_union plugin for the "Mobile" tab on the "L
     a.test { font-size: 16px; }
     """
     And I press "Save changes"
-    And Behat debugging is enabled
     And I navigate to "General > Mobile app > Mobile appearance" in site administration
     Then "//div[@id='admin-mobilecssurl']//input[contains(@value, 'theme/boost_union/mobile/styles.php')]" "xpath_element" should exist
 
@@ -28,7 +26,6 @@ Feature: Configuring the theme_boost_union plugin for the "Mobile" tab on the "L
       | config       | value                      |
       | mobilecssurl | https://mymoodle/mycss.css |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Mobile" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "Additional CSS for Mobile app" to multiline:
@@ -36,7 +33,6 @@ Feature: Configuring the theme_boost_union plugin for the "Mobile" tab on the "L
     a.test { font-size: 16px; }
     """
     And I press "Save changes"
-    And Behat debugging is enabled
     And I navigate to "General > Mobile app > Mobile appearance" in site administration
     Then "//div[@id='admin-mobilecssurl']//input[contains(@value, 'theme/boost_union/mobile/styles.php')]" "xpath_element" should exist
     And I should not see "mycss.css" in the "#id_s__mobilecssurl" "css_element"
@@ -49,14 +45,12 @@ Feature: Configuring the theme_boost_union plugin for the "Mobile" tab on the "L
       | config     | value                       | plugin            |
       | mobilescss | a.test { font-size: 16px; } | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Mobile" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "Additional CSS for Mobile app" to multiline:
     """
     """
     And I press "Save changes"
-    And Behat debugging is enabled
     And I navigate to "General > Mobile app > Mobile appearance" in site administration
     Then "//div[@id='admin-mobilecssurl']//input[contains(@value, 'theme/boost_union/mobile/styles.php')]" "xpath_element" should not exist
 
@@ -66,7 +60,6 @@ Feature: Configuring the theme_boost_union plugin for the "Mobile" tab on the "L
   @javascript @_file_upload
   Scenario: Setting: Touch icon files for iOS - Upload touch icon files
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Mobile" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I upload "theme/boost_union/tests/fixtures/apple-icon-180x180.png" file to "Touch icon files for iOS" filemanager
@@ -88,28 +81,23 @@ Feature: Configuring the theme_boost_union plugin for the "Mobile" tab on the "L
     And "//head//link[contains(@rel, 'apple-touch-icon')][contains(@sizes, '180x180')][contains(@href, 'pluginfile.php/1/theme_boost_union/touchiconsios')][contains(@href, 'apple-icon-180x180.png')]" "xpath_element" should exist
     And "//head//link[contains(@rel, 'apple-touch-icon')][contains(@sizes, '152x152')][contains(@href, 'pluginfile.php/1/theme_boost_union/touchiconsios')][contains(@href, 'apple-icon-152x152.png')]" "xpath_element" should not exist
     And "//head//link[contains(@rel, 'apple-touch-icon')][contains(@sizes, '60x60')][contains(@href, 'pluginfile.php/1/theme_boost_union/touchiconsios')][contains(@href, 'apple-icon-60x60.png')]" "xpath_element" should exist
-    And Behat debugging is enabled
 
   @javascript
   Scenario: Setting: Touch icon files for iOS - Do not upload any file (countercheck)
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Mobile" "link" in the "#adminsettings .nav-tabs" "css_element"
     Then I should not see "Touch icon files for iOS list"
     And ".settings-touchiconsios-filelist" "css_element" should not exist
-    And Behat debugging is enabled
 
   @javascript @_file_upload
   Scenario: Setting: Touch icon files for iOS - Do not ship touch icon files if Boost Union is not the active theme (cross-theme check).
     Given I log in as "admin"
     And I navigate to "Appearance > Themes" in site administration
     And I click on "Select theme" "button" in the "#theme-select-form-boost" "css_element"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Mobile" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I upload "theme/boost_union/tests/fixtures/apple-icon-180x180.png" file to "Touch icon files for iOS" filemanager
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on site homepage
     Then "//head//link[contains(@rel, 'apple-touch-icon')][contains(@sizes, '180x180')][contains(@href, 'pluginfile.php/1/theme_boost_union/touchiconsios')][contains(@href, 'apple-icon-180x180.png')]" "xpath_element" should not exist

--- a/tests/behat/theme_boost_union_looksettings_resources.feature
+++ b/tests/behat/theme_boost_union_looksettings_resources.feature
@@ -7,7 +7,6 @@ Feature: Configuring the theme_boost_union plugin for the "Resources" tab on the
   @javascript @_file_upload
   Scenario: Setting: Additional resources - Upload additional resources files
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Resources" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I upload "theme/boost_union/tests/fixtures/login_bg1.png" file to "Additional resources" filemanager
@@ -24,22 +23,18 @@ Feature: Configuring the theme_boost_union plugin for the "Resources" tab on the
     And I should see "/pluginfile.php/1/theme_boost_union/additionalresources/0/login_bg1.png" in the ".settings-additionalresources-filelist" "css_element"
     And I should see "URL (revisioned):" in the ".settings-additionalresources-filelist" "css_element"
     # Checking the revisioned URL is not possible currently with Behat without writing a custom step. We accept this for now.
-    And Behat debugging is enabled
 
   @javascript
   Scenario: Setting: Additional resources - Do not upload any file (countercheck)
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Resources" "link" in the "#adminsettings .nav-tabs" "css_element"
     Then I should not see "Additional resources list"
     And ".settings-additionalresources-filelist" "css_element" should not exist
-    And Behat debugging is enabled
 
   @javascript @_file_upload
   Scenario: Setting: Custom fonts - Upload custom fonts files
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Resources" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I upload "theme/boost_union/tests/fixtures/roboto-v30-latin-regular.woff" file to "Custom fonts" filemanager
@@ -51,14 +46,11 @@ Feature: Configuring the theme_boost_union plugin for the "Resources" tab on the
     And I should see "roboto-v30-latin-regular.woff" in the ".settings-customfonts-filelist h6" "css_element"
     And I should see "@font-face" in the ".settings-customfonts-filelist" "css_element"
     And I should see "/pluginfile.php/1/theme_boost_union/customfonts/0/roboto-v30-latin-regular.woff" in the ".settings-customfonts-filelist" "css_element"
-    And Behat debugging is enabled
 
   @javascript
   Scenario: Setting: Custom fonts - Do not upload any file (countercheck)
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "Resources" "link" in the "#adminsettings .nav-tabs" "css_element"
     Then I should not see "Custom fonts list"
     And ".settings-customfonts-filelist" "css_element" should not exist
-    And Behat debugging is enabled

--- a/tests/behat/theme_boost_union_looksettings_scss.feature
+++ b/tests/behat/theme_boost_union_looksettings_scss.feature
@@ -12,7 +12,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
   @javascript
   Scenario: Setting: Raw (initial) SCSS - Add custom SCSS to the theme
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a SCSS variable and a small SCSS snippet to the page which hides the heading in the page header.
@@ -26,7 +25,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
     #page-header h1 { display: $myvariable; }
     """
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
 
@@ -36,7 +34,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
       | config        | value | plugin            |
       | extscsssource | 1     | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a small CSS snippet to the page which hides the heading in the page header.
@@ -44,7 +41,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
     And I set the following fields to these values:
       | <urlfield> | <url> |
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
 
@@ -59,7 +55,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
       | config        | value | plugin            |
       | extscsssource | 2     | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We add a small CSS snippet to the page which hides the heading in the page header.
@@ -70,7 +65,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
       | External SCSS Github API repository | moodle-theme_boost_union-extscsstest            |
       | <pathfield>                         | <filepath>                                      |
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     Then I should not see "Course 1" in the "#page-header .page-header-headings" "css_element"
 
@@ -87,7 +81,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
       | config        | value | plugin            |
       | extscsssource | 1     | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We first add a valid CSS snippet to the page which is just there to detect later that SCSS has been compiled correctly.
@@ -101,7 +94,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
     # And then we add a broken SCSS URL to the theme.
     And I set the field "External Post SCSS download URL" to "<url>"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     # Regardless of the fact that the broken URL was configured as external source, the SCSS
     # should be compiled correctly.
@@ -118,7 +110,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
       | extscsssource     | 1     | theme_boost_union |
       | extscssvalidation | yes   | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # We first add a valid CSS snippet to the page which is just there to detect later that SCSS has been compiled correctly.
@@ -131,7 +122,6 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     And I set the field "External Post SCSS download URL" to "<url>"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     # Regardless of the fact that invalid SCSS code has been fetched from the external source, the SCSS
     # should be compiled correctly.
@@ -149,13 +139,11 @@ Feature: Configuring the theme_boost_union plugin for the "SCSS" tab on the "Loo
       | extscsssource     | 1          | theme_boost_union |
       | extscssvalidation | <validate> | theme_boost_union |
     When I log in as "admin"
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And I click on "SCSS" "link" in the "#adminsettings .nav-tabs" "css_element"
     # And then we add external SCSS code with Bootstrap variables to the theme.
     And I set the field "External Post SCSS download URL" to "<url>"
     And I press "Save changes"
-    And Behat debugging is enabled
     And I am on "Course 1" course homepage
     # Regardless of the fact that broken / invalid SCSS code has been fetched from the external source, the SCSS
     # should be compiled correctly.

--- a/tests/behat/theme_boost_union_managers.feature
+++ b/tests/behat/theme_boost_union_managers.feature
@@ -20,12 +20,10 @@ Feature: Configuring the theme_boost_union plugin as manager
     And I follow "Site administration"
     Then ".secondary-navigation li[data-key='appearance']" "css_element" should exist
     # We just need to test the 'look' page as a representative of all theme admin pages.
-    And Behat debugging is disabled
     And I navigate to "Appearance > Boost Union > Look" in site administration
     And "body#page-admin-setting-theme_boost_union_look" "css_element" should exist
     And I should see "Look" in the "#region-main" "css_element"
     And I should see "General settings" in the "#region-main" "css_element"
-    And Behat debugging is enabled
     # However, we have to test the 'flavours' page as well as this is an external admin page.
     And I navigate to "Appearance > Boost Union > Flavours" in site administration
     And "body#page-admin-theme-boost_union-flavours-overview" "css_element" should exist


### PR DESCRIPTION
## Summary

Closes #1241.

Once [MDL-76975](https://moodle.atlassian.net/browse/MDL-76975)
landed in Moodle Core 5.0+, the
\`Too much data passed as arguments to js_call_amd\` debug message
that the workaround was guarding against is gone, and the explicit
\`And Behat debugging is (disabled|enabled)\` steps can be removed
from our scenarios.

## Changes

- Drop \`Behat debugging is (disabled|enabled)\` lines from every
  \`.feature\` file under \`tests/behat/\` (15 files, 110 lines —
  both active steps and the few \`#\`-commented variants).
- Remove the now-unused \`disable_behat_debugging\` /
  \`enable_behat_debugging\` helper methods and their
  \`@Given /^Behat debugging is (disabled|enabled)$/\` annotations
  from \`tests/behat/behat_theme_boost_union_base_general.php\`.

The helper deletion and the scenario edits land in the same commit.
With the helpers gone, Behat would otherwise refuse to recognise any
leftover step text — and any forgotten step text would show up as a
test failure.

## Branch scope

This branch (\`main\`, \`v5.1-r11\`) targets Moodle 5.1, which the
issue lists as in-scope ("affecting 5.1 only" label). Per the issue
the same change applies to the 5.0 and 5.2 stable branches; happy
to backport if that's the convention here, or you can cherry-pick.

## Test plan

- [x] \`php -l tests/behat/behat_theme_boost_union_base_general.php\`
      reports no syntax errors.
- [x] \`grep -r 'Behat debugging is' tests/behat\` is empty.
- [x] \`grep -r 'disable_behat_debugging\\|enable_behat_debugging' tests/behat\`
      is empty.
- [ ] Behat run against a local Moodle 5.0+ — I don't have a Moodle
      install wired up here so I'm relying on CI for the runtime
      check. The change is purely deletion (no new steps, no
      reorder), so the only failure modes are (a) a forgotten step
      text in a scenario, which the grep above rules out, or (b) a
      scenario that genuinely depended on the debug toggle to not
      hit MDL-76975 — but that's exactly what the maintainer's
      issue body says is now safe to drop.