### PR TITLE
Fix #1063: rename remaining 'courselistinghow*' settings to 'courselistingshow*'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2026-05-15 - Chore: Rename the settings 'courselistinghow*' to 'courselistingshow*' to fix a typo, resolves #1063
 * 2026-05-12 - Improvement: Allow the admin to further control the logo, heading, and tagline presentation on the login page, resolves #1262
 * 2026-05-12 - Improvement: Allow the admin to set the login page logo max-width and max-height as well as a margin-bottom and the horizontal alignment for the logo, resolves #1260
 * 2026-05-12 - Improvement: Add admin settings to set the button colors on the login page, resolves #1225.

--- a/classes/output/core/course_renderer.php
+++ b/classes/output/core/course_renderer.php
@@ -49,12 +49,12 @@ class course_renderer extends \core_course_renderer {
         static $detailsmodalchecked = null;
         if ($detailsmodalchecked == null) {
             $courselistingpresentation = get_config('theme_boost_union', 'courselistingpresentation');
-            $courselistinghowpopup = get_config('theme_boost_union', 'courselistinghowpopup');
+            $courselistingshowpopup = get_config('theme_boost_union', 'courselistingshowpopup');
             if (
                 isset($courselistingpresentation) &&
                     $courselistingpresentation != THEME_BOOST_UNION_SETTING_COURSELISTPRES_NOCHANGE &&
-                    isset($courselistinghowpopup) &&
-                    $courselistinghowpopup == THEME_BOOST_UNION_SETTING_SELECT_YES
+                    isset($courselistingshowpopup) &&
+                    $courselistingshowpopup == THEME_BOOST_UNION_SETTING_SELECT_YES
             ) {
                 $page->requires->js_call_amd('theme_boost_union/coursedetailsmodal', 'init');
             }
@@ -423,7 +423,7 @@ class course_renderer extends \core_course_renderer {
             // the code quality much.
 
             // Enable course image, if configured.
-            if (get_config('theme_boost_union', 'courselistinghowimage') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            if (get_config('theme_boost_union', 'courselistingshowimage') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
                 $skeleton['showcourseimage'] = true;
             } else {
                 $skeleton['showcourseimage'] = false;
@@ -437,28 +437,28 @@ class course_renderer extends \core_course_renderer {
             }
 
             // Enable course shortname, if configured.
-            if (get_config('theme_boost_union', 'courselistinghowshortname') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            if (get_config('theme_boost_union', 'courselistingshowshortname') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
                 $skeleton['showshortname'] = true;
             } else {
                 $skeleton['showshortname'] = false;
             }
 
             // Enable course category, if configured.
-            if (get_config('theme_boost_union', 'courselistinghowcategory') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            if (get_config('theme_boost_union', 'courselistingshowcategory') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
                 $skeleton['showcoursecategory'] = true;
             } else {
                 $skeleton['showcoursecategory'] = false;
             }
 
             // Enable course goto button, if configured.
-            if (get_config('theme_boost_union', 'courselistinghowgoto') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            if (get_config('theme_boost_union', 'courselistingshowgoto') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
                 $skeleton['showcoursegoto'] = true;
             } else {
                 $skeleton['showcoursegoto'] = false;
             }
 
             // Enable course details popup, if configured.
-            if (get_config('theme_boost_union', 'courselistinghowpopup') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            if (get_config('theme_boost_union', 'courselistingshowpopup') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
                 $skeleton['showcoursepopup'] = true;
             } else {
                 $skeleton['showcoursepopup'] = false;
@@ -479,14 +479,14 @@ class course_renderer extends \core_course_renderer {
             }
 
             // Enable course enrol icons, if configured.
-            if (get_config('theme_boost_union', 'courselistinghowenrolicons') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            if (get_config('theme_boost_union', 'courselistingshowenrolicons') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
                 $skeleton['showcourseenrolicons'] = true;
             } else {
                 $skeleton['showcourseenrolicons'] = false;
             }
 
             // Enable course progress, if configured.
-            if (get_config('theme_boost_union', 'courselistinghowprogress') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+            if (get_config('theme_boost_union', 'courselistingshowprogress') == THEME_BOOST_UNION_SETTING_SELECT_YES) {
                 $skeleton['showcourseprogress'] = true;
             } else {
                 $skeleton['showcourseprogress'] = false;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1092,6 +1092,38 @@ function xmldb_theme_boost_union_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025100624, 'theme', 'boost_union');
     }
 
+    if ($oldversion < 2026051500) {
+        // Rename the remaining 'courselistinghow*' settings to 'courselistingshow*' to fix a typo (see #1063).
+        // The 'courselistinghowfields' variant was already handled in the 2025041413 upgrade step above.
+        $renames = [
+            'courselistinghowimage' => 'courselistingshowimage',
+            'courselistinghowshortname' => 'courselistingshowshortname',
+            'courselistinghowcategory' => 'courselistingshowcategory',
+            'courselistinghowprogress' => 'courselistingshowprogress',
+            'courselistinghowenrolicons' => 'courselistingshowenrolicons',
+            'courselistinghowgoto' => 'courselistingshowgoto',
+            'courselistinghowpopup' => 'courselistingshowpopup',
+        ];
+
+        $migrated = false;
+        foreach ($renames as $oldname => $newname) {
+            $oldsetting = get_config('theme_boost_union', $oldname);
+            if ($oldsetting !== false) {
+                set_config($newname, $oldsetting, 'theme_boost_union');
+                unset_config($oldname, 'theme_boost_union');
+                $migrated = true;
+            }
+        }
+
+        if ($migrated) {
+            $message = get_string('upgradenotice_2026051500', 'theme_boost_union');
+            echo $OUTPUT->notification($message, 'info');
+        }
+
+        // Boost Union savepoint reached.
+        upgrade_plugin_savepoint(true, 2026051500, 'theme', 'boost_union');
+    }
+
     // Load the builtin SCSS snippets into the database.
     // This is done with every plugin update, regardless of the plugin version.
     snippets::add_builtin_snippets();

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -588,28 +588,28 @@ $string['courselistingpresentation_note'] = 'Please note: If you enable course c
 $string['coursecardscolumncount'] = 'Course card column count';
 $string['coursecardscolumncount_desc'] = 'The course card grid will be presented in a responsive way and its columns will wrap on smaller screens. With this setting, you just control the maximum number of columns in the course card grid on larger screens. Setting the maximum number of columns to 2 instead of 3 might make the course cards look more spacious and less crowded. Setting the maximum number of columns to 1 is possible as well and will effectively turn the course listing in a vertical list of cards.';
 // ... ... Setting: Show course image in the course listing.
-$string['courselistinghowimage'] = 'Show course image in the course listing';
-$string['courselistinghowimage_desc'] = 'With this setting, you control if the course image is shown in the course listing or not.';
+$string['courselistingshowimage'] = 'Show course image in the course listing';
+$string['courselistingshowimage_desc'] = 'With this setting, you control if the course image is shown in the course listing or not.';
 // ... ... Setting: Show course contacts in the course listing.
 $string['courselistingshowcontacts'] = 'Show course contacts in the course listing';
 $string['courselistingshowcontacts_desc'] = 'With this setting, you control if the course contact\'s pictures are shown in the course listing or not. Please note: The contact pictures are shown together with the course image, thus presenting course contacts without presenting the course image is not possible.';
 // ... ... Setting: Show course shortname in the course listing.
-$string['courselistinghowshortname'] = 'Show course shortname in the course listing';
-$string['courselistinghowshortname_desc'] = 'With this setting, you control if the course shortname is shown in the course listing or not.';
+$string['courselistingshowshortname'] = 'Show course shortname in the course listing';
+$string['courselistingshowshortname_desc'] = 'With this setting, you control if the course shortname is shown in the course listing or not.';
 // ... ... Setting: Show course category in the course listing.
-$string['courselistinghowcategory'] = 'Show course category in the course listing';
-$string['courselistinghowcategory_desc'] = 'With this setting, you control if the course category is shown in the course listing or not.';
+$string['courselistingshowcategory'] = 'Show course category in the course listing';
+$string['courselistingshowcategory_desc'] = 'With this setting, you control if the course category is shown in the course listing or not.';
 // ... ... Setting: Show course completion progress in the course listing.
-$string['courselistinghowprogress'] = 'Show course completion progress in the course listing';
-$string['courselistinghowprogress_desc'] = 'With this setting, you control if the course completion progress are shown in the course listing or not.';
+$string['courselistingshowprogress'] = 'Show course completion progress in the course listing';
+$string['courselistingshowprogress_desc'] = 'With this setting, you control if the course completion progress are shown in the course listing or not.';
 // ... ... Setting: Course completion progress style in the course listing.
 $string['courseistingprogressstyle'] = 'Course completion progress style in the course listing';
 $string['courseistingprogressstyle_desc'] = 'With this setting, you control how the course completion progress is displayed in the course listing. You can choose between a simple percentage text or a progress bar.';
 $string['courseistingprogressstyle_percentage'] = 'Percentage text';
 $string['courseistingprogressstyle_bar'] = 'Progress bar';
 // ... ... Setting: Show course enrolment icons in the course listing.
-$string['courselistinghowenrolicons'] = 'Show course enrolment icons in the course listing';
-$string['courselistinghowenrolicons_desc'] = 'With this setting, you control if the course enrolment icons are shown in the course listing or not.';
+$string['courselistingshowenrolicons'] = 'Show course enrolment icons in the course listing';
+$string['courselistingshowenrolicons_desc'] = 'With this setting, you control if the course enrolment icons are shown in the course listing or not.';
 // ... ... Setting: Show course fields in the course listing.
 $string['courselistingshowfields'] = 'Show course fields in the course listing';
 $string['courselistingshowfields_desc'] = 'With this setting, you control if the custom course fields are shown in the course listing or not.';
@@ -621,12 +621,12 @@ $string['courselistingselectfields_nofield'] = 'With this setting, you can selec
 $string['courselistingstylefields'] = 'Style course fields in the course listing';
 $string['courselistingstylefields_desc'] = 'With this setting, you can control how the custom course fields are displayed in the course listing. You can choose between showing them as text (showing the field value together with the field name as label) or as badge (showing just the field value).';
 // ... ... Setting: Show goto button in the course listing.
-$string['courselistinghowgoto'] = 'Show goto button in the course listing';
-$string['courselistinghowgoto_desc'] = 'With this setting, you control if a \'Go to course\' button is shown in the course listing or not. If this setting is disabled, the user is still able to go to the course by clicking on the course title or course image.';
+$string['courselistingshowgoto'] = 'Show goto button in the course listing';
+$string['courselistingshowgoto_desc'] = 'With this setting, you control if a \'Go to course\' button is shown in the course listing or not. If this setting is disabled, the user is still able to go to the course by clicking on the course title or course image.';
 $string['courselistinggoto'] = 'Go to course';
 // ... ... Setting: Show details popup in the course listing.
-$string['courselistinghowpopup'] = 'Show details popup in the course listing';
-$string['courselistinghowpopup_desc'] = 'With this setting, you control if a \'Course details\' button is shown in the course listing or not. With this button, the user can open a details popup which contains the course summary, the course contacts and the course fields. The popup will contain this information regardless if you enabled it on the course card / row itself or not.';
+$string['courselistingshowpopup'] = 'Show details popup in the course listing';
+$string['courselistingshowpopup_desc'] = 'With this setting, you control if a \'Course details\' button is shown in the course listing or not. With this button, the user can open a details popup which contains the course summary, the course contacts and the course fields. The popup will contain this information regardless if you enabled it on the course card / row itself or not.';
 $string['courselistingpopup'] = 'Details';
 $string['courselistingummary'] = 'Course summary';
 $string['courselistingnosummary'] = 'This course does not have a summary';
@@ -2111,3 +2111,4 @@ $string['upgradenotice_2025041410'] = 'The setting "Show hint for guest access" 
 $string['upgradenotice_2025041413'] = 'The setting "courselistinghowfields" has been renamed to "courselistingshowfields" to fix a typo. Your existing configuration has been migrated to the new setting name.';
 $string['upgradenotice_2025041416'] = 'Smart menu dividers are now available as a dedicated menu item type. Existing dividers (created using heading type with hash signs) have been automatically converted to the new divider type.';
 $string['upgradenotice_2025100623'] = 'The navbar color options "Primary color navbar with dark font color" and "Primary color navbar with light font color" have been renamed to "Colored navbar with dark font color" and "Colored navbar with light font color". Your existing configuration has been migrated automatically. Additionally, your primary brand color has been transferred to the new "Navbar tint" setting to maintain the previous visual appearance.';
+$string['upgradenotice_2026051500'] = 'Seven settings have been renamed to fix a typo: "courselistinghowimage", "courselistinghowshortname", "courselistinghowcategory", "courselistinghowprogress", "courselistinghowenrolicons", "courselistinghowgoto" and "courselistinghowpopup" are now called "courselistingshowimage", "courselistingshowshortname", "courselistingshowcategory", "courselistingshowprogress", "courselistingshowenrolicons", "courselistingshowgoto" and "courselistingshowpopup" respectively. Your existing configurations have been migrated to the new setting names.';

--- a/settings.php
+++ b/settings.php
@@ -2265,13 +2265,13 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         );
 
         // Setting: Show course image in the course listing.
-        $name = 'theme_boost_union/courselistinghowimage';
-        $title = get_string('courselistinghowimage', 'theme_boost_union');
-        $description = get_string('courselistinghowimage_desc', 'theme_boost_union');
+        $name = 'theme_boost_union/courselistingshowimage';
+        $title = get_string('courselistingshowimage', 'theme_boost_union');
+        $description = get_string('courselistingshowimage_desc', 'theme_boost_union');
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_YES, $yesnooption);
         $tab->add($setting);
         $page->hide_if(
-            'theme_boost_union/courselistinghowimage',
+            'theme_boost_union/courselistingshowimage',
             'theme_boost_union/courselistingpresentation',
             'eq',
             THEME_BOOST_UNION_SETTING_COURSELISTPRES_NOCHANGE
@@ -2291,45 +2291,45 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         );
         $page->hide_if(
             'theme_boost_union/courselistingshowcontacts',
-            'theme_boost_union/courselistinghowimage',
+            'theme_boost_union/courselistingshowimage',
             'neq',
             THEME_BOOST_UNION_SETTING_SELECT_YES
         );
 
         // Setting: Show course shortname in the course listing.
-        $name = 'theme_boost_union/courselistinghowshortname';
-        $title = get_string('courselistinghowshortname', 'theme_boost_union');
-        $description = get_string('courselistinghowshortname_desc', 'theme_boost_union');
+        $name = 'theme_boost_union/courselistingshowshortname';
+        $title = get_string('courselistingshowshortname', 'theme_boost_union');
+        $description = get_string('courselistingshowshortname_desc', 'theme_boost_union');
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
         $page->hide_if(
-            'theme_boost_union/courselistinghowshortname',
+            'theme_boost_union/courselistingshowshortname',
             'theme_boost_union/courselistingpresentation',
             'eq',
             THEME_BOOST_UNION_SETTING_COURSELISTPRES_NOCHANGE
         );
 
         // Setting: Show course category in the course listing.
-        $name = 'theme_boost_union/courselistinghowcategory';
-        $title = get_string('courselistinghowcategory', 'theme_boost_union');
-        $description = get_string('courselistinghowcategory_desc', 'theme_boost_union');
+        $name = 'theme_boost_union/courselistingshowcategory';
+        $title = get_string('courselistingshowcategory', 'theme_boost_union');
+        $description = get_string('courselistingshowcategory_desc', 'theme_boost_union');
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
         $page->hide_if(
-            'theme_boost_union/courselistinghowcategory',
+            'theme_boost_union/courselistingshowcategory',
             'theme_boost_union/courselistingpresentation',
             'eq',
             THEME_BOOST_UNION_SETTING_COURSELISTPRES_NOCHANGE
         );
 
         // Setting: Show course completion progress in the course listing.
-        $name = 'theme_boost_union/courselistinghowprogress';
-        $title = get_string('courselistinghowprogress', 'theme_boost_union');
-        $description = get_string('courselistinghowprogress_desc', 'theme_boost_union');
+        $name = 'theme_boost_union/courselistingshowprogress';
+        $title = get_string('courselistingshowprogress', 'theme_boost_union');
+        $description = get_string('courselistingshowprogress_desc', 'theme_boost_union');
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
         $page->hide_if(
-            'theme_boost_union/courselistinghowprogress',
+            'theme_boost_union/courselistingshowprogress',
             'theme_boost_union/courselistingpresentation',
             'eq',
             THEME_BOOST_UNION_SETTING_COURSELISTPRES_NOCHANGE
@@ -2361,19 +2361,19 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         );
         $page->hide_if(
             'theme_boost_union/courselistingprogressstyle',
-            'theme_boost_union/courselistinghowprogress',
+            'theme_boost_union/courselistingshowprogress',
             'neq',
             THEME_BOOST_UNION_SETTING_SELECT_YES
         );
 
         // Setting: Show course enrolment icons in the course listing.
-        $name = 'theme_boost_union/courselistinghowenrolicons';
-        $title = get_string('courselistinghowenrolicons', 'theme_boost_union');
-        $description = get_string('courselistinghowenrolicons_desc', 'theme_boost_union');
+        $name = 'theme_boost_union/courselistingshowenrolicons';
+        $title = get_string('courselistingshowenrolicons', 'theme_boost_union');
+        $description = get_string('courselistingshowenrolicons_desc', 'theme_boost_union');
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_YES, $yesnooption);
         $tab->add($setting);
         $page->hide_if(
-            'theme_boost_union/courselistinghowenrolicons',
+            'theme_boost_union/courselistingshowenrolicons',
             'theme_boost_union/courselistingpresentation',
             'eq',
             THEME_BOOST_UNION_SETTING_COURSELISTPRES_NOCHANGE
@@ -2476,26 +2476,26 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
             );
 
         // Setting: Show goto button in the course listing.
-        $name = 'theme_boost_union/courselistinghowgoto';
-        $title = get_string('courselistinghowgoto', 'theme_boost_union');
-        $description = get_string('courselistinghowgoto_desc', 'theme_boost_union');
+        $name = 'theme_boost_union/courselistingshowgoto';
+        $title = get_string('courselistingshowgoto', 'theme_boost_union');
+        $description = get_string('courselistingshowgoto_desc', 'theme_boost_union');
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_YES, $yesnooption);
         $tab->add($setting);
         $page->hide_if(
-            'theme_boost_union/courselistinghowgoto',
+            'theme_boost_union/courselistingshowgoto',
             'theme_boost_union/courselistingpresentation',
             'eq',
             THEME_BOOST_UNION_SETTING_COURSELISTPRES_NOCHANGE
         );
 
         // Setting: Show details popup in the course listing.
-        $name = 'theme_boost_union/courselistinghowpopup';
-        $title = get_string('courselistinghowpopup', 'theme_boost_union');
-        $description = get_string('courselistinghowpopup_desc', 'theme_boost_union');
+        $name = 'theme_boost_union/courselistingshowpopup';
+        $title = get_string('courselistingshowpopup', 'theme_boost_union');
+        $description = get_string('courselistingshowpopup_desc', 'theme_boost_union');
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_YES, $yesnooption);
         $tab->add($setting);
         $page->hide_if(
-            'theme_boost_union/courselistinghowpopup',
+            'theme_boost_union/courselistingshowpopup',
             'theme_boost_union/courselistingpresentation',
             'eq',
             THEME_BOOST_UNION_SETTING_COURSELISTPRES_NOCHANGE

--- a/tests/behat/theme_boost_union_looksettings_categoryindexsitehome.feature
+++ b/tests/behat/theme_boost_union_looksettings_categoryindexsitehome.feature
@@ -154,7 +154,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value          | plugin            |
       | courselistingpresentation | <coursevalue>  | theme_boost_union |
-      | courselistinghowimage     | <settingvalue> | theme_boost_union |
+      | courselistingshowimage     | <settingvalue> | theme_boost_union |
     When I log in as "student1"
     And I am on site homepage
     # Check the 'Combo list' view on site home as a whole
@@ -187,7 +187,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value           | plugin            |
       | courselistingpresentation | <coursevalue>   | theme_boost_union |
-      | courselistinghowimage     | <imagevalue>    | theme_boost_union |
+      | courselistingshowimage     | <imagevalue>    | theme_boost_union |
       | courselistingshowcontacts | <contactsvalue> | theme_boost_union |
     And the following "users" exist:
       | username | firstname | lastname |
@@ -234,7 +234,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value | plugin            |
       | courselistingpresentation | cards | theme_boost_union |
-      | courselistinghowimage     | yes   | theme_boost_union |
+      | courselistingshowimage     | yes   | theme_boost_union |
       | courselistingshowcontacts | yes   | theme_boost_union |
     And the following "users" exist:
       | username | firstname | lastname |
@@ -260,7 +260,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value          | plugin            |
       | courselistingpresentation | <coursevalue>  | theme_boost_union |
-      | courselistinghowshortname | <settingvalue> | theme_boost_union |
+      | courselistingshowshortname | <settingvalue> | theme_boost_union |
     When I log in as "student1"
     And I am on site homepage
     # Check the 'Combo list' view on site home as a whole
@@ -292,7 +292,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value         | plugin            |
       | courselistingpresentation | <coursevalue> | theme_boost_union |
-      | courselistinghowshortname | yes           | theme_boost_union |
+      | courselistingshowshortname | yes           | theme_boost_union |
     When I log in as "student1"
     And I am on the "CATA" category page
     Then "<selector>" "css_element" should exist in the ".course_category_tree" "css_element"
@@ -308,7 +308,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value          | plugin            |
       | courselistingpresentation | <coursevalue>  | theme_boost_union |
-      | courselistinghowcategory  | <settingvalue> | theme_boost_union |
+      | courselistingshowcategory  | <settingvalue> | theme_boost_union |
     When I log in as "student1"
     And I am on site homepage
     # Check the 'Combo list' view on site home as a whole
@@ -340,7 +340,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value         | plugin            |
       | courselistingpresentation | <coursevalue> | theme_boost_union |
-      | courselistinghowcategory  | yes           | theme_boost_union |
+      | courselistingshowcategory  | yes           | theme_boost_union |
     When I log in as "student1"
     And I am on the "CATA" category page
     Then "<selector>" "css_element" should exist in the ".course_category_tree" "css_element"
@@ -356,7 +356,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value          | plugin            |
       | courselistingpresentation | <coursevalue>  | theme_boost_union |
-      | courselistinghowprogress  | <settingvalue> | theme_boost_union |
+      | courselistingshowprogress  | <settingvalue> | theme_boost_union |
     And the following "activities" exist:
       | activity | name              | course | completion |
       | assign   | Activity sample 1 | C1     | 1          |
@@ -393,7 +393,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value         | plugin            |
       | courselistingpresentation | <coursevalue> | theme_boost_union |
-      | courselistinghowprogress  | yes           | theme_boost_union |
+      | courselistingshowprogress  | yes           | theme_boost_union |
     And the following "activities" exist:
       | activity | name              | course | completion |
       | assign   | Activity sample 1 | C1     | 1          |
@@ -413,7 +413,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                     | value         | plugin            |
       | courselistingpresentation  | <coursevalue> | theme_boost_union |
-      | courselistinghowprogress   | yes           | theme_boost_union |
+      | courselistingshowprogress   | yes           | theme_boost_union |
       | courselistingprogressstyle | <style>       | theme_boost_union |
     And the following "activities" exist:
       | activity | name              | course | completion |
@@ -437,7 +437,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                     | value          | plugin            |
       | courselistingpresentation  | <coursevalue>  | theme_boost_union |
-      | courselistinghowenrolicons | <settingvalue> | theme_boost_union |
+      | courselistingshowenrolicons | <settingvalue> | theme_boost_union |
     And the following config values are set as admin:
       | config           | value |
       | guestloginbutton | 1     |
@@ -489,7 +489,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                     | value         | plugin            |
       | courselistingpresentation  | <coursevalue> | theme_boost_union |
-      | courselistinghowenrolicons | yes           | theme_boost_union |
+      | courselistingshowenrolicons | yes           | theme_boost_union |
     And the following config values are set as admin:
       | config           | value |
       | guestloginbutton | 1     |
@@ -748,7 +748,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value          | plugin            |
       | courselistingpresentation | <coursevalue>  | theme_boost_union |
-      | courselistinghowgoto      | <settingvalue> | theme_boost_union |
+      | courselistingshowgoto      | <settingvalue> | theme_boost_union |
     When I log in as "student1"
     And I am on site homepage
     # Check the 'Combo list' view on site home as a whole
@@ -781,7 +781,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value         | plugin            |
       | courselistingpresentation | <coursevalue> | theme_boost_union |
-      | courselistinghowgoto      | yes           | theme_boost_union |
+      | courselistingshowgoto      | yes           | theme_boost_union |
     When I log in as "student1"
     And I am on the "CATA" category page
     Then "<selector>" "css_element" should exist in the ".course_category_tree" "css_element"
@@ -798,7 +798,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value          | plugin            |
       | courselistingpresentation | <coursevalue>  | theme_boost_union |
-      | courselistinghowpopup     | <settingvalue> | theme_boost_union |
+      | courselistingshowpopup     | <settingvalue> | theme_boost_union |
     When I log in as "student1"
     And I am on site homepage
     # Check the 'Combo list' view on site home as a whole
@@ -831,7 +831,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value          | plugin            |
       | courselistingpresentation | <coursevalue>  | theme_boost_union |
-      | courselistinghowpopup     | yes            | theme_boost_union |
+      | courselistingshowpopup     | yes            | theme_boost_union |
     When I log in as "student1"
     And I am on site homepage
     # Check the 'Combo list' view on site home as a whole
@@ -887,7 +887,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value | plugin            |
       | courselistingpresentation | cards | theme_boost_union |
-      | courselistinghowpopup     | yes   | theme_boost_union |
+      | courselistingshowpopup     | yes   | theme_boost_union |
     And I log in as "admin"
     And I am on "Course 1" course homepage
     And I navigate to "Settings" in current page administration
@@ -913,7 +913,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value | plugin            |
       | courselistingpresentation | cards | theme_boost_union |
-      | courselistinghowpopup     | yes   | theme_boost_union |
+      | courselistingshowpopup     | yes   | theme_boost_union |
     And the following "users" exist:
       | username | firstname | lastname |
       | teacher1 | John      | Doe      |
@@ -943,7 +943,7 @@ Feature: Configuring the theme_boost_union plugin for the "Category index / site
     Given the following config values are set as admin:
       | config                    | value | plugin            |
       | courselistingpresentation | cards | theme_boost_union |
-      | courselistinghowpopup     | yes   | theme_boost_union |
+      | courselistingshowpopup     | yes   | theme_boost_union |
       | courselistingshowfields   | yes   | theme_boost_union |
     And the following "custom field categories" exist:
       | name          | component   | area   | itemid |

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_boost_union';
-$plugin->version = 2025100631;
+$plugin->version = 2026051500;
 $plugin->release = 'v5.1-r12';
 $plugin->requires = 2025100600;
 $plugin->supported = [501, 501];


### PR DESCRIPTION
This PR resolves #1063.

Background:
The `courselistinghowfields` setting was renamed to `courselistingshowfields` in the 2025041413 upgrade step to correct a typo. The other seven settings of the same family were left untouched at that time.

This PR completes the cleanup by renaming the remaining settings:

- `courselistinghowimage` -> `courselistingshowimage`
- `courselistinghowshortname` -> `courselistingshowshortname`
- `courselistinghowcategory` -> `courselistingshowcategory`
- `courselistinghowprogress` -> `courselistingshowprogress`
- `courselistinghowenrolicons` -> `courselistingshowenrolicons`
- `courselistinghowgoto` -> `courselistingshowgoto`
- `courselistinghowpopup` -> `courselistingshowpopup`

The migration follows the same pattern used in the existing 2025041413 upgrade step, but consolidates all seven settings into a single upgrade block to keep the file readable.

Files changed:

- `lang/en/theme_boost_union.php` - renamed string keys plus a new `upgradenotice_2026051500` string
- `settings.php` - renamed `admin_setting_configselect` names and the two `hide_if` dependencies that point to `courselistinghowimage` and `courselistinghowprogress`
- `classes/output/core/course_renderer.php` - updated `get_config()` calls
- `db/upgrade.php` - new 2026051500 upgrade step
- `version.php` - version bump
- `CHANGES.md` - unreleased entry

About AMOS / translations:
As noted by @abias in the issue thread, AMOS does not parse Git logs for plugins, so existing translations of the renamed strings will need to be re-done. This PR does not handle translations; the string keys are simply renamed in `lang/en`.

Testing:
Verified on a live Moodle installation by setting all seven affected settings to non-default values, applying the patch, running the upgrade and confirming that:

- All seven old config keys are removed from `mdl_config_plugins`
- All seven new keys are created with the original values
- The upgrade notice is shown to the admin
- The course listing renders correctly with the renamed settings

The plugin's `$plugin->supported` declaration is left untouched.
