### PR TITLE
Improvement: Allow the admin to set the page layouts where the footnote is shown, helps to resolve #1279 - and others

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2026-05-25 - Improvement: Use the real page layout names in the 'Additional block regions for xxx layout' setting labels as well.
 * 2026-05-25 - Improvement: Allow the admin to set the page layouts where the footnote is shown, helps to resolve #1279
 * 2026-05-24 - Improvement: Enhance recommendations to only show in the list if an action is needed, resolves #1285
 * 2026-05-24 - Improvement: Transform settings_overview.php into an admin_externalpage, resolves #1281

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2026-05-25 - Bugfix: Fix the default value of the courseoverviewshowcourseimages setting, resolves #1288
 * 2026-05-25 - Improvement: Use the real page layout names in the 'Additional block regions for xxx layout' setting labels as well.
 * 2026-05-25 - Improvement: Allow the admin to set the page layouts where the footnote is shown, helps to resolve #1279
 * 2026-05-24 - Improvement: Enhance recommendations to only show in the list if an action is needed, resolves #1285

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2026-05-25 - Improvement: Allow the admin to set the page layouts where the footnote is shown, helps to resolve #1279
 * 2026-05-24 - Improvement: Enhance recommendations to only show in the list if an action is needed, resolves #1285
 * 2026-05-24 - Improvement: Transform settings_overview.php into an admin_externalpage, resolves #1281
 

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -72,6 +72,18 @@ $string['bootstrap0to5_5'] = '5 (Extra large)';
 $string['horizontalalignment_left'] = 'Left';
 $string['horizontalalignment_center'] = 'Centered';
 $string['horizontalalignment_right'] = 'Right';
+$string['pagelayout_admin'] = 'Administration pages';
+$string['pagelayout_base'] = 'Base layout';
+$string['pagelayout_course'] = 'Course main pages';
+$string['pagelayout_coursecategory'] = 'Course category pages';
+$string['pagelayout_frontpage'] = 'Site home page';
+$string['pagelayout_incourse'] = 'Course sub pages / Activity pages';
+$string['pagelayout_login'] = 'Login page';
+$string['pagelayout_mycourses'] = 'My courses';
+$string['pagelayout_mydashboard'] = 'Dashboard';
+$string['pagelayout_mypublic'] = 'User profiles';
+$string['pagelayout_report'] = 'Report pages';
+$string['pagelayout_standard'] = 'Standard layout';
 
 // Course overrides: General strings.
 $string['courseoverride'] = 'Add to course settings as well';
@@ -1124,6 +1136,9 @@ $string['footnoteheading'] = 'Footnote';
 // ... ... Setting: Footnote.
 $string['footnotesetting'] = 'Footnote';
 $string['footnotesetting_desc'] = 'Whatever you add to this textarea will be displayed at the end of a page, in the footer (not the floating footer) on every page which uses the layouts "drawers", "columns2" or "login". Content in this area could be for example the copyright, the terms of use or the name of your organisation. <br/> If you want to remove the footnote again, just empty the text area.';
+// ... ... Setting: Page layouts for footnote.
+$string['footnotelayouts'] = 'Page layouts for footnote';
+$string['footnotelayouts_desc'] = 'With this setting, you can control on which page layouts the footnote is shown. If no layout is selected, the footnote will not be shown on any layout.';
 // ... Section: Footer.
 $string['footerheading'] = 'Footer';
 // ... ... Setting: Enable footer.

--- a/layout/includes/footnote.php
+++ b/layout/includes/footnote.php
@@ -28,6 +28,25 @@ defined('MOODLE_INTERNAL') || die();
 // Require flavours library.
 require_once($CFG->dirroot . '/theme/boost_union/flavours/flavourslib.php');
 
+// Check if the footnote should be shown on this page layout.
+// If no layout is selected, the footnote will not be shown on any layout.
+$footnotelayoutssetting = get_config('theme_boost_union', 'footnotelayouts');
+if (empty($footnotelayoutssetting)) {
+    return;
+}
+// The setting contains a comma separated list of layouts, so we need to split it into an array.
+$footnotelayoutsarray = explode(',', $footnotelayoutssetting);
+// As a fallback, also show the footnote if the active layout file is columns2.php.
+// columns2.php is a legacy layout file which is no longer registered in $THEME->layouts
+// but may still be used by legacy plugins, so $PAGE->pagelayout would never match it
+// in the configured list above.
+$currentlayoutfile = $PAGE->theme->layouts[$PAGE->pagelayout]['file'] ?? '';
+$iscolumns2fallback = ($currentlayoutfile === 'columns2.php');
+// If the current page layout is not in the list of layouts, the footnote will not be shown on this page.
+if (!in_array($PAGE->pagelayout, $footnotelayoutsarray) && !$iscolumns2fallback) {
+    return;
+}
+
 // Get footnote setting.
 $footnotesetting = get_config('theme_boost_union', 'footnote');
 $format = FORMAT_HTML;

--- a/settings.php
+++ b/settings.php
@@ -4008,8 +4008,9 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         // Create admin setting for each page layout.
         foreach ($pagelayouts as $layout => $regions) {
             $name = 'theme_boost_union/blockregionsfor' . $layout;
-            $title = get_string('blockregionsforlayout', 'theme_boost_union', $layout, true);
-            $description = get_string('blockregionsforlayout_desc', 'theme_boost_union', $layout, true);
+            $layoutname = get_string('pagelayout_' . $layout, 'theme_boost_union', null, true);
+            $title = get_string('blockregionsforlayout', 'theme_boost_union', $layoutname, true);
+            $description = get_string('blockregionsforlayout_desc', 'theme_boost_union', $layoutname, true);
             // If this layout only supports sticky blocks, add a notification to the description.
             if (in_array($layout, $stickyonlylayouts)) {
                 $notificationurl = 'https://docs.moodle.org/en/Block_settings#Making_a_block_sticky_throughout_the_whole_site';

--- a/settings.php
+++ b/settings.php
@@ -2331,7 +2331,7 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
             $name,
             $title,
             $description,
-            $showcourseimagesoptions,
+            array_fill_keys(array_keys($showcourseimagesoptions), 1),
             $showcourseimagesoptions
         );
         $setting->set_updatedcallback('theme_reset_all_caches');

--- a/settings.php
+++ b/settings.php
@@ -4370,6 +4370,35 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $setting = new admin_setting_confightmleditor($name, $title, $description, '');
         $tab->add($setting);
 
+        // Setting: Page layouts for footnote.
+        // The list contains all page layouts defined in the theme that include footnote.php
+        // (i.e. all layouts using drawers.php or login.php).
+        $footnotelayoutsoptions = [
+            'base' => get_string('pagelayout_base', 'theme_boost_union', null, true),
+            'standard' => get_string('pagelayout_standard', 'theme_boost_union', null, true),
+            'course' => get_string('pagelayout_course', 'theme_boost_union', null, true),
+            'coursecategory' => get_string('pagelayout_coursecategory', 'theme_boost_union', null, true),
+            'incourse' => get_string('pagelayout_incourse', 'theme_boost_union', null, true),
+            'frontpage' => get_string('pagelayout_frontpage', 'theme_boost_union', null, true),
+            'admin' => get_string('pagelayout_admin', 'theme_boost_union', null, true),
+            'mycourses' => get_string('pagelayout_mycourses', 'theme_boost_union', null, true),
+            'mydashboard' => get_string('pagelayout_mydashboard', 'theme_boost_union', null, true),
+            'mypublic' => get_string('pagelayout_mypublic', 'theme_boost_union', null, true),
+            'login' => get_string('pagelayout_login', 'theme_boost_union', null, true),
+            'report' => get_string('pagelayout_report', 'theme_boost_union', null, true),
+        ];
+        $name = 'theme_boost_union/footnotelayouts';
+        $title = get_string('footnotelayouts', 'theme_boost_union', null, true);
+        $description = get_string('footnotelayouts_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configmulticheckbox(
+            $name,
+            $title,
+            $description,
+            array_fill_keys(array_keys($footnotelayoutsoptions), 1),
+            $footnotelayoutsoptions
+        );
+        $tab->add($setting);
+
         // Heading: Footer.
         $name = 'theme_boost_union/footerheading';
         $title = get_string('footerheading', 'theme_boost_union', null, true);

--- a/tests/behat/theme_boost_union_contentsettings_footer.feature
+++ b/tests/behat/theme_boost_union_contentsettings_footer.feature
@@ -46,6 +46,27 @@ Feature: Configuring the theme_boost_union plugin for the "Footer" tab on the "C
     And I should not see "<span lang=\"en\" class=\"multilang\">Footnote</span>" in the "#footnote" "css_element"
     And I should not see "FootnoteFussnote" in the "#footnote" "css_element"
 
+  Scenario Outline: Setting: Page layouts for footnote - Set the layouts
+    Given the following config values are set as admin:
+      | config          | value         | plugin            |
+      | footnote        | Footnote text | theme_boost_union |
+      | footnotelayouts | <layouts>     | theme_boost_union |
+    When I log in as "admin"
+    And I follow "Dashboard"
+    Then "#footnote" "css_element" <dashboardshouldornot> exist
+    And I am on "Course 1" course homepage
+    Then "#footnote" "css_element" <courseshouldornot> exist
+    And I log out
+    And I am on login page
+    Then "#footnote" "css_element" <loginshouldornot> exist
+
+    # We do not want to burn too much CPU time by testing all available layouts. We just test three important layouts.
+    Examples:
+      | layouts                  | dashboardshouldornot | courseshouldornot | loginshouldornot |
+      | mydashboard              | should               | should not        | should not       |
+      | login                    | should not           | should not        | should           |
+      | mydashboard,login,course | should               | should            | should           |
+
   @javascript
   Scenario Outline: Setting: Footer - Enable and disable the footer button
     Given the following config values are set as admin:


### PR DESCRIPTION
This PR contains the following fixes:

*     Bugfix: Fix the default value of the courseoverviewshowcourseimages setting, resolves #1288
*     Improvement: Use the real page layout names in the 'Additional block regions for xxx layout' setting labels as well.
*     Improvement: Allow the admin to set the page layouts where the footnote is shown, helps to resolve #1279