### PR TITLE
Feature: Show a configurable external course link below the course he…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes
 
 ### Unreleased
 
+* 2026-06-12 - Feature: Show a configurable link to an external system (e.g. a campus management system) below the course header, resolves #1326
 * 2026-06-10 - Improvement: Support Bootstrap large and small buttons on the login page, resolves #1321
 * 2026-06-10 - Improvement: Support Moodle's color for the secondary outline buttons on the login page, resolves #1319
 * 2026-06-10 - Bugfix: Move the footnote in the side-by-side login arrangement to the right panel, resolves #1279

--- a/README.md
+++ b/README.md
@@ -582,6 +582,32 @@ With this setting a hint will appear in the course header if the course is visib
 
 With this setting a hint will appear in the course header when a user is accessing it with the guest access feature.
 
+##### External course link
+
+###### Enable external course link
+
+With this setting a configurable link to an external system, for example a campus management system, will appear below the course header on course pages.
+
+###### Course field
+
+The field from the course table which is used as the course identifier for composing the external course link.
+
+###### Course identifier pattern
+
+A regular expression which the course identifier has to match for the external course link to be shown. Capture groups can be referenced in the external course link URL.
+
+###### External course link URL
+
+The URL which the external course link points to. Capture groups from the course identifier pattern can be referenced with $1, $2 and so on.
+
+###### External course link text
+
+The text which is displayed as the external course link. It supports the Moodle multi-language filter.
+
+###### Open external course link in new window
+
+With this setting the external course link will be opened in a new browser window.
+
 #### Tab "Administration"
 
 In this tab there are the following settings:

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -1605,6 +1605,26 @@ $string['showhintcoursguestaccesssetting'] = 'Show hint for guest access';
 $string['showhintcourseguestaccesssetting_desc'] = 'With this setting a hint will appear in the course header when a user is accessing it with the guest access feature. If the course provides an active self enrolment, a link to that page is also presented to the user.';
 $string['showhintcourseguestaccessgeneral'] = 'You are currently viewing this course as <strong>{$a->role}</strong>.';
 $string['showhintcourseguestaccesslink'] = 'To have full access to the course, you can <a href="{$a->url}">self enrol into this course</a>.';
+// ... Section: External course link.
+$string['externalcourselinkheading'] = 'External course link';
+// ... ... Setting: Enable external course link.
+$string['enableexternalcourselinksetting'] = 'Enable external course link';
+$string['enableexternalcourselinksetting_desc'] = 'With this setting a configurable link to an external system, for example a campus management system, will appear below the course header on course pages.';
+// ... ... Setting: External course link course field.
+$string['externalcourselinkcoursefieldsetting'] = 'Course field';
+$string['externalcourselinkcoursefieldsetting_desc'] = 'The field from the course table which is used as the course identifier for composing the external course link.';
+// ... ... Setting: External course link pattern.
+$string['externalcourselinkpatternsetting'] = 'Course identifier pattern';
+$string['externalcourselinkpatternsetting_desc'] = 'A regular expression which the course identifier has to match for the external course link to be shown. Capture groups can be referenced in the external course link URL. Please note that the course field value is URL-encoded before it is matched, so special characters like & or = have to be matched in their encoded form. Example: <pre>^([0-9]{6})-(20[0-9]{2}[WS])$</pre>';
+// ... ... Setting: External course link URL.
+$string['externalcourselinkurlsetting'] = 'External course link URL';
+$string['externalcourselinkurlsetting_desc'] = 'The URL which the external course link points to. Capture groups from the course identifier pattern can be referenced with $1, $2 and so on. Example: <pre>https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=$1&semester=$2</pre>';
+// ... ... Setting: External course link text.
+$string['externalcourselinktextsetting'] = 'External course link text';
+$string['externalcourselinktextsetting_desc'] = 'The text which is displayed as the external course link. It supports the Moodle multi-language filter.';
+// ... ... Setting: Open external course link in new window.
+$string['externalcourselinknewwindowsetting'] = 'Open external course link in new window';
+$string['externalcourselinknewwindowsetting_desc'] = 'With this setting the external course link will be opened in a new browser window.';
 
 // Settings: Accessibility page.
 $string['configtitleaccessibility'] = 'Accessibility';

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -22,6 +22,7 @@
  * Modifications compared to this layout file:
  * * Include activity navigation
  * * Include course related hints
+ * * Include external course link
  * * Include back to top button
  * * Include scroll spy
  * * Include footnote
@@ -119,6 +120,9 @@ $templatecontext = [
 
 // Include the template content for the course related hints.
 require_once(__DIR__ . '/includes/courserelatedhints.php');
+
+// Include the template content for the external course link.
+require_once(__DIR__ . '/includes/externalcourselink.php');
 
 // Include the content for the back to top button.
 require_once(__DIR__ . '/includes/backtotopbutton.php');

--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -22,6 +22,7 @@
  * Modifications compared to this layout file:
  * * Include activity navigation
  * * Include course related hints
+ * * Include external course link
  * * Include back to top button
  * * Include scroll spy
  * * Include footnote
@@ -191,6 +192,9 @@ $templatecontext = [
 
 // Include the template content for the course related hints.
 require_once(__DIR__ . '/includes/courserelatedhints.php');
+
+// Include the template content for the external course link.
+require_once(__DIR__ . '/includes/externalcourselink.php');
 
 // Include the template content for the block regions.
 require_once(__DIR__ . '/includes/blockregions.php');

--- a/layout/includes/externalcourselink.php
+++ b/layout/includes/externalcourselink.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - external course link include.
+ *
+ * @package    theme_boost_union
+ * @copyright  2026 Simeon Naydenov <moninaydenov@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+// Get and use the external course link HTML code, if the feature is enabled and configured.
+$externalcourselinkhtml = theme_boost_union_get_external_course_link();
+if ($externalcourselinkhtml) {
+    $templatecontext['externalcourselink'] = $externalcourselinkhtml;
+}

--- a/locallib.php
+++ b/locallib.php
@@ -425,6 +425,61 @@ function theme_boost_union_get_course_related_hints() {
 }
 
 /**
+ * Build the external course link HTML code.
+ * This function composes a configurable link to an external system (e.g. a campus management system)
+ * which may appear on a course page below the course header.
+ *
+ * The link is only shown if the configured course field matches the configured regular expression.
+ * Capture groups from the regular expression are substituted into the configured URL.
+ *
+ * @copyright  2026 Simeon Naydenov <moninaydenov@gmail.com>
+ *
+ * @return string.
+ */
+function theme_boost_union_get_external_course_link() {
+    global $COURSE, $OUTPUT, $PAGE;
+
+    // If the external course link feature is not enabled, return directly.
+    if (get_config('theme_boost_union', 'enableexternalcourselink') != THEME_BOOST_UNION_SETTING_SELECT_YES) {
+        return '';
+    }
+
+    // The link is only shown on course pages and not on the site home page.
+    if ($COURSE->id == SITEID || $PAGE->context->contextlevel != CONTEXT_COURSE) {
+        return '';
+    }
+
+    // Get the remaining settings; if any required setting is not configured, return directly.
+    $coursefield = get_config('theme_boost_union', 'externalcourselinkcoursefield');
+    $pattern = get_config('theme_boost_union', 'externalcourselinkpattern');
+    $url = get_config('theme_boost_union', 'externalcourselinkurl');
+    $text = get_config('theme_boost_union', 'externalcourselinktext');
+    if (empty($pattern) || empty($url) || empty($text) || empty($COURSE->{$coursefield})) {
+        return '';
+    }
+
+    // URL-encode the course field value before matching, this allows the safe composition of the link URL.
+    $fieldvalue = rawurlencode($COURSE->{$coursefield});
+    $regex = '/' . str_replace('/', '\/', $pattern) . '/';
+
+    // Match the pattern, gracefully ignoring an invalid regular expression which the admin might have configured.
+    if (@preg_match($regex, $fieldvalue) !== 1) {
+        return '';
+    }
+
+    // Compose the link URL by substituting the capture groups into the configured URL.
+    $templatecontext = [
+            'externalcourselinkurl' => preg_replace($regex, $url, $fieldvalue),
+            'externalcourselinktext' => format_text($text, FORMAT_HTML, ['context' => $PAGE->context]),
+            'externalcourselinknewwindow' =>
+                    get_config('theme_boost_union', 'externalcourselinknewwindow') == THEME_BOOST_UNION_SETTING_SELECT_YES,
+    ];
+
+    // Render template and return HTML code.
+    return $OUTPUT->render_from_template('theme_boost_union/course-external-link', $templatecontext);
+}
+
+/**
  * Build the link to a static page.
  *
  * @param string $page The static page's identifier.

--- a/settings.php
+++ b/settings.php
@@ -6019,6 +6019,91 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
 
+        // Heading: External course link.
+        $name = 'theme_boost_union/externalcourselinkheading';
+        $title = get_string('externalcourselinkheading', 'theme_boost_union', null, true);
+        $setting = new admin_setting_heading($name, $title, null);
+        $tab->add($setting);
+
+        // Setting: Enable external course link.
+        $name = 'theme_boost_union/enableexternalcourselink';
+        $title = get_string('enableexternalcourselinksetting', 'theme_boost_union', null, true);
+        $description = get_string('enableexternalcourselinksetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
+        // Setting: External course link course field.
+        $name = 'theme_boost_union/externalcourselinkcoursefield';
+        $title = get_string('externalcourselinkcoursefieldsetting', 'theme_boost_union', null, true);
+        $description = get_string('externalcourselinkcoursefieldsetting_desc', 'theme_boost_union', null, true);
+        $coursefieldoptions = [
+                'id' => 'id',
+                'fullname' => 'fullname',
+                'shortname' => 'shortname',
+                'idnumber' => 'idnumber',
+                'category' => 'category',
+        ];
+        $setting = new admin_setting_configselect($name, $title, $description, 'idnumber', $coursefieldoptions);
+        $tab->add($setting);
+        $page->hide_if(
+            'theme_boost_union/externalcourselinkcoursefield',
+            'theme_boost_union/enableexternalcourselink',
+            'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES
+        );
+
+        // Setting: External course link pattern.
+        $name = 'theme_boost_union/externalcourselinkpattern';
+        $title = get_string('externalcourselinkpatternsetting', 'theme_boost_union', null, true);
+        $description = get_string('externalcourselinkpatternsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configtext($name, $title, $description, '', PARAM_RAW);
+        $tab->add($setting);
+        $page->hide_if(
+            'theme_boost_union/externalcourselinkpattern',
+            'theme_boost_union/enableexternalcourselink',
+            'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES
+        );
+
+        // Setting: External course link URL.
+        $name = 'theme_boost_union/externalcourselinkurl';
+        $title = get_string('externalcourselinkurlsetting', 'theme_boost_union', null, true);
+        $description = get_string('externalcourselinkurlsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configtext($name, $title, $description, '', PARAM_URL);
+        $tab->add($setting);
+        $page->hide_if(
+            'theme_boost_union/externalcourselinkurl',
+            'theme_boost_union/enableexternalcourselink',
+            'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES
+        );
+
+        // Setting: External course link text.
+        $name = 'theme_boost_union/externalcourselinktext';
+        $title = get_string('externalcourselinktextsetting', 'theme_boost_union', null, true);
+        $description = get_string('externalcourselinktextsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configtext($name, $title, $description, '', PARAM_RAW);
+        $tab->add($setting);
+        $page->hide_if(
+            'theme_boost_union/externalcourselinktext',
+            'theme_boost_union/enableexternalcourselink',
+            'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES
+        );
+
+        // Setting: Open external course link in new window.
+        $name = 'theme_boost_union/externalcourselinknewwindow';
+        $title = get_string('externalcourselinknewwindowsetting', 'theme_boost_union', null, true);
+        $description = get_string('externalcourselinknewwindowsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+        $page->hide_if(
+            'theme_boost_union/externalcourselinknewwindow',
+            'theme_boost_union/enableexternalcourselink',
+            'neq',
+            THEME_BOOST_UNION_SETTING_SELECT_YES
+        );
+
         // Add tab to settings page.
         $page->add($tab);
 

--- a/templates/course-external-link.mustache
+++ b/templates/course-external-link.mustache
@@ -31,6 +31,6 @@
         "externalcourselinknewwindow": true
     }
 }}
-<div class="course-external-link mb-2">
+<div class="course-external-link d-inline-block mb-2 ps-0 ps-md-3">
     <a href="{{externalcourselinkurl}}"{{#externalcourselinknewwindow}} target="_blank" rel="noopener"{{/externalcourselinknewwindow}}>{{{externalcourselinktext}}}</a>
 </div>

--- a/templates/course-external-link.mustache
+++ b/templates/course-external-link.mustache
@@ -1,0 +1,36 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_boost_union/course-external-link
+
+    Boost Union template for outputting the external course link.
+
+    Context variables required for this template:
+    * externalcourselinkurl - The composed URL which the link points to
+    * externalcourselinktext - The text which is displayed as the link
+    * externalcourselinknewwindow - The fact if the link should be opened in a new window or not
+
+    Example context (json):
+    {
+        "externalcourselinkurl": "https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=136039&semester=2026S",
+        "externalcourselinktext": "View this course in TISS",
+        "externalcourselinknewwindow": true
+    }
+}}
+<div class="course-external-link mb-2">
+    <a href="{{externalcourselinkurl}}"{{#externalcourselinknewwindow}} target="_blank" rel="noopener"{{/externalcourselinknewwindow}}>{{{externalcourselinktext}}}</a>
+</div>

--- a/templates/theme_boost/columns2.mustache
+++ b/templates/theme_boost/columns2.mustache
@@ -56,6 +56,7 @@
     * Include theme_boost_union/footer template instead of theme_boost/footer
     * Include theme_boost_union/navbar template instead of theme_boost/navbar
     * Added the possibility to show course related hints.
+    * Added the possibility to show an external course link.
     * Added the possibility to show info banners.
     * Added smartmenu js to support third level submenus.
 }}
@@ -104,6 +105,7 @@
                         </div>
                     {{/overflow}}
                     {{{courserelatedhints}}}
+                    {{{externalcourselink}}}
                     {{{ output.main_content }}}
                     {{{ output.activity_navigation }}}
                     {{{ output.course_content_footer }}}

--- a/templates/theme_boost/columns2.mustache
+++ b/templates/theme_boost/columns2.mustache
@@ -75,6 +75,7 @@
         {{> theme_boost_union/javascriptdisabledhint }}
         {{> theme_boost_union/infobannersabove }}
         {{{ output.full_header }}}
+        {{{externalcourselink}}}
         {{> theme_boost_union/infobannersbelow }}
             {{#secondarymoremenu}}
                 <div class="secondary-navigation">
@@ -105,7 +106,6 @@
                         </div>
                     {{/overflow}}
                     {{{courserelatedhints}}}
-                    {{{externalcourselink}}}
                     {{{ output.main_content }}}
                     {{{ output.activity_navigation }}}
                     {{{ output.course_content_footer }}}

--- a/templates/theme_boost/drawers.mustache
+++ b/templates/theme_boost/drawers.mustache
@@ -57,6 +57,7 @@
     * Include theme_boost_union/footer template instead of theme_boost/footer
     * Include theme_boost_union/navbar template instead of theme_boost/navbar
     * Added the possibility to show course related hints.
+    * Added the possibility to show an external course link.
     * Added the possibility to show info banners.
     * Include theme_boost_union/advertisementtiles template
     * Include theme_boost_union/slider template
@@ -246,6 +247,7 @@
                             </div>
                         {{/overflow}}
                         {{{courserelatedhints}}}
+                        {{{externalcourselink}}}
                         {{#sliderpositionbeforebefore}}
                             {{> theme_boost_union/slider }}
                         {{/sliderpositionbeforebefore}}

--- a/templates/theme_boost/drawers.mustache
+++ b/templates/theme_boost/drawers.mustache
@@ -210,6 +210,7 @@
             {{> theme_boost_union/javascriptdisabledhint }}
             {{> theme_boost_union/infobannersabove }}
             {{{ output.full_header }}}
+            {{{externalcourselink}}}
             {{> theme_boost_union/infobannersbelow }}
             {{#secondarymoremenu}}
                 <div class="secondary-navigation d-print-none">
@@ -247,7 +248,6 @@
                             </div>
                         {{/overflow}}
                         {{{courserelatedhints}}}
-                        {{{externalcourselink}}}
                         {{#sliderpositionbeforebefore}}
                             {{> theme_boost_union/slider }}
                         {{/sliderpositionbeforebefore}}

--- a/tests/behat/theme_boost_union_functionalitysettings_courses.feature
+++ b/tests/behat/theme_boost_union_functionalitysettings_courses.feature
@@ -500,3 +500,80 @@ Feature: Configuring the theme_boost_union plugin for the "Courses" tab on the "
     And I should not see "The Self enrolment as 'Student' enrolment instance allows unrestricted self enrolment indefinitely."
     And I should see "The Custom self enrolment enrolment instance allows unrestricted self enrolment until Saturday, 1 January 2050, 12:00 AM."
     And ".course-hint-selfenrol" "css_element" should exist
+
+  Scenario: Setting: External course link - Show the link if the course identifier matches the pattern
+    Given the following "courses" exist:
+      | fullname | shortname | idnumber     |
+      | Course 2 | C2        | 136039-2026S |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | C2     | student |
+    And the following config values are set as admin:
+      | config                        | value                                                                        | plugin            |
+      | enableexternalcourselink      | yes                                                                          | theme_boost_union |
+      | externalcourselinkcoursefield | idnumber                                                                     | theme_boost_union |
+      | externalcourselinkpattern     | ^([0-9]{6})-(20[0-9]{2}[WS])$                                                | theme_boost_union |
+      | externalcourselinkurl         | https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=$1&semester=$2 | theme_boost_union |
+      | externalcourselinktext        | View this course in TISS                                                     | theme_boost_union |
+    When I log in as "student1"
+    And I am on "Course 2" course homepage
+    Then I should see "View this course in TISS" in the ".course-external-link" "css_element"
+    And the "href" attribute of ".course-external-link a" "css_element" should contain "courseNr=136039"
+    And the "href" attribute of ".course-external-link a" "css_element" should contain "semester=2026S"
+
+  Scenario: Setting: External course link - Do not show the link if the course identifier does not match the pattern
+    Given the following config values are set as admin:
+      | config                        | value                                                                        | plugin            |
+      | enableexternalcourselink      | yes                                                                          | theme_boost_union |
+      | externalcourselinkcoursefield | idnumber                                                                     | theme_boost_union |
+      | externalcourselinkpattern     | ^([0-9]{6})-(20[0-9]{2}[WS])$                                                | theme_boost_union |
+      | externalcourselinkurl         | https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=$1&semester=$2 | theme_boost_union |
+      | externalcourselinktext        | View this course in TISS                                                     | theme_boost_union |
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    Then I should not see "View this course in TISS"
+    And ".course-external-link" "css_element" should not exist
+
+  Scenario: Setting: External course link - Do not show the link if the setting is disabled
+    Given the following "courses" exist:
+      | fullname | shortname | idnumber     |
+      | Course 2 | C2        | 136039-2026S |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | C2     | student |
+    And the following config values are set as admin:
+      | config                        | value                                                                        | plugin            |
+      | enableexternalcourselink      | no                                                                           | theme_boost_union |
+      | externalcourselinkcoursefield | idnumber                                                                     | theme_boost_union |
+      | externalcourselinkpattern     | ^([0-9]{6})-(20[0-9]{2}[WS])$                                                | theme_boost_union |
+      | externalcourselinkurl         | https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=$1&semester=$2 | theme_boost_union |
+      | externalcourselinktext        | View this course in TISS                                                     | theme_boost_union |
+    When I log in as "student1"
+    And I am on "Course 2" course homepage
+    Then I should not see "View this course in TISS"
+    And ".course-external-link" "css_element" should not exist
+
+  Scenario Outline: Setting: External course link - Open the link in a new window or in the same window
+    Given the following "courses" exist:
+      | fullname | shortname | idnumber     |
+      | Course 2 | C2        | 136039-2026S |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | C2     | student |
+    And the following config values are set as admin:
+      | config                        | value                                                                        | plugin            |
+      | enableexternalcourselink      | yes                                                                          | theme_boost_union |
+      | externalcourselinkcoursefield | idnumber                                                                     | theme_boost_union |
+      | externalcourselinkpattern     | ^([0-9]{6})-(20[0-9]{2}[WS])$                                                | theme_boost_union |
+      | externalcourselinkurl         | https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=$1&semester=$2 | theme_boost_union |
+      | externalcourselinktext        | View this course in TISS                                                     | theme_boost_union |
+      | externalcourselinknewwindow   | <newwindowsetting>                                                           | theme_boost_union |
+    When I log in as "student1"
+    And I am on "Course 2" course homepage
+    Then I should see "View this course in TISS" in the ".course-external-link" "css_element"
+    And "<shouldorshouldnot>" "css_element" should exist
+
+    Examples:
+      | newwindowsetting | shouldorshouldnot                              |
+      | yes              | .course-external-link a[target='_blank']       |
+      | no               | .course-external-link a:not([target='_blank']) |


### PR DESCRIPTION
### Motivation

Many institutions run a campus management system (CMS) — such as TISS at TU Wien, CAMPUSonline, HISinOne or similar — next to Moodle. Courses in Moodle usually carry the external system's course identifier in one of their course fields (typically the course ID number). For students and teachers it is very convenient to be able to jump from a Moodle course directly to the corresponding course page in the campus management system, for example to look up the official course description, registration details or exam dates.

This feature has been in production use at our institution as part of a Boost Union child theme and is hereby contributed upstream in a generalized form.

### What this PR adds

A new section **"External course link"** on the *Functionality → Courses* settings tab. When enabled and configured, a link is shown below the course header on all course pages, mirroring the architecture of the existing "Course related hints" feature (locallib function → layout include → `drawers.php` / `columns2.php` layouts → overridden Boost templates).

The link is composed as follows:

1. The admin picks a **course field** (`id`, `fullname`, `shortname`, `idnumber` or `category`) which holds the external course identifier.
2. The field value is URL-encoded and matched against an admin-defined **regular expression**. If it does not match, no link is shown — so the feature can be rolled out globally even if only a part of the courses carry a valid external identifier.
3. Capture groups from the pattern are substituted (`$1`, `$2`, …) into the configured **URL template**.
4. The configured **link text** is displayed (with `format_text()`, so the Moodle multi-language filter is supported).
5. Optionally the link opens in a **new window** (`target="_blank"` with `rel="noopener"`).

New settings (all `theme_boost_union/...`, feature fully opt-in, default disabled — in line with Boost Union's non-invasive design principle):

| Setting | Type | Default |
|---|---|---|
| `enableexternalcourselink` | yes/no | no |
| `externalcourselinkcoursefield` | select (id/fullname/shortname/idnumber/category) | idnumber |
| `externalcourselinkpattern` | text (regex) | empty |
| `externalcourselinkurl` | text (URL template) | empty |
| `externalcourselinktext` | text (multilang capable) | empty |
| `externalcourselinknewwindow` | yes/no | no |

All dependent settings are hidden via `hide_if` until the feature is enabled.

### Worked example (TISS, TU Wien)

* Course ID number: `015709-2016W` (course number + semester)
* Course field: `idnumber`
* Course identifier pattern: `^([0-9]{6})-(20[0-9]{2}[WS])$`
* External course link URL: `https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=$1&semester=$2`
* External course link text: `View this course in TISS`

Resulting link below the course header:
`https://tiss.tuwien.ac.at/course/courseDetails.xhtml?courseNr=015709&semester=2016W`

Courses whose ID number does not match the pattern (and the site home) show no link at all.

### Screenshots

*Settings (Functionality → Courses → External course link):*

<img width="1064" height="673" alt="screenshot-settings" src="https://github.com/user-attachments/assets/6c86680e-d46c-4823-9336-fdc9c4dcc2a9" />

*Course page with the rendered link below the course header:*

<img width="809" height="387" alt="Screenshot from 2026-06-21 23-17-46" src="https://github.com/user-attachments/assets/d11fa73d-e8b9-46c1-b6c6-be3de9e0c41e" />

*The same, annotated with the identifier-to-URL composition:*

<img width="872" height="420" alt="screenshot-coursepage-annotated" src="https://github.com/user-attachments/assets/53aede57-e522-4bcc-bf29-d1361cc5a817" />

### Implementation notes

* Output follows the established "Course related hints" mechanism: `theme_boost_union_get_external_course_link()` in `locallib.php`, included via `layout/includes/externalcourselink.php` in the `drawers` and `columns2` layouts, rendered through the new `templates/course-external-link.mustache` (root CSS class `course-external-link`).
* The course field value is `rawurlencode()`-d **before** matching, so the substituted values are always URL-safe; the setting description points this out for patterns containing special characters.
* An invalid regular expression configured by the admin is silently ignored (no debugging output on every course page).
* The link is only rendered in course context and never on the site home.

### Testing

* Four new Behat scenarios in `tests/behat/theme_boost_union_functionalitysettings_courses.feature`: link shown on pattern match (incl. href assertions for both capture groups), no link on non-matching identifier, no link when disabled, and a scenario outline for the new-window option.
* Manually verified on Moodle 5.2 (theme Boost Union, current `main`): settings save correctly (incl. `$1`/`$2` placeholders in the `PARAM_URL` setting), link renders with correct href/target/rel, hidden on non-matching courses and site home.
* `phpcs --standard=moodle` clean on all changed PHP files; diff contains no `theme->settings->` usage.
* `README.md` (Functionality → Courses section) and `CHANGES.md` updated.