### PR TITLE
# Bugfix: Apply the configured string filters (e.g. the multilang filter) to the course names in the starred courses navbar popover, resolves #1332

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2026-06-16 - Bugfix: Apply the configured string filters (e.g. the multilang filter) to the course names in the starred courses navbar popover, resolves #1332
+
 ### v5.2-r6
 
 * 2026-06-13 - Tests: Use Behat slicing to bring Behat runtime down and reduce GHA container outages, resolves #1016

--- a/locallib.php
+++ b/locallib.php
@@ -2496,7 +2496,7 @@ function theme_boost_union_get_navbar_starredcoursespopover() {
         if ($course->visible || $canviewhiddencourses) {
             $coursesfortemplate[] = [
                 'url' => new \core\url('/course/view.php', ['id' => $course->id]),
-                'fullname' => $course->fullname,
+                'fullname' => format_string($course->fullname, true, ['context' => $context]),
                 'visible' => $course->visible == 1,
             ];
         }

--- a/tests/behat/theme_boost_union_feelsettings_navigation.feature
+++ b/tests/behat/theme_boost_union_feelsettings_navigation.feature
@@ -219,6 +219,32 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
     And I should not see "Course 4" in the ".popover-region-favourites .popover-region-content-container" "css_element"
 
   @javascript
+  Scenario: Setting: Show starred courses popover in the navbar (and make sure that the course names are filtered).
+    Given the following config values are set as admin:
+      | config          | value |
+      | enablemycourses | 1     |
+    And the following config values are set as admin:
+      | config                   | value | plugin            |
+      | shownavbarstarredcourses | yes   | theme_boost_union |
+    And the "multilang" filter is "on"
+    And the "multilang" filter applies to "content and headings"
+    And the following "courses" exist:
+      | fullname                                                                                                     | shortname |
+      | <span lang="en" class="multilang">English name</span><span lang="de" class="multilang">Deutscher Name</span> | MLC       |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | MLC    | student |
+    And the theme cache is purged and the theme is reloaded
+    When I log in as "student1"
+    And I follow "My courses"
+    And I click on ".coursemenubtn" "css_element" in the "//div[contains(@class, 'card course-card') and contains(.,'English name')]" "xpath_element"
+    And I click on "Star this course" "link" in the "//div[contains(@class, 'card course-card') and contains(.,'English name')]" "xpath_element"
+    And I reload the page
+    And I click on "nav.navbar #usernavigation .popover-region-favourites .nav-link" "css_element"
+    Then I should see "English name" in the ".popover-region-favourites .popover-region-content-container" "css_element"
+    And I should not see "Deutscher Name" in the ".popover-region-favourites .popover-region-content-container" "css_element"
+
+  @javascript
   Scenario Outline: Setting: Starred courses popover cog icon link target
     Given the following config values are set as admin:
       | config          | value |


### PR DESCRIPTION
## Problem

When the "Show starred courses popover in the navbar" feature (`shownavbarstarredcourses`) is enabled, the
popover lists the user's starred courses by their full name. On multilingual sites, the course names are not
processed by Moodle's text filters: a course whose full name uses the multilang filter shows **both/all
language variants concatenated** (e.g. `English nameDeutscher Name`) instead of the name in the user's current
language. The same happens for any other configured filter — the raw, unfiltered course name is shown.

This is inconsistent with the rest of the theme and of Moodle: the very same course name is filtered correctly
in the course page header and in the smart menus.

## Root cause

`theme_boost_union_get_navbar_starredcoursespopover()` in `locallib.php` put the **raw** `$course->fullname`
into the template context:

```php
'fullname' => $course->fullname,
```

The template `templates/popover-favourites.mustache` prints this value **unescaped** (`{{{fullname}}}`, both as
the link text and inside the `title="…"` attribute), trusting it to be already-formatted, safe HTML. Because no
`format_*` call was made, no filters ran and the unprocessed value reached the page.

## Fix

Format the course name with `format_string()` — the idiomatic Moodle function for course/activity names —
reusing the course context that the function already computes a few lines above:

```php
'fullname' => format_string($course->fullname, true, ['context' => $context]),
```

(`$context = \context_course::instance($favourite->itemid);` already exists in the loop.)

### Why `format_string()` and not `format_text()`

* `format_string()` is what Moodle core and Boost Union itself use for course names everywhere else, e.g. the
  page header (`layout/drawers.php`, `format_string($PAGE->course->fullname, true, ['context' => …])`) and the
  smart menu placeholders (`classes/smartmenu_item.php`, `format_string($COURSE->fullname)`). This makes the
  popover render the name identically to the header.
* It applies the **string** filters (multilang, …), i.e. exactly the filters that are meant to run on short
  headings/titles, and it cleans/strips markup so the result is safe inside the unescaped `title="…"` attribute.
* `format_text(…, FORMAT_HTML)` would additionally run **content-only** filters (media player, H5P, activity-name
  autolinking, …) on what is a one-line title in a compact menu — undesirable and divergent from the header.

No template change is required: `format_string()` output is already filtered and cleaned, so the existing
`{{{fullname}}}` continues to be correct. The popover's alphabetical `usort()` keeps working on the resulting
display name.

## Screenshots

Before
<img width="450" height="61" alt="screenshot-popover-before" src="https://github.com/user-attachments/assets/01a54863-5c2f-422a-a936-b5ffdb6e7818" />

After
<img width="250" height="61" alt="screenshot-popover-after" src="https://github.com/user-attachments/assets/5fcb1010-48d7-432f-b13a-50cd9f7ec425" />


The example course full name is a multilang value with an English and a German variant. Before the fix the
popover shows both variants; after the fix it shows only the variant for the current language.

## Testing

* Added a `@javascript` Behat scenario to
  `tests/behat/theme_boost_union_feelsettings_navigation.feature` ("… make sure that the course names are
  filtered"). It enables the core `multilang` filter for content and headings, creates a course whose full name
  contains an English and a German `<span class="multilang">` variant, stars it, opens the popover and asserts
  that only the current-language variant ("English name") is shown and the other variant ("Deutscher Name") is
  not.
* Verified manually on a live Moodle 5.2 site (see screenshots).