### PR TITLE
Feature: Show the logged-in user's full name in the navbar, resolves #1348

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2026-07-06 - Feature: Show the logged-in user's full name in the navbar
+
 ### v5.2-r6
 
 * 2026-06-13 - Tests: Use Behat slicing to bring Behat runtime down and reduce GHA container outages, resolves #1016

--- a/README.md
+++ b/README.md
@@ -348,6 +348,10 @@ With this setting, you can set an alternative link URL which will be used as lin
 
 With this setting, you can show the logged-in user's full name at the top of the user menu. This can be especially helpful for exam situations where teachers have to confirm that the user is logged in with his own account, but it might also be helpful for the user himself. In contrast to the Classic theme which shows the user's full name in the navbar near the avatar, this approach here does not claim any additional rare space in the navbar.
 
+###### Show full name in the navbar
+
+With this setting, you can show the logged-in user's full name in the navbar, next to the user menu button. This is how the Classic theme presents the user's full name and it can be helpful, for example, in exam situations where teachers have to verify quickly that a user is logged in with his own account. However, in contrast to the 'Show full name in the user menu' setting, this approach claims additional rare space in the navbar. On small screens, the full name is automatically hidden to preserve the available space.
+
 ###### Add preferred language link to language menu
 
 With this setting, you can add a 'Set preferred language' setting to the language menu within the user menu. Understandably, this setting is only processed if the language menu is enabled at all.

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -978,6 +978,9 @@ $string['usermenuheading'] = 'User menu';
 $string['showfullnameinusermenussetting'] = 'Show full name in the user menu';
 $string['showfullnameinusermenussetting_desc'] = 'With this setting, you can show the logged-in user\'s full name at the top of the user menu. This can be especially helpful for exam situations where teachers have to confirm that the user is logged in with his own account, but it might also be helpful for the user himself. In contrast to the Classic theme which shows the user\'s full name in the navbar near the avatar, this approach here does not claim any additional rare space in the navbar.';
 $string['showfullnameinusermenussetting_loggedinas'] = 'You are logged in as:';
+// ... ... Settings: Show full name in the navbar.
+$string['showfullnameinnavbarsetting'] = 'Show full name in the navbar';
+$string['showfullnameinnavbarsetting_desc'] = 'With this setting, you can show the logged-in user\'s full name in the navbar, next to the user menu button. This is how the Classic theme presents the user\'s full name and it can be helpful, for example, in exam situations where teachers have to verify quickly that a user is logged in with his own account. However, in contrast to the \'Show full name in the user menu\' setting, this approach claims additional rare space in the navbar. On small screens, the full name is automatically hidden to preserve the available space.';
 // ... ... Settings: Add preferred language link to language menu.
 $string['addpreferredlangsetting'] = 'Add preferred language link to language menu';
 $string['addpreferredlangsetting_desc'] = 'With this setting, you can add a \'Set preferred language\' setting to the language menu within the user menu. Understandably, this setting is only processed if the setting <a href="{$a->url1}">Display language menu</a> is enabled, and if at least <a href="{$a->url2}">a second language pack is installed</a> and <a href="{$a->url3}">offered for selection</a>.';

--- a/layout/includes/navbar.php
+++ b/layout/includes/navbar.php
@@ -88,6 +88,13 @@ if ($showfullnameinusermenusetting == THEME_BOOST_UNION_SETTING_SELECT_YES) {
     $templatecontext['showfullnameinusermenu'] = true;
 }
 
+// If showing the user name in the navbar is activated.
+$showfullnameinnavbarsetting = get_config('theme_boost_union', 'showfullnameinnavbar');
+if ($showfullnameinnavbarsetting == THEME_BOOST_UNION_SETTING_SELECT_YES) {
+    // Set a flag in the templatecontext.
+    $templatecontext['showfullnameinnavbar'] = true;
+}
+
 // If displaying the login link as button is activated.
 $loginlinkbuttonenabledsetting = get_config('theme_boost_union', 'loginlinkbuttonenabled');
 if ($loginlinkbuttonenabledsetting == THEME_BOOST_UNION_SETTING_SELECT_YES) {

--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -1114,6 +1114,19 @@ body.hascourseindexcmicons {
 }
 
 /*---------------------------------------
+ * Setting: Show full name in the navbar.
+ --------------------------------------*/
+
+/* Avoid that very long user names break the navbar layout. */
+.usermenu .dropdown-toggle .usertext {
+    max-width: 12rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+/*---------------------------------------
  * Setting: Show starred courses popover in the navbar.
  --------------------------------------*/
 .navbar #nav-popover-favourites-container {

--- a/settings.php
+++ b/settings.php
@@ -3973,6 +3973,13 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
         $tab->add($setting);
 
+        // Setting: Show full name in the navbar.
+        $name = 'theme_boost_union/showfullnameinnavbar';
+        $title = get_string('showfullnameinnavbarsetting', 'theme_boost_union', null, true);
+        $description = get_string('showfullnameinnavbarsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configselect($name, $title, $description, THEME_BOOST_UNION_SETTING_SELECT_NO, $yesnooption);
+        $tab->add($setting);
+
         // Setting: Add preferred language link to language menu.
         $name = 'theme_boost_union/addpreferredlang';
         $title = get_string('addpreferredlangsetting', 'theme_boost_union', null, true);

--- a/templates/core/user_menu.mustache
+++ b/templates/core/user_menu.mustache
@@ -51,7 +51,8 @@
             }
         ],
         "showfullnameinusermenu": true,
-        "loginlinkbuttonenabled": true
+        "loginlinkbuttonenabled": true,
+        "showfullnameinnavbar": true
     }
 }}
 {{!
@@ -64,6 +65,7 @@
     * Support submenus with more than one level (for adding smart menus into the user menu).
     * Make submenu headers fully clickable as soon as at least one smart menu exists on the page.
     * Set the submenus' data-bs-theme attribute to light even if the navbar is dark
+    * Add the user's full name to the navbar, next to the user menu button.
 }}
 <div class="usermenu">
     {{#unauthenticateduser}}
@@ -81,6 +83,9 @@
         <div class="dropdown show">
             <a href="#" role="button" id="user-menu-toggle" data-bs-toggle="dropdown" aria-label="{{#str}}usermenu{{/str}}"
                aria-haspopup="true" aria-controls="user-action-menu" class="btn dropdown-toggle">
+                {{#showfullnameinnavbar}}
+                    <span class="usertext me-1 d-none d-md-inline-block">{{userfullname}}</span>
+                {{/showfullnameinnavbar}}
                 <span class="userbutton">
                     {{> core/user_menu_metadata }}
                 </span>

--- a/tests/behat/theme_boost_union_feelsettings_navigation.feature
+++ b/tests/behat/theme_boost_union_feelsettings_navigation.feature
@@ -104,6 +104,22 @@ Feature: Configuring the theme_boost_union plugin for the "Navigation" tab on th
       | yes     | should      |
       | no      | should not  |
 
+  Scenario Outline: Setting: Show full name in the navbar.
+    Given the following config values are set as admin:
+      | config               | value     | plugin            |
+      | showfullnameinnavbar | <setting> | theme_boost_union |
+    And the following "users" exist:
+      | username       | firstname  | lastname |
+      | navbartestuser | Navbartest | User     |
+    When I log in as "navbartestuser"
+    Then ".usermenu #user-menu-toggle .usertext" "css_element" <shouldornot> exist
+    And I <shouldornot> see "Navbartest User" in the ".usermenu #user-menu-toggle" "css_element"
+
+    Examples:
+      | setting | shouldornot |
+      | yes     | should      |
+      | no      | should not  |
+
   @javascript
   Scenario Outline: Setting: Add preferred language link to language menu.
     Given the following "language packs" exist:


### PR DESCRIPTION
Adds an opt-in setting "Show full name in the navbar" (Feel → Navigation → User menu, default: No) that shows the logged-in user's full name next to the user menu button, like the Classic theme does. Complements the existing "Show full name in the user menu" setting from #439. Resolves #1348

To protect the scarce navbar space, the name is hidden on small screens and truncated with an ellipsis if too long. Includes Behat coverage, README and CHANGES.md entries.

**Information for peer review**
- Follows the shape of 5cf2382 ("Feature: Show the logged-in user's full name in the user menu, resolves #439") exactly: setting on Feel → Navigation, flag set in `layout/includes/navbar.php`, markup in the overridden `core/user_menu.mustache` (example context JSON and modifications list updated), SCSS under the "Settings: Feel -> Navigation." banner in `post.scss`, Behat Scenario Outline with yes/no examples, README and CHANGES.md entries.
- Navbar space safety (the concern that led #439 to the user-menu variant): the name span is `d-none d-md-inline-block` (hidden below the md breakpoint) and capped at `max-width: 12rem` with ellipsis, so long names cannot break the navbar.
- On dark navbars the name inherits the white color from the existing `.usermenu .dropdown-toggle` rule in post.scss — no extra rule needed.
- Placement note: the setting sits under the "User menu" heading (not "Navbar") because the element renders inside the user menu toggle button and is the direct counterpart of "Show full name in the user menu" — admins comparing the two options find them side by side.
- Default is "No", so existing sites see zero change. No version.php bump (no DB changes).