### PR TITLE
Feature: Add a privacy notice link to the footer, resolves #1350

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ moodle-theme_boost_union
 Changes
 -------
 
+### Unreleased
+
+* 2026-07-06 - Feature: Add a privacy notice link to the footer
+
 ### v5.2-r6
 
 * 2026-06-13 - Tests: Use Behat slicing to bring Behat runtime down and reduce GHA container outages, resolves #1016

--- a/README.md
+++ b/README.md
@@ -480,6 +480,10 @@ With this setting, you can entirely suppress the icons in front of the footer li
 
 With these settings, you can entirely suppress particular links in the footer.
 
+###### Privacy notice URL
+
+With this setting, you can add a 'Privacy notice' link to the footer. As soon as a URL is entered, the link will be shown in the footer, pointing to the given URL. This is especially useful if your organisation publishes its privacy notice on an external website. If the field is left empty, no link will be shown.
+
 ###### Suppress footer output by plugin ...
 
 With this setting, you can entirely suppress the footer output by particular plugins.

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -2061,6 +2061,22 @@ class core_renderer extends core_renderer_intermediate {
     }
 
     /**
+     * Returns true if the current page should show the popover links in the footer.
+     *
+     * In addition to the Moodle core links which are evaluated by the parent function,
+     * this function respects the Boost Union privacy notice link as well.
+     *
+     * @return bool
+     */
+    public function has_popover_links(): bool {
+        // Get the privacy notice URL setting.
+        $privacynoticeurlsetting = get_config('theme_boost_union', 'footerprivacynoticeurl');
+
+        // Show the popover links if a privacy notice URL is configured or if any Moodle core link is present.
+        return !empty($privacynoticeurlsetting) || parent::has_popover_links();
+    }
+
+    /**
      * Returns the HTML for the site support email link
      *
      * This renderer function is copied and modified from /lib/classes/output/core_renderer.php

--- a/lang/en/theme_boost_union.php
+++ b/lang/en/theme_boost_union.php
@@ -1201,6 +1201,10 @@ $string['footersuppressthemeswitchsetting_desc'] = 'With this setting, you can e
 // ... ... Setting: Suppress 'Powered by Moodle' link.
 $string['footersuppresspoweredsetting'] = 'Suppress \'Powered by Moodle\' link';
 $string['footersuppresspoweredsetting_desc'] = 'With this setting, you can entirely suppress the \'Powered by Moodle\' link in the footer. This link would otherwise show an information that this site is running Moodle and provide a link to Moodle HQ.';
+// ... ... Setting: Privacy notice URL.
+$string['footerprivacynoticeurlsetting'] = 'Privacy notice URL';
+$string['footerprivacynoticeurlsetting_desc'] = 'With this setting, you can add a \'Privacy notice\' link to the footer. As soon as a URL is entered, the link will be shown in the footer, pointing to the given URL. This is especially useful if your organisation publishes its privacy notice on an external website. If the field is left empty, no link will be shown.';
+$string['footerprivacynoticeurlsetting_linktext'] = 'Privacy notice';
 // ... ... Setting: Suppress footer output by core components.
 $string['footersuppressstandardfootercore'] = 'Suppress footer output by core component \'{$a}\'';
 $string['footersuppressstandardfootercore_desc'] = 'With this setting, you can entirely suppress the footer output by the core component \'{$a}\'. Core components can add additional content to the footer by implementing a particular hook or function. This core component has implemented this hook / function and might add content to the footer in certain circumstances.';

--- a/layout/includes/footer.php
+++ b/layout/includes/footer.php
@@ -80,11 +80,26 @@ if ($footerquestionmark != THEME_BOOST_UNION_SETTING_ENABLEFOOTER_NONE) {
         $templatecontext['footershowcontact'] = false;
     }
 
-    // If any of the 'Documentation for this page', 'Services and support' or 'Contact site support' links are enabled.
+    // If a privacy notice URL is configured.
+    $footerprivacynoticeurlsetting = get_config('theme_boost_union', 'footerprivacynoticeurl');
+    if (!empty($footerprivacynoticeurlsetting)) {
+        // Add marker to show this link to the templatecontext as well as the link itself.
+        $templatecontext['footershowprivacynotice'] = true;
+        $templatecontext['footerprivacynoticeurl'] = $footerprivacynoticeurlsetting;
+
+        // Otherwise.
+    } else {
+        // Add marker to hide this link.
+        $templatecontext['footershowprivacynotice'] = false;
+    }
+
+    // If any of the 'Documentation for this page', 'Services and support', 'Contact site support' or privacy notice
+    // links are enabled.
     if (
         isset($templatecontext['footershowhelp']) && $templatecontext['footershowhelp'] == true ||
             isset($templatecontext['footershowservices']) && $templatecontext['footershowservices'] == true ||
-            isset($templatecontext['footershowcontact']) && $templatecontext['footershowcontact'] == true
+            isset($templatecontext['footershowcontact']) && $templatecontext['footershowcontact'] == true ||
+            isset($templatecontext['footershowprivacynotice']) && $templatecontext['footershowprivacynotice'] == true
     ) {
         // Add marker to show popover links.
         $templatecontext['footershowpopoverlinks'] = true;

--- a/settings.php
+++ b/settings.php
@@ -4753,6 +4753,19 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
             THEME_BOOST_UNION_SETTING_ENABLEFOOTER_NONE
         );
 
+        // Setting: Privacy notice URL.
+        $name = 'theme_boost_union/footerprivacynoticeurl';
+        $title = get_string('footerprivacynoticeurlsetting', 'theme_boost_union', null, true);
+        $description = get_string('footerprivacynoticeurlsetting_desc', 'theme_boost_union', null, true);
+        $setting = new admin_setting_configtext($name, $title, $description, '', PARAM_URL);
+        $tab->add($setting);
+        $page->hide_if(
+            'theme_boost_union/footerprivacynoticeurl',
+            'theme_boost_union/enablefooterbutton',
+            'eq',
+            THEME_BOOST_UNION_SETTING_ENABLEFOOTER_NONE
+        );
+
         // Settings: Suppress footer output by plugins (for updated plugins with the hook).
         // Get the array of plugins with the before_standard_footer_html_generation hook which can be suppressed by Boost Union.
         $pluginswithcallback =

--- a/templates/theme_boost/footer.mustache
+++ b/templates/theme_boost/footer.mustache
@@ -47,6 +47,8 @@
         "footershowlogininfo": true,
         "footershowpopoverlinks": true,
         "footershowpowered": true,
+        "footershowprivacynotice": true,
+        "footerprivacynoticeurl": "https://yourorganisation.example.com/privacy",
         "footershowservices": true,
         "footershowtelemetrytraceid": true,
         "footershowusertour": true,
@@ -109,6 +111,7 @@
         code. If this JS code does not find the placeholder div, it will add the link at another location on the page.
         That's why we keep the placeholder here and hide it with CSS if the link should be suppressed.
     * Added the possibility to suppress the icons in front of the footer links.
+    * Added the possibility to show a privacy notice link.
 }}
 
 <footer id="page-footer" class="footer-popover bg-white">
@@ -160,6 +163,12 @@
                                 <div class="footer-support-link">{{{ output.supportemail }}}</div>
                             {{/ output.supportemail }}
                         {{/footershowcontact}}
+
+                        {{#footershowprivacynotice}}
+                            <div class="footer-support-link theme_boost_union_footer_privacynoticelink">
+                                <a href="{{ footerprivacynoticeurl }}">{{^ suppressfooterlinkicons }}<i class="icon fa fa-user-shield fa-fw " aria-hidden="true"></i>{{/ suppressfooterlinkicons }}{{#str}}footerprivacynoticeurlsetting_linktext, theme_boost_union{{/str}}</a>
+                            </div>
+                        {{/footershowprivacynotice}}
                     </div>
                 {{/ output.has_popover_links }}
             {{/footershowpopoverlinks}}

--- a/tests/behat/theme_boost_union_contentsettings_footer.feature
+++ b/tests/behat/theme_boost_union_contentsettings_footer.feature
@@ -322,6 +322,30 @@ Feature: Configuring the theme_boost_union plugin for the "Footer" tab on the "C
       | no    | should      |
       | yes   | should not  |
 
+  Scenario Outline: Setting: Footer - Add a privacy notice link to the footer
+    Given the following config values are set as admin:
+      | config                 | value   | plugin            |
+      | footerprivacynoticeurl | <value> | theme_boost_union |
+    And all Boost Union MUC caches are purged
+    And I log in as "admin"
+    When I am on homepage
+    Then ".theme_boost_union_footer_privacynoticelink" "css_element" <shouldornot> exist in the ".footer-content-popover" "css_element"
+
+    Examples:
+      | value                       | shouldornot |
+      |                             | should not  |
+      | https://example.com/privacy | should      |
+
+  Scenario: Setting: Footer - Privacy notice link points to the configured URL
+    Given the following config values are set as admin:
+      | config                 | value                       | plugin            |
+      | footerprivacynoticeurl | https://example.com/privacy | theme_boost_union |
+    And all Boost Union MUC caches are purged
+    And I log in as "admin"
+    When I am on homepage
+    Then I should see "Privacy notice" in the ".theme_boost_union_footer_privacynoticelink" "css_element"
+    And the "href" attribute of ".theme_boost_union_footer_privacynoticelink a" "css_element" should contain "https://example.com/privacy"
+
   Scenario Outline: Setting: Footer - Suppress footer output by plugin 'tool_dataprivacy'
     Given the following config values are set as admin:
       | config                   | value | plugin           |


### PR DESCRIPTION
Adds a setting "Privacy notice URL" (Content → Footer, default: empty). When a URL is entered, a translatable "Privacy notice" link is shown in the footer popover, in the same section as the "Documentation for this page", "Services and support" and "Contact site support" links. It follows the styling of the existing footer links and respects the "Suppress icons in front of the footer links" setting. Resolves #1350

Useful when the privacy notice lives on an external organisation website, which the static pages feature cannot link to. Empty URL = no link, so existing sites are unaffected.

**Information for peer review**
- The popover-links section is gated by both `footershowpopoverlinks` and `output.has_popover_links`. So that the link is also shown when the three core links are absent or suppressed, this PR extends both conditions: the `footershowpopoverlinks` OR-aggregation in `layout/includes/footer.php` now includes the privacy notice flag, and `classes/output/core_renderer.php` gets a small `has_popover_links()` override (calls the parent and additionally checks the setting — no copied core code).
- The setting is a plain `admin_setting_configtext` with PARAM_URL (model: `alternativelogolinkurl`) and is hidden via `hide_if` when the footer button is disabled, like the sibling footer settings.
- Link markup follows the house pattern of the static-page footer links: marker class `theme_boost_union_footer_privacynoticelink`, icon wrapped in `{{^ suppressfooterlinkicons }}`.
- The link text "Privacy notice" is a language string (`footerprivacynoticeurlsetting_linktext`), translatable via AMOS and customisable per site via language customisation.
- Behat: non-JS scenarios asserting the popover DOM (presence/absence outline + href/text check), per the footer feature file's stated preference. README and CHANGES.md entries included; no version.php bump (no DB changes).
